### PR TITLE
Add API proxy server with OpenAI-compatible vLLM passthrough

### DIFF
--- a/ainode/api/server.py
+++ b/ainode/api/server.py
@@ -1,0 +1,227 @@
+"""AINode API proxy server — aiohttp app that serves the web UI and proxies to vLLM."""
+
+import time
+from dataclasses import asdict
+from typing import Optional
+
+import aiohttp
+from aiohttp import web
+
+from ainode.core.config import NodeConfig
+from ainode.core.gpu import detect_gpu, GPUInfo
+from ainode.web.serve import get_index_html, get_static_path
+
+__version__ = "0.1.0"
+
+
+def create_app(
+    config: Optional[NodeConfig] = None,
+    engine=None,
+) -> web.Application:
+    """Create and return the aiohttp application.
+
+    Parameters
+    ----------
+    config : NodeConfig
+        Node configuration (defaults created if None).
+    engine : VLLMEngine | None
+        Optional engine instance for health/status queries.
+    """
+    if config is None:
+        config = NodeConfig()
+
+    app = web.Application(middlewares=[cors_middleware])
+    app["config"] = config
+    app["engine"] = engine
+    app["start_time"] = time.time()
+    app["client_session"] = None  # lazy-init in startup
+
+    # --- Lifecycle -----------------------------------------------------------
+    app.on_startup.append(_on_startup)
+    app.on_cleanup.append(_on_cleanup)
+
+    # --- AINode routes -------------------------------------------------------
+    app.router.add_get("/", handle_index)
+    app.router.add_get("/api/health", handle_health)
+    app.router.add_get("/api/status", handle_status)
+    app.router.add_get("/api/nodes", handle_nodes)
+
+    # --- OpenAI-compatible proxy routes --------------------------------------
+    app.router.add_get("/v1/models", proxy_to_vllm)
+    app.router.add_post("/v1/chat/completions", proxy_to_vllm)
+    app.router.add_post("/v1/completions", proxy_to_vllm)
+
+    # --- Static files --------------------------------------------------------
+    app.router.add_static("/static", get_static_path(), name="static")
+
+    return app
+
+
+# =============================================================================
+# Lifecycle helpers
+# =============================================================================
+
+async def _on_startup(app: web.Application) -> None:
+    app["client_session"] = aiohttp.ClientSession()
+
+
+async def _on_cleanup(app: web.Application) -> None:
+    session: Optional[aiohttp.ClientSession] = app.get("client_session")
+    if session and not session.closed:
+        await session.close()
+
+
+# =============================================================================
+# Middleware
+# =============================================================================
+
+@web.middleware
+async def cors_middleware(request: web.Request, handler):
+    """Add CORS headers to every response so the dashboard can fetch freely."""
+    if request.method == "OPTIONS":
+        resp = web.Response(status=204)
+    else:
+        try:
+            resp = await handler(request)
+        except web.HTTPException as exc:
+            resp = exc
+
+    resp.headers["Access-Control-Allow-Origin"] = "*"
+    resp.headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, DELETE, OPTIONS"
+    resp.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
+    return resp
+
+
+# =============================================================================
+# Web UI
+# =============================================================================
+
+async def handle_index(_request: web.Request) -> web.Response:
+    """Serve the embedded dashboard HTML."""
+    html = get_index_html()
+    return web.Response(text=html, content_type="text/html")
+
+
+# =============================================================================
+# AINode API endpoints
+# =============================================================================
+
+async def handle_health(_request: web.Request) -> web.Response:
+    """Simple liveness probe."""
+    return web.json_response({"status": "ok"})
+
+
+async def handle_status(request: web.Request) -> web.Response:
+    """Return rich node status."""
+    config: NodeConfig = request.app["config"]
+    engine = request.app["engine"]
+    start_time: float = request.app["start_time"]
+
+    gpu: Optional[GPUInfo] = detect_gpu()
+    gpu_info = asdict(gpu) if gpu else None
+
+    engine_ready = False
+    models_loaded: list[str] = []
+    if engine is not None:
+        engine_ready = getattr(engine, "ready", False)
+        try:
+            hc = engine.health_check()
+            models_loaded = hc.get("models_loaded", [])
+        except Exception:
+            pass
+
+    return web.json_response({
+        "node_id": config.node_id,
+        "node_name": config.node_name,
+        "model": config.model,
+        "gpu": gpu_info,
+        "engine_ready": engine_ready,
+        "uptime": round(time.time() - start_time, 1),
+        "version": __version__,
+        "powered_by": "argentos.ai",
+        "models_loaded": models_loaded,
+        "api_port": config.api_port,
+    })
+
+
+async def handle_nodes(request: web.Request) -> web.Response:
+    """Return the list of known cluster nodes (stub: just this node)."""
+    config: NodeConfig = request.app["config"]
+    engine = request.app["engine"]
+    engine_ready = False
+    if engine is not None:
+        engine_ready = getattr(engine, "ready", False)
+
+    node = {
+        "node_id": config.node_id,
+        "node_name": config.node_name,
+        "host": config.host,
+        "api_port": config.api_port,
+        "web_port": config.web_port,
+        "model": config.model,
+        "engine_ready": engine_ready,
+    }
+    return web.json_response({"nodes": [node]})
+
+
+# =============================================================================
+# vLLM proxy
+# =============================================================================
+
+async def proxy_to_vllm(request: web.Request) -> web.StreamResponse:
+    """Forward the request to the local vLLM server and stream the response back."""
+    config: NodeConfig = request.app["config"]
+    session: aiohttp.ClientSession = request.app["client_session"]
+    vllm_url = f"http://localhost:{config.api_port}{request.path}"
+
+    # Build upstream request kwargs
+    kwargs: dict = {
+        "headers": {k: v for k, v in request.headers.items()
+                    if k.lower() not in ("host", "transfer-encoding")},
+    }
+    if request.method == "POST":
+        kwargs["data"] = await request.read()
+
+    try:
+        async with session.request(request.method, vllm_url, **kwargs) as upstream:
+            # Detect SSE streaming
+            is_sse = "text/event-stream" in upstream.headers.get("Content-Type", "")
+
+            if is_sse:
+                resp = web.StreamResponse(
+                    status=upstream.status,
+                    headers={
+                        "Content-Type": "text/event-stream",
+                        "Cache-Control": "no-cache",
+                        "X-Accel-Buffering": "no",
+                    },
+                )
+                await resp.prepare(request)
+                async for chunk in upstream.content.iter_any():
+                    await resp.write(chunk)
+                await resp.write_eof()
+                return resp
+            else:
+                body = await upstream.read()
+                return web.Response(
+                    status=upstream.status,
+                    body=body,
+                    content_type=upstream.headers.get("Content-Type", "application/json"),
+                )
+    except aiohttp.ClientError:
+        return web.json_response(
+            {"error": {"message": "vLLM engine not reachable", "type": "server_error"}},
+            status=502,
+        )
+
+
+# =============================================================================
+# Convenience runner
+# =============================================================================
+
+def run_server(config: Optional[NodeConfig] = None, engine=None) -> None:
+    """Start the API server (blocking)."""
+    if config is None:
+        config = NodeConfig()
+    app = create_app(config=config, engine=engine)
+    web.run_app(app, host=config.host, port=config.web_port, print=None)

