### PR TITLE
Complete engine-vllm slice: readiness, health, tests

### DIFF
--- a/ainode/cli/main.py
+++ b/ainode/cli/main.py
@@ -3,10 +3,30 @@
 import argparse
 import sys
 import uuid
+import time
+import threading
+
+from rich.console import Console
+from rich.live import Live
+from rich.spinner import Spinner
+from rich.text import Text
 
 from ainode import __version__
 from ainode.core.config import NodeConfig, ensure_dirs
 from ainode.core.gpu import gpu_summary, detect_gpu
+
+console = Console()
+
+
+def _tail_log(path, lines=10):
+    """Print the last N lines of a log file."""
+    try:
+        with open(path) as f:
+            all_lines = f.readlines()
+        for line in all_lines[-lines:]:
+            console.print(f"    {line.rstrip()}")
+    except Exception:
+        pass
 
 
 BANNER = """
@@ -46,30 +66,41 @@ def cmd_start(args):
     print()
 
     # Start vLLM engine
-    print(f"  Model: {config.model}")
-    print(f"  API:   http://localhost:{config.api_port}/v1")
-    print(f"  Web:   http://localhost:{config.web_port}")
-    print()
-    print("  Starting inference engine...")
+    console.print(f"  Model: {config.model}")
+    console.print(f"  API:   http://localhost:{config.api_port}/v1")
+    console.print(f"  Web:   http://localhost:{config.web_port}")
+    console.print()
 
     from ainode.engine.vllm_engine import VLLMEngine
 
     engine = VLLMEngine(config)
-    if engine.start():
-        print("  Engine started. Open your browser to get started.")
-        print()
-        print(f"  Powered by argentos.ai")
-        print()
-
-        # Keep running until interrupted
-        try:
-            engine.process.wait()
-        except KeyboardInterrupt:
-            print("\n  Shutting down...")
-            engine.stop()
-    else:
-        print("  Failed to start engine. Check logs in ~/.ainode/logs/")
+    if not engine.start():
+        console.print("  [red]Failed to start engine.[/red] Check logs in ~/.ainode/logs/")
         sys.exit(1)
+
+    # Wait for readiness with spinner and log tailing
+    with Live(Spinner("dots", text="Starting inference engine..."), console=console, transient=True):
+        ready = engine.wait_ready(timeout=300)
+
+    if not ready:
+        console.print("  [red]Engine failed to become ready within 5 minutes.[/red]")
+        if engine.log_path and engine.log_path.exists():
+            console.print(f"  Last log lines:")
+            _tail_log(engine.log_path, lines=10)
+        engine.stop()
+        sys.exit(1)
+
+    console.print("  [green]Engine ready.[/green] Open your browser to get started.")
+    console.print()
+    console.print("  Powered by argentos.ai")
+    console.print()
+
+    # Keep running until interrupted
+    try:
+        engine.process.wait()
+    except KeyboardInterrupt:
+        console.print("\n  Shutting down...")
+        engine.stop()
 
 
 def cmd_stop(args):
@@ -82,14 +113,29 @@ def cmd_stop(args):
 def cmd_status(args):
     """Show cluster status."""
     print(BANNER)
-    print(f"  GPU: {gpu_summary()}")
+    console.print(f"  GPU: {gpu_summary()}")
 
     config = NodeConfig.load()
-    print(f"  Node ID: {config.node_id or 'not configured'}")
-    print(f"  Model: {config.model}")
-    print(f"  API: http://localhost:{config.api_port}/v1")
-    print(f"  Email: {config.email or 'not set'}")
-    print()
+    console.print(f"  Node ID: {config.node_id or 'not configured'}")
+    console.print(f"  Model: {config.model}")
+    console.print(f"  API: http://localhost:{config.api_port}/v1")
+    console.print(f"  Email: {config.email or 'not set'}")
+    console.print()
+
+    # Engine health check
+    from ainode.engine.vllm_engine import VLLMEngine
+    engine = VLLMEngine(config)
+    health = engine.health_check()
+
+    if health["api_responding"]:
+        console.print("  Engine: [green]running[/green]")
+        if health["models_loaded"]:
+            console.print(f"  Models: {', '.join(health['models_loaded'])}")
+    elif health["process_alive"]:
+        console.print("  Engine: [yellow]starting[/yellow] (process alive, API not ready)")
+    else:
+        console.print("  Engine: [red]stopped[/red]")
+    console.print()
 
 
 def cmd_models(args):

--- a/ainode/engine/vllm_engine.py
+++ b/ainode/engine/vllm_engine.py
@@ -109,7 +109,11 @@ class VLLMEngine:
         return False
 
     def health_check(self) -> dict:
-        """Check if vLLM is healthy and responding."""
+        """Check if vLLM is healthy and responding.
+
+        Works both when this instance owns the process and when checking
+        an externally-running vLLM server (e.g. from `ainode status`).
+        """
         import urllib.request
         import json
 
@@ -118,9 +122,6 @@ class VLLMEngine:
             "api_responding": False,
             "models_loaded": [],
         }
-
-        if not result["process_alive"]:
-            return result
 
         try:
             req = urllib.request.Request(f"{self.api_url}/models")

--- a/ainode/engine/vllm_engine.py
+++ b/ainode/engine/vllm_engine.py
@@ -1,29 +1,35 @@
-"""vLLM engine wrapper — manages the vLLM inference server."""
+"""vLLM engine wrapper — manages the vLLM inference server lifecycle."""
 
+import asyncio
 import subprocess
 import signal
 import os
-from typing import Optional
-from ainode.core.config import NodeConfig
+import sys
+import time
+import threading
+from pathlib import Path
+from typing import Optional, Callable
+from ainode.core.config import NodeConfig, LOGS_DIR
 from ainode.core.gpu import detect_gpu
 
 
 class VLLMEngine:
-    """Start, stop, and manage a vLLM inference server."""
+    """Start, stop, manage, and health-check a vLLM inference server."""
 
-    def __init__(self, config: NodeConfig):
+    def __init__(self, config: NodeConfig, on_ready: Optional[Callable] = None):
         self.config = config
         self.process: Optional[subprocess.Popen] = None
+        self.on_ready = on_ready
+        self._log_thread: Optional[threading.Thread] = None
+        self._ready = False
+        self._log_file: Optional[Path] = None
 
-    def start(self) -> bool:
-        """Start the vLLM server."""
-        if self.process and self.process.poll() is None:
-            return True  # Already running
-
+    def build_cmd(self) -> list[str]:
+        """Build the vLLM launch command."""
         gpu = detect_gpu()
 
         cmd = [
-            "python3", "-m", "vllm.entrypoints.openai.api_server",
+            sys.executable, "-m", "vllm.entrypoints.openai.api_server",
             "--model", self.config.model,
             "--host", self.config.host,
             "--port", str(self.config.api_port),
@@ -37,36 +43,120 @@ class VLLMEngine:
         if self.config.quantization:
             cmd.extend(["--quantization", self.config.quantization])
 
+        if self.config.models_dir:
+            cmd.extend(["--download-dir", self.config.models_dir])
+
         # DGX Spark / GB10 unified memory needs dtype override
         if gpu and gpu.unified_memory:
             cmd.extend(["--dtype", "bfloat16"])
 
+        return cmd
+
+    def start(self) -> bool:
+        """Start the vLLM server with log streaming and readiness detection."""
+        if self.process and self.process.poll() is None:
+            return True
+
+        cmd = self.build_cmd()
+
         env = os.environ.copy()
-        env["CUDA_VISIBLE_DEVICES"] = "0"
+        env["CUDA_VISIBLE_DEVICES"] = os.environ.get("CUDA_VISIBLE_DEVICES", "0")
+
+        # Log to file
+        LOGS_DIR.mkdir(parents=True, exist_ok=True)
+        self._log_file = LOGS_DIR / "vllm.log"
 
         self.process = subprocess.Popen(
             cmd,
             env=env,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
+            bufsize=1,
+            universal_newlines=True,
         )
+
+        # Start log streaming thread
+        self._log_thread = threading.Thread(target=self._stream_logs, daemon=True)
+        self._log_thread.start()
 
         return self.process.poll() is None
 
+    def _stream_logs(self):
+        """Read vLLM stdout, write to log file, detect readiness."""
+        if not self.process or not self.process.stdout:
+            return
+
+        with open(self._log_file, "w") as log_f:
+            for line in self.process.stdout:
+                log_f.write(line)
+                log_f.flush()
+
+                # Detect vLLM readiness
+                if not self._ready and ("Uvicorn running on" in line or "Application startup complete" in line):
+                    self._ready = True
+                    if self.on_ready:
+                        self.on_ready()
+
+    def wait_ready(self, timeout: int = 300) -> bool:
+        """Block until vLLM is ready to serve requests, or timeout."""
+        start = time.time()
+        while time.time() - start < timeout:
+            if self._ready:
+                return True
+            if self.process and self.process.poll() is not None:
+                return False  # Process died
+            time.sleep(1)
+        return False
+
+    def health_check(self) -> dict:
+        """Check if vLLM is healthy and responding."""
+        import urllib.request
+        import json
+
+        result = {
+            "process_alive": self.is_running(),
+            "api_responding": False,
+            "models_loaded": [],
+        }
+
+        if not result["process_alive"]:
+            return result
+
+        try:
+            req = urllib.request.Request(f"{self.api_url}/models")
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                data = json.loads(resp.read().decode())
+                result["api_responding"] = True
+                result["models_loaded"] = [m["id"] for m in data.get("data", [])]
+        except Exception:
+            pass
+
+        return result
+
     def stop(self):
-        """Stop the vLLM server."""
+        """Graceful shutdown of vLLM server."""
         if self.process and self.process.poll() is None:
             self.process.send_signal(signal.SIGTERM)
             try:
-                self.process.wait(timeout=10)
+                self.process.wait(timeout=15)
             except subprocess.TimeoutExpired:
                 self.process.kill()
+                self.process.wait(timeout=5)
             self.process = None
+            self._ready = False
 
     def is_running(self) -> bool:
-        """Check if the vLLM server is running."""
+        """Check if the vLLM process is alive."""
         return self.process is not None and self.process.poll() is None
+
+    @property
+    def ready(self) -> bool:
+        return self._ready
 
     @property
     def api_url(self) -> str:
         return f"http://localhost:{self.config.api_port}/v1"
+
+    @property
+    def log_path(self) -> Optional[Path]:
+        return self._log_file

--- a/ops/log/handoff-2026-04-12.md
+++ b/ops/log/handoff-2026-04-12.md
@@ -1,0 +1,76 @@
+HANDOFF — AINode Product Threadmaster Session 1
+
+Repo: getainode/ainode
+Date: 2026-04-12
+Author: Claude Opus 4.6 (Threadmaster, session 1)
+
+## Session Summary
+
+Built the AINode project from zero to scaffolded product with ops framework.
+
+## What Was Done
+
+### Decisions Made (with Operator)
+- Forked EXO, then **deleted the fork** — building from scratch to avoid GPL v3 lock-in
+- Chose **Apache 2.0** license — full commercial freedom
+- Name: **AINode** (ainode.dev, ainode.app — operator owns both domains)
+- Backend engine: **vLLM** (not tinygrad) — production-grade, NVIDIA-supported
+- Target hardware: NVIDIA GB10 (DGX Spark, ASUS, Dell, HP variants)
+- Branding: "Powered by argentos.ai" in all output
+- GitHub org: **getainode** (github.com/getainode)
+
+### Repos Created
+- `getainode/ainode` — Product code (public, Apache 2.0)
+- `getainode/ainode.dev` — Marketing site (private, Next.js + shadcn + Tailwind)
+
+### Code Written
+- `ainode/core/config.py` — Config management with JSON persistence
+- `ainode/core/gpu.py` — GPU detection with DGX Spark unified memory fallback
+- `ainode/engine/vllm_engine.py` — vLLM wrapper with health checks, readiness wait, log streaming, graceful shutdown
+- `ainode/discovery/broadcast.py` — UDP broadcast node discovery
+- `ainode/cli/main.py` — CLI: start, stop, status, models commands
+- `ainode/onboarding/setup.py` — First-run onboarding with email capture
+- `scripts/install.sh` — One-line curl installer
+- `pyproject.toml` — Package config, entry points
+- Full ops/ structure: rules, runbooks, slices, agents
+
+### Current Branch State
+- `main` — Ops structure + initial scaffold (pushed)
+- `dev` — Clean integration lane (created, pushed)
+- `codex/engine-vllm` — **ACTIVE** — Enhanced VLLMEngine (pushed, WIP)
+
+## What's In Progress
+
+### Active Slice: `codex/engine-vllm`
+Branch: `codex/engine-vllm` (commit cea10c2)
+Status: WIP — engine enhanced, CLI not yet updated to use new features
+
+Remaining work on this slice:
+1. Update CLI `cmd_start` to use `wait_ready()` with a progress indicator
+2. Wire in `health_check()` to `cmd_status`
+3. Add log tailing to `cmd_start` (show vLLM output as it starts)
+
+## What's Next (P0 Slices)
+
+| Priority | Slice | Description |
+|----------|-------|-------------|
+| **Current** | `engine-vllm` | Finish engine lifecycle, update CLI |
+| **Next** | `api-proxy` | aiohttp server in front of vLLM: /status, /nodes, model catalog |
+| **Next** | `web-ui` | Embedded chat UI served by ainode, no external deps |
+
+## Context the Next Session Needs
+
+- Operator is Jason Brashear (@JasonBrashearTX), MSP owner, 30+ years IT
+- Target audience: MSP owners who bought NVIDIA Sparks, not deeply technical
+- The marketing site Threadmaster is running in a separate session (`ainode-tm`)
+- There is also the DGX Spark cluster guide repo at `ArgentAIOS/dgx-spark-cluster`
+- vLLM has official DGX Spark support: https://build.nvidia.com/spark/vllm
+- The install experience is the product — `curl | bash → browser opens → AI running`
+- Read CLAUDE.md and ops/ for full project config and workflow rules
+
+## Risks / Assumptions
+
+- vLLM ARM64/aarch64 install on DGX Spark may require building from source (not just pip)
+- Unified memory GPU detection patch is implemented but untested on real hardware in this codebase
+- No tests written yet — need pytest suite before first PR to dev
+- Email capture endpoint at argentos.ai not yet built (placeholder in onboarding)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,46 @@
+"""Tests for ainode.cli.main — argument parsing and command dispatch."""
+
+import sys
+from unittest.mock import patch
+from ainode.cli.main import main
+
+
+def test_version(capsys):
+    with patch.object(sys, "argv", ["ainode", "--version"]):
+        try:
+            main()
+        except SystemExit:
+            pass
+    captured = capsys.readouterr()
+    assert "0.1.0" in captured.out
+
+
+def test_no_args_calls_start(monkeypatch):
+    """Running `ainode` with no subcommand calls cmd_start."""
+    called = {}
+    def fake_start(args):
+        called["start"] = True
+    monkeypatch.setattr("ainode.cli.main.cmd_start", fake_start)
+    with patch.object(sys, "argv", ["ainode"]):
+        main()
+    assert called.get("start") is True
+
+
+def test_status_subcommand(monkeypatch):
+    called = {}
+    def fake_status(args):
+        called["status"] = True
+    monkeypatch.setattr("ainode.cli.main.cmd_status", fake_status)
+    with patch.object(sys, "argv", ["ainode", "status"]):
+        main()
+    assert called.get("status") is True
+
+
+def test_models_subcommand(monkeypatch):
+    called = {}
+    def fake_models(args):
+        called["models"] = True
+    monkeypatch.setattr("ainode.cli.main.cmd_models", fake_models)
+    with patch.object(sys, "argv", ["ainode", "models"]):
+        main()
+    assert called.get("models") is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,50 @@
+"""Tests for ainode.core.config."""
+
+import json
+from pathlib import Path
+from ainode.core.config import NodeConfig
+
+
+def test_config_defaults():
+    """Default config has expected values."""
+    config = NodeConfig()
+    assert config.api_port == 8000
+    assert config.web_port == 3000
+    assert config.host == "0.0.0.0"
+    assert config.model == "meta-llama/Llama-3.2-3B-Instruct"
+    assert config.gpu_memory_utilization == 0.9
+    assert config.onboarded is False
+    assert config.node_id is None
+
+
+def test_config_save_load(tmp_path, monkeypatch):
+    """Config round-trips through save/load."""
+    monkeypatch.setattr("ainode.core.config.AINODE_HOME", tmp_path)
+    monkeypatch.setattr("ainode.core.config.CONFIG_FILE", tmp_path / "config.json")
+
+    config = NodeConfig(node_id="abc123", model="test-model", api_port=9000)
+    config.save()
+
+    loaded = NodeConfig.load()
+    assert loaded.node_id == "abc123"
+    assert loaded.model == "test-model"
+    assert loaded.api_port == 9000
+
+
+def test_config_load_missing(tmp_path, monkeypatch):
+    """Loading from nonexistent file returns defaults."""
+    monkeypatch.setattr("ainode.core.config.CONFIG_FILE", tmp_path / "nope.json")
+    config = NodeConfig.load()
+    assert config.api_port == 8000
+    assert config.node_id is None
+
+
+def test_config_load_ignores_unknown_fields(tmp_path, monkeypatch):
+    """Unknown fields in config file are silently ignored."""
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps({"node_id": "x", "unknown_field": True}))
+    monkeypatch.setattr("ainode.core.config.CONFIG_FILE", config_file)
+
+    config = NodeConfig.load()
+    assert config.node_id == "x"
+    assert not hasattr(config, "unknown_field")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,113 @@
+"""Tests for ainode.engine.vllm_engine."""
+
+import sys
+from unittest.mock import patch, MagicMock
+from ainode.core.config import NodeConfig
+from ainode.core.gpu import GPUInfo
+from ainode.engine.vllm_engine import VLLMEngine
+
+
+def _make_engine(**config_overrides):
+    config = NodeConfig(**config_overrides)
+    return VLLMEngine(config)
+
+
+def test_build_cmd_defaults():
+    engine = _make_engine()
+    with patch("ainode.engine.vllm_engine.detect_gpu", return_value=None):
+        cmd = engine.build_cmd()
+
+    assert sys.executable in cmd[0]
+    assert "-m" in cmd
+    assert "vllm.entrypoints.openai.api_server" in cmd
+    assert "--model" in cmd
+    assert "meta-llama/Llama-3.2-3B-Instruct" in cmd
+    assert "--port" in cmd
+    assert "8000" in cmd
+    assert "--trust-remote-code" in cmd
+
+
+def test_build_cmd_with_quantization():
+    engine = _make_engine(quantization="awq")
+    with patch("ainode.engine.vllm_engine.detect_gpu", return_value=None):
+        cmd = engine.build_cmd()
+    assert "--quantization" in cmd
+    assert "awq" in cmd
+
+
+def test_build_cmd_with_max_model_len():
+    engine = _make_engine(max_model_len=4096)
+    with patch("ainode.engine.vllm_engine.detect_gpu", return_value=None):
+        cmd = engine.build_cmd()
+    assert "--max-model-len" in cmd
+    assert "4096" in cmd
+
+
+def test_build_cmd_unified_memory_adds_dtype():
+    gpu = GPUInfo(
+        name="NVIDIA GB10", memory_total_mb=131072, memory_free_mb=120000,
+        cuda_version="12.8", driver_version="570.86",
+        compute_capability="10.0", unified_memory=True,
+    )
+    engine = _make_engine()
+    with patch("ainode.engine.vllm_engine.detect_gpu", return_value=gpu):
+        cmd = engine.build_cmd()
+    assert "--dtype" in cmd
+    assert "bfloat16" in cmd
+
+
+def test_build_cmd_discrete_gpu_no_dtype():
+    gpu = GPUInfo(
+        name="RTX 4090", memory_total_mb=24576, memory_free_mb=20000,
+        cuda_version="12.4", driver_version="550.00",
+        compute_capability="8.9", unified_memory=False,
+    )
+    engine = _make_engine()
+    with patch("ainode.engine.vllm_engine.detect_gpu", return_value=gpu):
+        cmd = engine.build_cmd()
+    assert "--dtype" not in cmd
+
+
+def test_api_url():
+    engine = _make_engine(api_port=9999)
+    assert engine.api_url == "http://localhost:9999/v1"
+
+
+def test_is_running_no_process():
+    engine = _make_engine()
+    assert engine.is_running() is False
+
+
+def test_is_running_with_live_process():
+    engine = _make_engine()
+    proc = MagicMock()
+    proc.poll.return_value = None
+    engine.process = proc
+    assert engine.is_running() is True
+
+
+def test_is_running_with_dead_process():
+    engine = _make_engine()
+    proc = MagicMock()
+    proc.poll.return_value = 1
+    engine.process = proc
+    assert engine.is_running() is False
+
+
+def test_health_check_api_down():
+    engine = _make_engine()
+    health = engine.health_check()
+    assert health["process_alive"] is False
+    assert health["api_responding"] is False
+    assert health["models_loaded"] == []
+
+
+def test_ready_default_false():
+    engine = _make_engine()
+    assert engine.ready is False
+
+
+def test_stop_no_process():
+    """Stop is a no-op when no process exists."""
+    engine = _make_engine()
+    engine.stop()  # Should not raise

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -1,0 +1,46 @@
+"""Tests for ainode.core.gpu."""
+
+from unittest.mock import patch, MagicMock
+from ainode.core.gpu import GPUInfo, detect_gpu, gpu_summary
+
+
+def _make_gpu(**overrides):
+    defaults = dict(
+        name="NVIDIA GB10",
+        memory_total_mb=131072,
+        memory_free_mb=120000,
+        cuda_version="12.8",
+        driver_version="570.86",
+        compute_capability="10.0",
+        unified_memory=True,
+    )
+    defaults.update(overrides)
+    return GPUInfo(**defaults)
+
+
+def test_gpu_info_fields():
+    gpu = _make_gpu()
+    assert gpu.name == "NVIDIA GB10"
+    assert gpu.unified_memory is True
+    assert gpu.memory_total_mb == 131072
+
+
+def test_detect_gpu_no_pynvml():
+    """Returns None when pynvml is not available."""
+    with patch.dict("sys.modules", {"pynvml": None}):
+        result = detect_gpu()
+        assert result is None
+
+
+def test_gpu_summary_no_gpu():
+    with patch("ainode.core.gpu.detect_gpu", return_value=None):
+        assert gpu_summary() == "No NVIDIA GPU detected"
+
+
+def test_gpu_summary_with_gpu():
+    gpu = _make_gpu()
+    with patch("ainode.core.gpu.detect_gpu", return_value=gpu):
+        summary = gpu_summary()
+        assert "NVIDIA GB10" in summary
+        assert "128 GB" in summary
+        assert "unified memory" in summary


### PR DESCRIPTION
## Summary
- `cmd_start` uses `wait_ready()` with Rich spinner during vLLM startup, tails log on timeout
- `cmd_status` probes vLLM API via `health_check()` — shows green/yellow/red engine state
- `health_check()` works standalone without local process reference
- 24 pytest tests covering config, GPU detection, engine build_cmd/lifecycle, CLI dispatch

## Test plan
- [x] `pip install -e .` succeeds
- [x] `ainode --version` → `ainode 0.1.0`
- [x] `pytest tests/` → 24/24 passing
- [ ] Manual GPU test on DGX Spark (deferred to hardware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)