--- a/ainode/web/serve.py
+++ b/ainode/web/serve.py
@@ -1,0 +1,18 @@
+"""Web UI file serving — serves the embedded dashboard."""
+
+from pathlib import Path
+
+WEB_DIR = Path(__file__).parent
+STATIC_DIR = WEB_DIR / "static"
+TEMPLATES_DIR = WEB_DIR / "templates"
+
+
+def get_index_html() -> str:
+    """Return the main dashboard HTML."""
+    index = TEMPLATES_DIR / "index.html"
+    return index.read_text()
+
+
+def get_static_path() -> Path:
+    """Return the path to static assets directory."""
+    return STATIC_DIR

--- a/ainode/web/static/css/style.css
+++ b/ainode/web/static/css/style.css
@@ -1,0 +1,611 @@
+/* AINode Dashboard — Core Styles */
+
+:root {
+  --bg-primary: #0a0e17;
+  --bg-secondary: #111827;
+  --bg-card: #1a2332;
+  --bg-card-hover: #1e2a3d;
+  --border: #2d3748;
+  --border-active: #4a90d9;
+  --text-primary: #e2e8f0;
+  --text-secondary: #94a3b8;
+  --text-muted: #64748b;
+  --accent: #4a90d9;
+  --accent-hover: #5ba0e9;
+  --green: #10b981;
+  --green-glow: rgba(16, 185, 129, 0.2);
+  --yellow: #f59e0b;
+  --yellow-glow: rgba(245, 158, 11, 0.2);
+  --red: #ef4444;
+  --red-glow: rgba(239, 68, 68, 0.2);
+  --purple: #8b5cf6;
+  --font-mono: 'JetBrains Mono', 'Fira Code', 'SF Mono', monospace;
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  --radius: 12px;
+  --radius-sm: 8px;
+  --shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--font-sans);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+/* Layout */
+.app {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 240px;
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  z-index: 100;
+}
+
+.sidebar-header {
+  padding: 24px 20px;
+  border-bottom: 1px solid var(--border);
+}
+
+.sidebar-logo {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.5px;
+  color: var(--text-primary);
+}
+
+.sidebar-logo span {
+  color: var(--accent);
+}
+
+.sidebar-subtitle {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 4px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.sidebar-nav {
+  flex: 1;
+  padding: 12px 8px;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 2px;
+}
+
+.nav-item:hover {
+  background: var(--bg-card);
+  color: var(--text-primary);
+}
+
+.nav-item.active {
+  background: var(--accent);
+  color: white;
+}
+
+.nav-item svg {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
+.sidebar-footer {
+  padding: 16px 20px;
+  border-top: 1px solid var(--border);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.sidebar-footer a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.main {
+  flex: 1;
+  margin-left: 240px;
+  padding: 24px 32px;
+  min-height: 100vh;
+}
+
+/* Page Header */
+.page-header {
+  margin-bottom: 24px;
+}
+
+.page-title {
+  font-size: 24px;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.page-desc {
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+/* Cards */
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+  transition: border-color 0.15s ease;
+}
+
+.card:hover {
+  border-color: var(--border-active);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.card-title {
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+}
+
+/* Grid layouts */
+.grid-2 {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+}
+
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+.grid-4 {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+
+/* Stat cards */
+.stat-value {
+  font-size: 32px;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  line-height: 1;
+  margin-bottom: 4px;
+}
+
+.stat-label {
+  font-size: 12px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* Status indicators */
+.status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.status-online .status-dot {
+  background: var(--green);
+  box-shadow: 0 0 8px var(--green-glow);
+}
+
+.status-online { color: var(--green); }
+
+.status-starting .status-dot {
+  background: var(--yellow);
+  box-shadow: 0 0 8px var(--yellow-glow);
+  animation: pulse 1.5s infinite;
+}
+
+.status-starting { color: var(--yellow); }
+
+.status-offline .status-dot {
+  background: var(--red);
+  box-shadow: 0 0 8px var(--red-glow);
+}
+
+.status-offline { color: var(--red); }
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+/* Node cards */
+.node-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+  transition: all 0.2s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.node-card:hover {
+  border-color: var(--border-active);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow);
+}
+
+.node-card.is-leader {
+  border-color: var(--accent);
+}
+
+.node-card.is-leader::before {
+  content: 'LEADER';
+  position: absolute;
+  top: 12px;
+  right: -28px;
+  background: var(--accent);
+  color: white;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  padding: 2px 32px;
+  transform: rotate(45deg);
+}
+
+.node-name {
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.node-id {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  margin-bottom: 12px;
+}
+
+.node-gpu {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+}
+
+.node-model {
+  font-size: 13px;
+  color: var(--accent);
+  font-family: var(--font-mono);
+}
+
+/* Progress bars */
+.progress-bar {
+  width: 100%;
+  height: 6px;
+  background: var(--bg-primary);
+  border-radius: 3px;
+  overflow: hidden;
+  margin-top: 8px;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.5s ease;
+}
+
+.progress-fill.green { background: var(--green); }
+.progress-fill.yellow { background: var(--yellow); }
+.progress-fill.red { background: var(--red); }
+
+/* Chat */
+.chat-container {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 120px);
+}
+
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 0;
+}
+
+.chat-message {
+  padding: 12px 16px;
+  margin-bottom: 8px;
+  border-radius: var(--radius-sm);
+  max-width: 80%;
+  line-height: 1.6;
+  font-size: 14px;
+}
+
+.chat-message.user {
+  background: var(--accent);
+  color: white;
+  margin-left: auto;
+  border-bottom-right-radius: 2px;
+}
+
+.chat-message.assistant {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-bottom-left-radius: 2px;
+}
+
+.chat-message pre {
+  background: var(--bg-primary);
+  border-radius: var(--radius-sm);
+  padding: 12px;
+  margin: 8px 0;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+
+.chat-message code {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  background: var(--bg-primary);
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.chat-input-area {
+  border-top: 1px solid var(--border);
+  padding: 16px 0;
+}
+
+.chat-input-wrapper {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+}
+
+.chat-input {
+  flex: 1;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 12px 16px;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-family: var(--font-sans);
+  resize: none;
+  min-height: 48px;
+  max-height: 200px;
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.chat-input:focus {
+  border-color: var(--accent);
+}
+
+.chat-input::placeholder {
+  color: var(--text-muted);
+}
+
+.chat-send {
+  background: var(--accent);
+  color: white;
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 12px 20px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease;
+  white-space: nowrap;
+}
+
+.chat-send:hover {
+  background: var(--accent-hover);
+}
+
+.chat-send:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.chat-model-select {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 12px;
+  color: var(--text-primary);
+  font-size: 13px;
+  outline: none;
+  margin-bottom: 12px;
+}
+
+/* Models list */
+.model-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  transition: border-color 0.15s ease;
+  margin-bottom: 8px;
+}
+
+.model-card:hover {
+  border-color: var(--border-active);
+}
+
+.model-info {
+  flex: 1;
+}
+
+.model-name {
+  font-size: 15px;
+  font-weight: 600;
+  font-family: var(--font-mono);
+  margin-bottom: 4px;
+}
+
+.model-meta {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.model-status {
+  text-align: right;
+}
+
+.model-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 20px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.model-badge.loaded {
+  background: var(--green-glow);
+  color: var(--green);
+  border: 1px solid var(--green);
+}
+
+.model-badge.available {
+  background: rgba(74, 144, 217, 0.1);
+  color: var(--accent);
+  border: 1px solid var(--accent);
+}
+
+/* Training section */
+.training-placeholder {
+  text-align: center;
+  padding: 80px 20px;
+  color: var(--text-muted);
+}
+
+.training-placeholder svg {
+  width: 64px;
+  height: 64px;
+  margin-bottom: 16px;
+  opacity: 0.3;
+}
+
+.training-placeholder h3 {
+  font-size: 18px;
+  margin-bottom: 8px;
+  color: var(--text-secondary);
+}
+
+/* Table */
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th {
+  text-align: left;
+  padding: 10px 16px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border);
+}
+
+.table td {
+  padding: 12px 16px;
+  font-size: 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.table tr:hover td {
+  background: var(--bg-card-hover);
+}
+
+/* Scrollbar */
+::-webkit-scrollbar {
+  width: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
+}
+
+/* Responsive */
+@media (max-width: 1024px) {
+  .grid-4 { grid-template-columns: repeat(2, 1fr); }
+  .grid-3 { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (max-width: 768px) {
+  .sidebar { display: none; }
+  .main { margin-left: 0; }
+  .grid-4, .grid-3, .grid-2 { grid-template-columns: 1fr; }
+}
+
+/* Loading skeleton */
+.skeleton {
+  background: linear-gradient(90deg, var(--bg-card) 25%, var(--bg-card-hover) 50%, var(--bg-card) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+  border-radius: var(--radius-sm);
+}
+
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}

--- a/ainode/web/static/js/app.js
+++ b/ainode/web/static/js/app.js
@@ -1,0 +1,419 @@
+/* AINode Dashboard — Single Page Application */
+
+const AINode = {
+  state: {
+    currentView: 'dashboard',
+    status: null,
+    nodes: [],
+    messages: [],
+    streaming: false,
+    pollInterval: null,
+  },
+
+  // ─── Initialization ────────────────────────────────
+  init() {
+    this.bindNav();
+    this.bindChat();
+    this.navigate(window.location.hash.slice(1) || 'dashboard');
+    this.startPolling();
+  },
+
+  // ─── Navigation ────────────────────────────────────
+  bindNav() {
+    document.querySelectorAll('.nav-item').forEach(el => {
+      el.addEventListener('click', () => {
+        const view = el.dataset.view;
+        if (view) this.navigate(view);
+      });
+    });
+  },
+
+  navigate(view) {
+    this.state.currentView = view;
+    window.location.hash = view;
+
+    // Update nav active state
+    document.querySelectorAll('.nav-item').forEach(el => {
+      el.classList.toggle('active', el.dataset.view === view);
+    });
+
+    // Show/hide views
+    document.querySelectorAll('.view').forEach(el => {
+      el.style.display = el.id === `view-${view}` ? 'block' : 'none';
+    });
+
+    // Refresh data for the view
+    this.refresh();
+  },
+
+  // ─── Data Fetching ─────────────────────────────────
+  async fetchJSON(url) {
+    try {
+      const resp = await fetch(url);
+      if (!resp.ok) return null;
+      return await resp.json();
+    } catch {
+      return null;
+    }
+  },
+
+  async refresh() {
+    const [status, nodes] = await Promise.all([
+      this.fetchJSON('/api/status'),
+      this.fetchJSON('/api/nodes'),
+    ]);
+
+    this.state.status = status;
+    this.state.nodes = nodes?.nodes || [];
+
+    switch (this.state.currentView) {
+      case 'dashboard': this.renderDashboard(); break;
+      case 'chat': this.renderChatHeader(); break;
+      case 'models': this.renderModels(); break;
+      case 'training': this.renderTraining(); break;
+    }
+  },
+
+  startPolling() {
+    this.state.pollInterval = setInterval(() => this.refresh(), 5000);
+  },
+
+  // ─── Dashboard View ────────────────────────────────
+  renderDashboard() {
+    const s = this.state.status;
+    const nodes = this.state.nodes;
+
+    if (!s) {
+      document.getElementById('dashboard-stats').innerHTML = this.skeletonCards(4);
+      return;
+    }
+
+    // Stats row
+    const totalGPUs = nodes.reduce((sum, n) => sum + (n.gpu_count || 1), 0);
+    const totalMem = nodes.reduce((sum, n) => sum + (n.gpu_memory_gb || 0), 0);
+    const onlineNodes = nodes.filter(n => n.status === 'online').length;
+    const modelsLoaded = s.models_loaded?.length || 0;
+
+    document.getElementById('dashboard-stats').innerHTML = `
+      <div class="card">
+        <div class="stat-value">${onlineNodes || 1}</div>
+        <div class="stat-label">Nodes Online</div>
+      </div>
+      <div class="card">
+        <div class="stat-value">${totalGPUs || 1}</div>
+        <div class="stat-label">GPUs</div>
+      </div>
+      <div class="card">
+        <div class="stat-value">${totalMem || (s.gpu?.memory_gb || 0)} GB</div>
+        <div class="stat-label">Total Memory</div>
+      </div>
+      <div class="card">
+        <div class="stat-value">${modelsLoaded}</div>
+        <div class="stat-label">Models Loaded</div>
+      </div>
+    `;
+
+    // Node cards
+    this.renderNodes(nodes, s);
+
+    // Cluster health
+    this.renderClusterHealth(s);
+  },
+
+  renderNodes(nodes, status) {
+    const container = document.getElementById('dashboard-nodes');
+    if (!container) return;
+
+    // If no cluster nodes, show this node
+    if (nodes.length === 0 && status) {
+      nodes = [{
+        node_id: status.node_id || 'local',
+        node_name: status.node_name || 'This Node',
+        gpu_name: status.gpu?.name || 'Unknown GPU',
+        gpu_memory_gb: status.gpu?.memory_gb || 0,
+        unified_memory: status.gpu?.unified_memory || false,
+        model: status.model || 'none',
+        status: status.engine_ready ? 'online' : 'starting',
+        is_leader: true,
+      }];
+    }
+
+    container.innerHTML = nodes.map(node => {
+      const statusClass = node.status === 'online' ? 'status-online' :
+                          node.status === 'starting' ? 'status-starting' : 'status-offline';
+      const leaderClass = node.is_leader ? 'is-leader' : '';
+      const memLabel = node.unified_memory ? 'unified' : 'VRAM';
+      const memPct = node.gpu_memory_used_pct || 0;
+      const barClass = memPct > 90 ? 'red' : memPct > 70 ? 'yellow' : 'green';
+
+      return `
+        <div class="node-card ${leaderClass}">
+          <div style="display:flex; justify-content:space-between; align-items:start; margin-bottom:12px">
+            <div>
+              <div class="node-name">${this.esc(node.node_name || node.node_id)}</div>
+              <div class="node-id">${this.esc(node.node_id)}</div>
+            </div>
+            <div class="status ${statusClass}">
+              <span class="status-dot"></span>
+              ${node.status || 'unknown'}
+            </div>
+          </div>
+          <div class="node-gpu">${this.esc(node.gpu_name || 'Unknown')} &middot; ${node.gpu_memory_gb || '?'} GB ${memLabel}</div>
+          <div class="node-model">${this.esc(node.model || 'no model')}</div>
+          <div class="progress-bar">
+            <div class="progress-fill ${barClass}" style="width:${memPct}%"></div>
+          </div>
+          <div style="font-size:11px; color:var(--text-muted); margin-top:4px">
+            Memory: ${memPct}% used
+          </div>
+        </div>
+      `;
+    }).join('');
+  },
+
+  renderClusterHealth(status) {
+    const container = document.getElementById('dashboard-health');
+    if (!container) return;
+
+    const uptime = status.uptime_seconds ? this.formatUptime(status.uptime_seconds) : 'N/A';
+
+    container.innerHTML = `
+      <div class="card">
+        <div class="card-header">
+          <div class="card-title">Engine Status</div>
+        </div>
+        <table class="table">
+          <tr>
+            <td>Engine</td>
+            <td>${status.engine_ready ?
+              '<span class="status status-online"><span class="status-dot"></span>Ready</span>' :
+              '<span class="status status-starting"><span class="status-dot"></span>Starting</span>'}</td>
+          </tr>
+          <tr>
+            <td>Model</td>
+            <td style="font-family:var(--font-mono)">${this.esc(status.model || 'none')}</td>
+          </tr>
+          <tr>
+            <td>API Port</td>
+            <td style="font-family:var(--font-mono)">${status.api_port || 8000}</td>
+          </tr>
+          <tr>
+            <td>Uptime</td>
+            <td>${uptime}</td>
+          </tr>
+          <tr>
+            <td>Version</td>
+            <td>${this.esc(status.version || 'unknown')}</td>
+          </tr>
+        </table>
+      </div>
+    `;
+  },
+
+  // ─── Chat View ─────────────────────────────────────
+  bindChat() {
+    const input = document.getElementById('chat-input');
+    const send = document.getElementById('chat-send');
+    if (!input || !send) return;
+
+    send.addEventListener('click', () => this.sendMessage());
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        this.sendMessage();
+      }
+    });
+
+    // Auto-resize textarea
+    input.addEventListener('input', () => {
+      input.style.height = 'auto';
+      input.style.height = Math.min(input.scrollHeight, 200) + 'px';
+    });
+  },
+
+  renderChatHeader() {
+    const s = this.state.status;
+    const select = document.getElementById('chat-model');
+    if (!select || !s) return;
+
+    const models = s.models_loaded || [];
+    if (models.length === 0) {
+      select.innerHTML = '<option>No models loaded</option>';
+    } else {
+      select.innerHTML = models.map(m =>
+        `<option value="${this.esc(m)}">${this.esc(m)}</option>`
+      ).join('');
+    }
+  },
+
+  async sendMessage() {
+    const input = document.getElementById('chat-input');
+    const content = input.value.trim();
+    if (!content || this.state.streaming) return;
+
+    input.value = '';
+    input.style.height = 'auto';
+
+    // Add user message
+    this.state.messages.push({ role: 'user', content });
+    this.renderMessages();
+
+    // Get model
+    const select = document.getElementById('chat-model');
+    const model = select?.value || '';
+
+    // Stream response
+    this.state.streaming = true;
+    document.getElementById('chat-send').disabled = true;
+
+    const assistantMsg = { role: 'assistant', content: '' };
+    this.state.messages.push(assistantMsg);
+
+    try {
+      const resp = await fetch('/v1/chat/completions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model,
+          messages: this.state.messages.slice(0, -1).map(m => ({
+            role: m.role, content: m.content
+          })),
+          stream: true,
+        }),
+      });
+
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop();
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          const data = line.slice(6);
+          if (data === '[DONE]') break;
+
+          try {
+            const json = JSON.parse(data);
+            const delta = json.choices?.[0]?.delta?.content;
+            if (delta) {
+              assistantMsg.content += delta;
+              this.renderMessages();
+            }
+          } catch { /* skip malformed chunks */ }
+        }
+      }
+    } catch (err) {
+      assistantMsg.content = `Error: ${err.message}. Is the engine running?`;
+    }
+
+    this.state.streaming = false;
+    document.getElementById('chat-send').disabled = false;
+    this.renderMessages();
+  },
+
+  renderMessages() {
+    const container = document.getElementById('chat-messages');
+    if (!container) return;
+
+    container.innerHTML = this.state.messages.map(msg => `
+      <div class="chat-message ${msg.role}">
+        ${this.formatMarkdown(msg.content)}
+      </div>
+    `).join('');
+
+    container.scrollTop = container.scrollHeight;
+  },
+
+  // ─── Models View ───────────────────────────────────
+  renderModels() {
+    const container = document.getElementById('models-list');
+    if (!container) return;
+
+    const s = this.state.status;
+    const loaded = s?.models_loaded || [];
+
+    const recommended = [
+      { id: 'meta-llama/Llama-3.2-3B-Instruct', size: '~6 GB', desc: 'Quick start, fast inference' },
+      { id: 'meta-llama/Llama-3.1-8B-Instruct', size: '~16 GB', desc: 'Recommended for most tasks' },
+      { id: 'meta-llama/Llama-3.1-70B-Instruct-AWQ', size: '~35 GB', desc: 'High quality, needs 40+ GB' },
+      { id: 'Qwen/Qwen2.5-72B-Instruct', size: '~40 GB', desc: 'Great for coding + multilingual' },
+      { id: 'deepseek-ai/DeepSeek-R1-Distill-Qwen-7B', size: '~14 GB', desc: 'Reasoning specialist' },
+      { id: 'mistralai/Mistral-7B-Instruct-v0.3', size: '~14 GB', desc: 'Fast, general purpose' },
+    ];
+
+    container.innerHTML = recommended.map(model => {
+      const isLoaded = loaded.includes(model.id);
+      return `
+        <div class="model-card">
+          <div class="model-info">
+            <div class="model-name">${this.esc(model.id)}</div>
+            <div class="model-meta">${model.size} &middot; ${model.desc}</div>
+          </div>
+          <div class="model-status">
+            ${isLoaded ?
+              '<span class="model-badge loaded">Loaded</span>' :
+              '<span class="model-badge available">Available</span>'}
+          </div>
+        </div>
+      `;
+    }).join('');
+  },
+
+  // ─── Training View ─────────────────────────────────
+  renderTraining() {
+    const container = document.getElementById('training-content');
+    if (!container) return;
+
+    container.innerHTML = `
+      <div class="training-placeholder">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+          <path d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
+        </svg>
+        <h3>Fine-Tuning Studio</h3>
+        <p>Upload datasets, configure LoRA adapters, and train models — all from your browser.</p>
+        <p style="margin-top:16px; font-size:13px">Coming in AINode v0.2</p>
+      </div>
+    `;
+  },
+
+  // ─── Utilities ─────────────────────────────────────
+  esc(str) {
+    const div = document.createElement('div');
+    div.textContent = str || '';
+    return div.innerHTML;
+  },
+
+  formatUptime(seconds) {
+    if (seconds < 60) return `${seconds}s`;
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    return `${h}h ${m}m`;
+  },
+
+  formatMarkdown(text) {
+    if (!text) return '';
+    // Basic markdown: code blocks, inline code, bold, newlines
+    return text
+      .replace(/```(\w*)\n([\s\S]*?)```/g, '<pre><code>$2</code></pre>')
+      .replace(/`([^`]+)`/g, '<code>$1</code>')
+      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+      .replace(/\n/g, '<br>');
+  },
+
+  skeletonCards(n) {
+    return Array(n).fill(
+      '<div class="card"><div class="skeleton" style="height:48px;margin-bottom:8px"></div><div class="skeleton" style="height:14px;width:60%"></div></div>'
+    ).join('');
+  },
+};
+
+// Boot
+document.addEventListener('DOMContentLoaded', () => AINode.init());

--- a/ainode/web/templates/index.html
+++ b/ainode/web/templates/index.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AINode — Local AI Platform</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/css/style.css">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚡</text></svg>">
+</head>
+<body>
+  <div class="app">
+    <!-- Sidebar -->
+    <aside class="sidebar">
+      <div class="sidebar-header">
+        <div class="sidebar-logo"><span>AI</span>Node</div>
+        <div class="sidebar-subtitle">Local AI Platform</div>
+      </div>
+
+      <nav class="sidebar-nav">
+        <div class="nav-item active" data-view="dashboard">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <rect x="3" y="3" width="7" height="7" rx="1"/>
+            <rect x="14" y="3" width="7" height="7" rx="1"/>
+            <rect x="3" y="14" width="7" height="7" rx="1"/>
+            <rect x="14" y="14" width="7" height="7" rx="1"/>
+          </svg>
+          Dashboard
+        </div>
+        <div class="nav-item" data-view="chat">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/>
+          </svg>
+          Chat
+        </div>
+        <div class="nav-item" data-view="models">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/>
+            <polyline points="3.27 6.96 12 12.01 20.73 6.96"/>
+            <line x1="12" y1="22.08" x2="12" y2="12"/>
+          </svg>
+          Models
+        </div>
+        <div class="nav-item" data-view="training">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
+          </svg>
+          Training
+        </div>
+      </nav>
+
+      <div class="sidebar-footer">
+        Powered by <a href="https://argentos.ai" target="_blank">argentos.ai</a>
+      </div>
+    </aside>
+
+    <!-- Main Content -->
+    <main class="main">
+
+      <!-- Dashboard View -->
+      <div id="view-dashboard" class="view">
+        <div class="page-header">
+          <div class="page-title">Dashboard</div>
+          <div class="page-desc">Cluster overview and node status</div>
+        </div>
+
+        <div id="dashboard-stats" class="grid-4" style="margin-bottom:24px">
+          <!-- Filled by JS -->
+        </div>
+
+        <div class="card-header" style="margin-bottom:12px">
+          <div class="card-title">Nodes</div>
+        </div>
+        <div id="dashboard-nodes" class="grid-3" style="margin-bottom:24px">
+          <!-- Filled by JS -->
+        </div>
+
+        <div id="dashboard-health">
+          <!-- Filled by JS -->
+        </div>
+      </div>
+
+      <!-- Chat View -->
+      <div id="view-chat" class="view" style="display:none">
+        <div class="page-header">
+          <div class="page-title">Chat</div>
+          <div class="page-desc">Talk to your local models</div>
+        </div>
+
+        <div class="chat-container">
+          <select id="chat-model" class="chat-model-select">
+            <option>Loading models...</option>
+          </select>
+
+          <div id="chat-messages" class="chat-messages">
+            <div style="text-align:center; color:var(--text-muted); padding:60px 0">
+              Send a message to get started
+            </div>
+          </div>
+
+          <div class="chat-input-area">
+            <div class="chat-input-wrapper">
+              <textarea id="chat-input" class="chat-input" placeholder="Type a message..." rows="1"></textarea>
+              <button id="chat-send" class="chat-send">Send</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Models View -->
+      <div id="view-models" class="view" style="display:none">
+        <div class="page-header">
+          <div class="page-title">Models</div>
+          <div class="page-desc">Browse and manage available models</div>
+        </div>
+
+        <div id="models-list">
+          <!-- Filled by JS -->
+        </div>
+      </div>
+
+      <!-- Training View -->
+      <div id="view-training" class="view" style="display:none">
+        <div class="page-header">
+          <div class="page-title">Training</div>
+          <div class="page-desc">Fine-tune models on your hardware</div>
+        </div>
+
+        <div id="training-content">
+          <!-- Filled by JS -->
+        </div>
+      </div>
+
+    </main>
+  </div>
+
+  <script src="/static/js/app.js"></script>
+</body>
+</html>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,106 @@
+"""Tests for ainode.api.server — AINode-specific endpoints."""
+
+import pytest
+import pytest_asyncio
+from aiohttp.test_utils import TestClient, TestServer
+
+from ainode.api.server import create_app
+from ainode.core.config import NodeConfig
+
+
+@pytest.fixture
+def config():
+    return NodeConfig(node_id="test-node-1", node_name="TestNode", model="test-model")
+
+
+@pytest.fixture
+def app(config):
+    return create_app(config=config, engine=None)
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    async with TestClient(TestServer(app)) as c:
+        yield c
+
+
+# ---- /api/health -----------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_health(client):
+    resp = await client.get("/api/health")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data == {"status": "ok"}
+
+
+# ---- /api/status -----------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_status_fields(client):
+    resp = await client.get("/api/status")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["node_id"] == "test-node-1"
+    assert data["node_name"] == "TestNode"
+    assert data["model"] == "test-model"
+    assert data["version"] == "0.1.0"
+    assert data["powered_by"] == "argentos.ai"
+    assert data["engine_ready"] is False
+    assert isinstance(data["uptime"], (int, float))
+    assert isinstance(data["models_loaded"], list)
+    assert "api_port" in data
+
+
+# ---- /api/nodes ------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_nodes(client):
+    resp = await client.get("/api/nodes")
+    assert resp.status == 200
+    data = await resp.json()
+    assert "nodes" in data
+    nodes = data["nodes"]
+    assert len(nodes) == 1
+    node = nodes[0]
+    assert node["node_id"] == "test-node-1"
+    assert node["node_name"] == "TestNode"
+    assert node["model"] == "test-model"
+    assert node["engine_ready"] is False
+
+
+# ---- / (index) -------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_index_serves_html(client):
+    resp = await client.get("/")
+    assert resp.status == 200
+    assert "text/html" in resp.headers.get("Content-Type", "")
+    body = await resp.text()
+    assert "<html" in body.lower() or "<!doctype" in body.lower()
+
+
+# ---- CORS ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_cors_headers(client):
+    resp = await client.get("/api/health")
+    assert resp.headers.get("Access-Control-Allow-Origin") == "*"
+
+
+@pytest.mark.asyncio
+async def test_cors_preflight(client):
+    resp = await client.options("/api/health")
+    assert resp.status == 204
+    assert resp.headers.get("Access-Control-Allow-Origin") == "*"
+    assert "POST" in resp.headers.get("Access-Control-Allow-Methods", "")
+
+
+# ---- vLLM proxy returns 502 when engine is down ----------------------------
+
+@pytest.mark.asyncio
+async def test_vllm_proxy_returns_502_when_down(client):
+    resp = await client.get("/v1/models")
+    assert resp.status == 502
+    data = await resp.json()
+    assert "error" in data


### PR DESCRIPTION
## Summary
- Adds aiohttp API proxy server (`ainode/api/server.py`) that listens on `web_port` (3000) and proxies `/v1/*` requests to the local vLLM engine on `api_port` (8000)
- Serves the embedded web dashboard at `/` with static file serving
- Exposes AINode-specific endpoints: `/api/health`, `/api/status` (with node info, GPU, uptime, version, "Powered by argentos.ai"), and `/api/nodes` (cluster stub)
- Includes CORS middleware, SSE streaming support for chat completions, and 502 error handling when vLLM is down
- Pulls in web UI assets (serve.py, templates, static) as a dependency

## Test plan
- [x] 7 new tests in `tests/test_api.py` covering health, status, nodes, index, CORS, preflight, and 502 proxy error
- [x] All 31 tests pass (`pytest tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)