### PR TITLE
Add multi-node cluster discovery and coordination

### DIFF
--- a/ainode/discovery/__init__.py
+++ b/ainode/discovery/__init__.py
@@ -1,0 +1,20 @@
+"""UDP broadcast discovery and cluster coordination for AINode."""
+
+from ainode.discovery.broadcast import (
+    NodeAnnouncement,
+    NodeStatus,
+    DiscoveredNode,
+    BroadcastSender,
+    BroadcastListener,
+)
+from ainode.discovery.cluster import ClusterState, ClusterNode
+
+__all__ = [
+    "NodeAnnouncement",
+    "NodeStatus",
+    "DiscoveredNode",
+    "BroadcastSender",
+    "BroadcastListener",
+    "ClusterState",
+    "ClusterNode",
+]

--- a/ainode/discovery/broadcast.py
+++ b/ainode/discovery/broadcast.py
@@ -3,111 +3,224 @@
 import json
 import socket
 import asyncio
-import uuid
-from dataclasses import dataclass, asdict
-from typing import Callable, Optional
+import time
+from dataclasses import dataclass, field, asdict
+from enum import Enum
+from typing import Callable, Dict, List, Optional
+
+
+class NodeStatus(str, Enum):
+    """Health status of a discovered node."""
+    ONLINE = "online"
+    STALE = "stale"
+    OFFLINE = "offline"
+
+
+# Thresholds in seconds
+ONLINE_THRESHOLD = 15.0
+STALE_THRESHOLD = 30.0
 
 
 @dataclass
 class NodeAnnouncement:
     """Broadcast message from a node."""
     node_id: str
-    host: str
-    api_port: int
+    node_name: str
     gpu_name: str
-    gpu_memory_mb: int
-    models_loaded: list
-    version: str
+    gpu_memory_gb: float
+    unified_memory: bool
+    model: str
+    status: str
+    api_port: int
+    web_port: int
+    timestamp: float = field(default_factory=time.time)
+
+    def to_json(self) -> str:
+        """Serialize to JSON string."""
+        return json.dumps(asdict(self))
+
+    @classmethod
+    def from_json(cls, data: str) -> "NodeAnnouncement":
+        """Deserialize from JSON string."""
+        return cls(**json.loads(data))
 
 
-class NodeDiscovery:
-    """Discovers other AINode instances on the local network via UDP broadcast."""
+@dataclass
+class DiscoveredNode:
+    """A node discovered on the network, with health tracking."""
+    announcement: NodeAnnouncement
+    last_seen: float = field(default_factory=time.time)
+
+    @property
+    def age(self) -> float:
+        """Seconds since last heartbeat."""
+        return time.time() - self.last_seen
+
+    @property
+    def health(self) -> NodeStatus:
+        """Determine node health based on heartbeat age."""
+        age = self.age
+        if age < ONLINE_THRESHOLD:
+            return NodeStatus.ONLINE
+        elif age < STALE_THRESHOLD:
+            return NodeStatus.STALE
+        return NodeStatus.OFFLINE
+
+
+class BroadcastSender:
+    """Sends UDP broadcast announcements on a regular interval."""
 
     def __init__(
         self,
-        node_id: str,
-        host: str,
-        api_port: int,
+        announcement: NodeAnnouncement,
         discovery_port: int = 5678,
         broadcast_interval: float = 5.0,
-        on_node_found: Optional[Callable] = None,
-        on_node_lost: Optional[Callable] = None,
     ):
-        self.node_id = node_id
-        self.host = host
-        self.api_port = api_port
+        self.announcement = announcement
         self.discovery_port = discovery_port
         self.broadcast_interval = broadcast_interval
-        self.on_node_found = on_node_found
-        self.on_node_lost = on_node_lost
-        self.known_nodes: dict[str, NodeAnnouncement] = {}
         self._running = False
+        self._task: Optional[asyncio.Task] = None
 
     async def start(self):
-        """Start broadcasting and listening."""
+        """Start the broadcast loop."""
         self._running = True
-        asyncio.create_task(self._broadcast_loop())
-        asyncio.create_task(self._listen_loop())
+        self._task = asyncio.create_task(self._broadcast_loop())
 
     async def stop(self):
-        """Stop discovery."""
+        """Stop broadcasting."""
         self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+    def update_announcement(self, **kwargs):
+        """Update fields on the announcement (e.g. model, status)."""
+        for key, value in kwargs.items():
+            if hasattr(self.announcement, key):
+                setattr(self.announcement, key, value)
 
     async def _broadcast_loop(self):
         """Periodically broadcast our presence."""
-        from ainode.core.gpu import detect_gpu
-        from ainode import __version__
-
-        gpu = detect_gpu()
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
         sock.setblocking(False)
 
-        announcement = NodeAnnouncement(
-            node_id=self.node_id,
-            host=self.host,
-            api_port=self.api_port,
-            gpu_name=gpu.name if gpu else "unknown",
-            gpu_memory_mb=gpu.memory_total_mb if gpu else 0,
-            models_loaded=[],
-            version=__version__,
+        try:
+            while self._running:
+                try:
+                    self.announcement.timestamp = time.time()
+                    data = self.announcement.to_json().encode()
+                    sock.sendto(data, ("<broadcast>", self.discovery_port))
+                except Exception:
+                    pass
+                await asyncio.sleep(self.broadcast_interval)
+        finally:
+            sock.close()
+
+
+class BroadcastListener:
+    """Listens for UDP broadcast announcements and maintains a node registry."""
+
+    def __init__(
+        self,
+        local_node_id: str,
+        discovery_port: int = 5678,
+        on_node_found: Optional[Callable[[NodeAnnouncement], None]] = None,
+        on_node_lost: Optional[Callable[[str], None]] = None,
+    ):
+        self.local_node_id = local_node_id
+        self.discovery_port = discovery_port
+        self.on_node_found = on_node_found
+        self.on_node_lost = on_node_lost
+        self._registry: Dict[str, DiscoveredNode] = {}
+        self._running = False
+        self._listen_task: Optional[asyncio.Task] = None
+        self._reaper_task: Optional[asyncio.Task] = None
+
+    @property
+    def registry(self) -> Dict[str, DiscoveredNode]:
+        return dict(self._registry)
+
+    def get_nodes(self, include_offline: bool = False) -> List[DiscoveredNode]:
+        """Return discovered nodes, optionally filtering out offline ones."""
+        nodes = list(self._registry.values())
+        if not include_offline:
+            nodes = [n for n in nodes if n.health != NodeStatus.OFFLINE]
+        return nodes
+
+    def get_node(self, node_id: str) -> Optional[DiscoveredNode]:
+        """Get a specific discovered node by ID."""
+        return self._registry.get(node_id)
+
+    def _process_announcement(self, announcement: NodeAnnouncement):
+        """Process a received announcement."""
+        if announcement.node_id == self.local_node_id:
+            return
+
+        is_new = announcement.node_id not in self._registry
+        self._registry[announcement.node_id] = DiscoveredNode(
+            announcement=announcement,
+            last_seen=time.time(),
         )
 
-        while self._running:
-            try:
-                data = json.dumps(asdict(announcement)).encode()
-                sock.sendto(data, ("<broadcast>", self.discovery_port))
-            except Exception:
-                pass
-            await asyncio.sleep(self.broadcast_interval)
+        if is_new and self.on_node_found:
+            self.on_node_found(announcement)
 
-        sock.close()
+    async def start(self):
+        """Start listening for broadcasts."""
+        self._running = True
+        self._listen_task = asyncio.create_task(self._listen_loop())
+        self._reaper_task = asyncio.create_task(self._reaper_loop())
+
+    async def stop(self):
+        """Stop listening."""
+        self._running = False
+        for task in [self._listen_task, self._reaper_task]:
+            if task:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
 
     async def _listen_loop(self):
-        """Listen for broadcasts from other nodes."""
+        """Listen for broadcast announcements."""
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+        except (AttributeError, OSError):
+            pass
         sock.bind(("", self.discovery_port))
         sock.setblocking(False)
 
         loop = asyncio.get_event_loop()
 
+        try:
+            while self._running:
+                try:
+                    data = await loop.run_in_executor(None, lambda: sock.recv(4096))
+                    announcement = NodeAnnouncement.from_json(data.decode())
+                    self._process_announcement(announcement)
+                except Exception:
+                    await asyncio.sleep(1)
+        finally:
+            sock.close()
+
+    async def _reaper_loop(self):
+        """Periodically check for offline nodes and fire on_node_lost."""
         while self._running:
-            try:
-                data = await loop.run_in_executor(None, lambda: sock.recv(4096))
-                announcement = NodeAnnouncement(**json.loads(data.decode()))
+            await asyncio.sleep(10)
+            to_remove = []
+            for node_id, node in self._registry.items():
+                if node.health == NodeStatus.OFFLINE:
+                    to_remove.append(node_id)
 
-                if announcement.node_id == self.node_id:
-                    continue  # Ignore our own broadcasts
-
-                if announcement.node_id not in self.known_nodes:
-                    self.known_nodes[announcement.node_id] = announcement
-                    if self.on_node_found:
-                        self.on_node_found(announcement)
-                else:
-                    self.known_nodes[announcement.node_id] = announcement
-
-            except Exception:
-                await asyncio.sleep(1)
-
-        sock.close()
+            for node_id in to_remove:
+                del self._registry[node_id]
+                if self.on_node_lost:
+                    self.on_node_lost(node_id)

--- a/ainode/discovery/cluster.py
+++ b/ainode/discovery/cluster.py
@@ -1,0 +1,143 @@
+"""Cluster coordinator -- tracks nodes, elects leader, routes model requests."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from ainode.discovery.broadcast import (
+    DiscoveredNode,
+    NodeAnnouncement,
+    NodeStatus,
+)
+
+
+@dataclass
+class ClusterNode:
+    """Enriched view of a node within the cluster."""
+    node_id: str
+    node_name: str
+    gpu_name: str
+    gpu_memory_gb: float
+    unified_memory: bool
+    model: str
+    status: NodeStatus
+    api_port: int
+    web_port: int
+    last_seen: float
+
+    @classmethod
+    def from_discovered(cls, discovered: DiscoveredNode) -> "ClusterNode":
+        a = discovered.announcement
+        return cls(
+            node_id=a.node_id,
+            node_name=a.node_name,
+            gpu_name=a.gpu_name,
+            gpu_memory_gb=a.gpu_memory_gb,
+            unified_memory=a.unified_memory,
+            model=a.model,
+            status=discovered.health,
+            api_port=a.api_port,
+            web_port=a.web_port,
+            last_seen=discovered.last_seen,
+        )
+
+    @classmethod
+    def from_announcement(cls, announcement: NodeAnnouncement, status: NodeStatus) -> "ClusterNode":
+        return cls(
+            node_id=announcement.node_id,
+            node_name=announcement.node_name,
+            gpu_name=announcement.gpu_name,
+            gpu_memory_gb=announcement.gpu_memory_gb,
+            unified_memory=announcement.unified_memory,
+            model=announcement.model,
+            status=status,
+            api_port=announcement.api_port,
+            web_port=announcement.web_port,
+            last_seen=time.time(),
+        )
+
+
+class ClusterState:
+    """Maintains cluster state: all nodes, their GPUs, loaded models, and leader election."""
+
+    def __init__(self, local_announcement: Optional[NodeAnnouncement] = None):
+        self._nodes: Dict[str, ClusterNode] = {}
+        self._local_announcement = local_announcement
+
+        # If we have a local announcement, add ourselves
+        if local_announcement:
+            self._nodes[local_announcement.node_id] = ClusterNode.from_announcement(
+                local_announcement, NodeStatus.ONLINE
+            )
+
+    def update_from_discovered(self, discovered_nodes: Dict[str, DiscoveredNode]):
+        """Sync cluster state from the listener registry."""
+        local_id = self._local_announcement.node_id if self._local_announcement else None
+
+        # Update remote nodes
+        for node_id, discovered in discovered_nodes.items():
+            self._nodes[node_id] = ClusterNode.from_discovered(discovered)
+
+        # Remove nodes no longer in the registry (except local)
+        remote_ids = set(discovered_nodes.keys())
+        to_remove = [
+            nid for nid in self._nodes
+            if nid != local_id and nid not in remote_ids
+        ]
+        for nid in to_remove:
+            del self._nodes[nid]
+
+        # Refresh local node timestamp
+        if local_id and self._local_announcement:
+            self._nodes[local_id] = ClusterNode.from_announcement(
+                self._local_announcement, NodeStatus.ONLINE
+            )
+
+    def add_node(self, node: ClusterNode):
+        """Add or update a node directly."""
+        self._nodes[node.node_id] = node
+
+    def remove_node(self, node_id: str):
+        """Remove a node from the cluster."""
+        self._nodes.pop(node_id, None)
+
+    def get_node(self, node_id: str) -> Optional[ClusterNode]:
+        """Get info for a specific node."""
+        return self._nodes.get(node_id)
+
+    def get_nodes(self, include_offline: bool = False) -> List[ClusterNode]:
+        """Get all nodes with their status."""
+        nodes = list(self._nodes.values())
+        if not include_offline:
+            nodes = [n for n in nodes if n.status != NodeStatus.OFFLINE]
+        return nodes
+
+    def get_leader(self) -> Optional[ClusterNode]:
+        """Return the current leader node. Leader = lowest node_id alphabetically among ONLINE nodes."""
+        online = [n for n in self._nodes.values() if n.status == NodeStatus.ONLINE]
+        if not online:
+            return None
+        return min(online, key=lambda n: n.node_id)
+
+    def find_model(self, model_name: str) -> List[ClusterNode]:
+        """Return which node(s) serve a given model. Only returns ONLINE or STALE nodes."""
+        return [
+            n for n in self._nodes.values()
+            if n.model == model_name and n.status in (NodeStatus.ONLINE, NodeStatus.STALE)
+        ]
+
+    def cluster_summary(self) -> dict:
+        """Return a summary dict of the cluster state."""
+        active_nodes = [n for n in self._nodes.values() if n.status != NodeStatus.OFFLINE]
+        models = set(n.model for n in active_nodes if n.model)
+        leader = self.get_leader()
+
+        return {
+            "total_nodes": len(active_nodes),
+            "total_gpus": len(active_nodes),
+            "total_memory_gb": sum(n.gpu_memory_gb for n in active_nodes),
+            "models_available": sorted(models),
+            "leader_id": leader.node_id if leader else None,
+        }

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,0 +1,232 @@
+"""Tests for cluster state, leader election, model routing, and summary."""
+
+import time
+import pytest
+
+from ainode.discovery.broadcast import (
+    NodeAnnouncement,
+    NodeStatus,
+    DiscoveredNode,
+)
+from ainode.discovery.cluster import ClusterState, ClusterNode
+
+
+def _make_announcement(**overrides) -> NodeAnnouncement:
+    defaults = dict(
+        node_id="node-aaa",
+        node_name="spark-1",
+        gpu_name="GB10",
+        gpu_memory_gb=128.0,
+        unified_memory=True,
+        model="meta-llama/Llama-3.2-3B-Instruct",
+        status="serving",
+        api_port=8000,
+        web_port=3000,
+        timestamp=time.time(),
+    )
+    defaults.update(overrides)
+    return NodeAnnouncement(**defaults)
+
+
+def _make_cluster_node(**overrides) -> ClusterNode:
+    defaults = dict(
+        node_id="node-aaa",
+        node_name="spark-1",
+        gpu_name="GB10",
+        gpu_memory_gb=128.0,
+        unified_memory=True,
+        model="meta-llama/Llama-3.2-3B-Instruct",
+        status=NodeStatus.ONLINE,
+        api_port=8000,
+        web_port=3000,
+        last_seen=time.time(),
+    )
+    defaults.update(overrides)
+    return ClusterNode(**defaults)
+
+
+class TestClusterState:
+    def test_local_node_added_on_init(self):
+        ann = _make_announcement(node_id="local-1")
+        cluster = ClusterState(local_announcement=ann)
+        assert cluster.get_node("local-1") is not None
+
+    def test_empty_cluster(self):
+        cluster = ClusterState()
+        assert cluster.get_nodes() == []
+        assert cluster.get_leader() is None
+
+    def test_add_and_get_node(self):
+        cluster = ClusterState()
+        node = _make_cluster_node(node_id="n1")
+        cluster.add_node(node)
+        assert cluster.get_node("n1") is not None
+        assert cluster.get_node("n1").gpu_memory_gb == 128.0
+
+    def test_remove_node(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="n1"))
+        cluster.remove_node("n1")
+        assert cluster.get_node("n1") is None
+
+    def test_remove_nonexistent_node_no_error(self):
+        cluster = ClusterState()
+        cluster.remove_node("nope")
+
+    def test_get_nodes_excludes_offline(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="online", status=NodeStatus.ONLINE))
+        cluster.add_node(_make_cluster_node(node_id="offline", status=NodeStatus.OFFLINE))
+        nodes = cluster.get_nodes(include_offline=False)
+        assert len(nodes) == 1
+        assert nodes[0].node_id == "online"
+
+    def test_get_nodes_includes_offline(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="online", status=NodeStatus.ONLINE))
+        cluster.add_node(_make_cluster_node(node_id="offline", status=NodeStatus.OFFLINE))
+        assert len(cluster.get_nodes(include_offline=True)) == 2
+
+
+class TestLeaderElection:
+    def test_single_node_is_leader(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="node-aaa"))
+        leader = cluster.get_leader()
+        assert leader is not None
+        assert leader.node_id == "node-aaa"
+
+    def test_lowest_id_wins(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="node-ccc"))
+        cluster.add_node(_make_cluster_node(node_id="node-aaa"))
+        cluster.add_node(_make_cluster_node(node_id="node-bbb"))
+        leader = cluster.get_leader()
+        assert leader.node_id == "node-aaa"
+
+    def test_offline_nodes_excluded_from_election(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="node-aaa", status=NodeStatus.OFFLINE))
+        cluster.add_node(_make_cluster_node(node_id="node-bbb", status=NodeStatus.ONLINE))
+        leader = cluster.get_leader()
+        assert leader.node_id == "node-bbb"
+
+    def test_stale_nodes_excluded_from_election(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="node-aaa", status=NodeStatus.STALE))
+        cluster.add_node(_make_cluster_node(node_id="node-bbb", status=NodeStatus.ONLINE))
+        leader = cluster.get_leader()
+        assert leader.node_id == "node-bbb"
+
+    def test_no_leader_when_all_offline(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="node-aaa", status=NodeStatus.OFFLINE))
+        assert cluster.get_leader() is None
+
+    def test_leader_changes_when_node_goes_offline(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="node-aaa", status=NodeStatus.ONLINE))
+        cluster.add_node(_make_cluster_node(node_id="node-bbb", status=NodeStatus.ONLINE))
+        assert cluster.get_leader().node_id == "node-aaa"
+        cluster.add_node(_make_cluster_node(node_id="node-aaa", status=NodeStatus.OFFLINE))
+        assert cluster.get_leader().node_id == "node-bbb"
+
+
+class TestModelRouting:
+    def test_find_model_single_match(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="n1", model="llama-3"))
+        cluster.add_node(_make_cluster_node(node_id="n2", model="mistral-7b"))
+        results = cluster.find_model("llama-3")
+        assert len(results) == 1
+        assert results[0].node_id == "n1"
+
+    def test_find_model_multiple_matches(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="n1", model="llama-3"))
+        cluster.add_node(_make_cluster_node(node_id="n2", model="llama-3"))
+        results = cluster.find_model("llama-3")
+        assert len(results) == 2
+
+    def test_find_model_no_match(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="n1", model="llama-3"))
+        assert cluster.find_model("gpt-4") == []
+
+    def test_find_model_excludes_offline(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="n1", model="llama-3", status=NodeStatus.ONLINE))
+        cluster.add_node(_make_cluster_node(node_id="n2", model="llama-3", status=NodeStatus.OFFLINE))
+        results = cluster.find_model("llama-3")
+        assert len(results) == 1
+        assert results[0].node_id == "n1"
+
+    def test_find_model_includes_stale(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="n1", model="llama-3", status=NodeStatus.STALE))
+        results = cluster.find_model("llama-3")
+        assert len(results) == 1
+
+
+class TestClusterSummary:
+    def test_summary_two_sparks(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(
+            node_id="spark-1", gpu_name="GB10", gpu_memory_gb=128.0,
+            model="meta-llama/Llama-3.2-70B-Instruct",
+        ))
+        cluster.add_node(_make_cluster_node(
+            node_id="spark-2", gpu_name="GB10", gpu_memory_gb=128.0,
+            model="meta-llama/Llama-3.2-3B-Instruct",
+        ))
+        summary = cluster.cluster_summary()
+        assert summary["total_nodes"] == 2
+        assert summary["total_gpus"] == 2
+        assert summary["total_memory_gb"] == 256.0
+        assert len(summary["models_available"]) == 2
+        assert summary["leader_id"] == "spark-1"
+
+    def test_summary_excludes_offline(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="n1", gpu_memory_gb=128.0))
+        cluster.add_node(_make_cluster_node(node_id="n2", gpu_memory_gb=128.0, status=NodeStatus.OFFLINE))
+        summary = cluster.cluster_summary()
+        assert summary["total_nodes"] == 1
+        assert summary["total_memory_gb"] == 128.0
+
+    def test_summary_empty_cluster(self):
+        cluster = ClusterState()
+        summary = cluster.cluster_summary()
+        assert summary["total_nodes"] == 0
+        assert summary["total_gpus"] == 0
+        assert summary["total_memory_gb"] == 0
+        assert summary["models_available"] == []
+        assert summary["leader_id"] is None
+
+    def test_summary_models_sorted(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="n1", model="zebra-model"))
+        cluster.add_node(_make_cluster_node(node_id="n2", model="alpha-model"))
+        summary = cluster.cluster_summary()
+        assert summary["models_available"] == ["alpha-model", "zebra-model"]
+
+    def test_update_from_discovered(self):
+        local_ann = _make_announcement(node_id="local-1")
+        cluster = ClusterState(local_announcement=local_ann)
+        discovered = {
+            "remote-1": DiscoveredNode(
+                announcement=_make_announcement(node_id="remote-1", model="mistral"),
+                last_seen=time.time(),
+            ),
+        }
+        cluster.update_from_discovered(discovered)
+        assert cluster.get_node("local-1") is not None
+        assert cluster.get_node("remote-1") is not None
+        assert cluster.get_node("remote-1").model == "mistral"
+
+    def test_cluster_node_from_discovered(self):
+        ann = _make_announcement(node_id="test-node")
+        discovered = DiscoveredNode(announcement=ann, last_seen=time.time())
+        cn = ClusterNode.from_discovered(discovered)
+        assert cn.node_id == "test-node"
+        assert cn.status == NodeStatus.ONLINE

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,173 @@
+"""Tests for UDP broadcast discovery -- announcement serialization, registry, health."""
+
+import time
+import json
+import pytest
+from unittest.mock import MagicMock
+
+from ainode.discovery.broadcast import (
+    NodeAnnouncement,
+    NodeStatus,
+    DiscoveredNode,
+    BroadcastListener,
+    ONLINE_THRESHOLD,
+    STALE_THRESHOLD,
+)
+
+
+def _make_announcement(**overrides) -> NodeAnnouncement:
+    defaults = dict(
+        node_id="node-aaa",
+        node_name="spark-1",
+        gpu_name="GB10",
+        gpu_memory_gb=128.0,
+        unified_memory=True,
+        model="meta-llama/Llama-3.2-3B-Instruct",
+        status="serving",
+        api_port=8000,
+        web_port=3000,
+        timestamp=1700000000.0,
+    )
+    defaults.update(overrides)
+    return NodeAnnouncement(**defaults)
+
+
+class TestNodeAnnouncement:
+    def test_to_json_roundtrip(self):
+        ann = _make_announcement()
+        raw = ann.to_json()
+        restored = NodeAnnouncement.from_json(raw)
+        assert restored.node_id == ann.node_id
+        assert restored.gpu_memory_gb == 128.0
+        assert restored.unified_memory is True
+        assert restored.model == ann.model
+
+    def test_json_contains_all_fields(self):
+        ann = _make_announcement()
+        data = json.loads(ann.to_json())
+        expected_keys = {
+            "node_id", "node_name", "gpu_name", "gpu_memory_gb",
+            "unified_memory", "model", "status", "api_port", "web_port", "timestamp",
+        }
+        assert set(data.keys()) == expected_keys
+
+    def test_default_timestamp(self):
+        ann = NodeAnnouncement(
+            node_id="x", node_name="x", gpu_name="x",
+            gpu_memory_gb=0, unified_memory=False, model="",
+            status="idle", api_port=8000, web_port=3000,
+        )
+        assert abs(ann.timestamp - time.time()) < 2
+
+
+class TestDiscoveredNodeHealth:
+    def test_online_when_fresh(self):
+        node = DiscoveredNode(announcement=_make_announcement(), last_seen=time.time())
+        assert node.health == NodeStatus.ONLINE
+
+    def test_stale_after_threshold(self):
+        node = DiscoveredNode(
+            announcement=_make_announcement(),
+            last_seen=time.time() - (ONLINE_THRESHOLD + 1),
+        )
+        assert node.health == NodeStatus.STALE
+
+    def test_offline_after_threshold(self):
+        node = DiscoveredNode(
+            announcement=_make_announcement(),
+            last_seen=time.time() - (STALE_THRESHOLD + 1),
+        )
+        assert node.health == NodeStatus.OFFLINE
+
+    def test_age_property(self):
+        now = time.time()
+        node = DiscoveredNode(announcement=_make_announcement(), last_seen=now - 10)
+        assert abs(node.age - 10) < 1
+
+    def test_health_transition_online_to_stale(self):
+        node = DiscoveredNode(announcement=_make_announcement(), last_seen=time.time())
+        assert node.health == NodeStatus.ONLINE
+        node.last_seen = time.time() - (ONLINE_THRESHOLD + 1)
+        assert node.health == NodeStatus.STALE
+
+    def test_health_transition_stale_to_offline(self):
+        node = DiscoveredNode(
+            announcement=_make_announcement(),
+            last_seen=time.time() - (ONLINE_THRESHOLD + 1),
+        )
+        assert node.health == NodeStatus.STALE
+        node.last_seen = time.time() - (STALE_THRESHOLD + 1)
+        assert node.health == NodeStatus.OFFLINE
+
+    def test_health_recovery(self):
+        node = DiscoveredNode(
+            announcement=_make_announcement(),
+            last_seen=time.time() - (ONLINE_THRESHOLD + 1),
+        )
+        assert node.health == NodeStatus.STALE
+        node.last_seen = time.time()
+        assert node.health == NodeStatus.ONLINE
+
+
+class TestBroadcastListenerRegistry:
+    def test_process_announcement_adds_node(self):
+        listener = BroadcastListener(local_node_id="local-node")
+        ann = _make_announcement(node_id="remote-1")
+        listener._process_announcement(ann)
+        assert "remote-1" in listener._registry
+        assert listener._registry["remote-1"].announcement.node_id == "remote-1"
+
+    def test_ignores_own_announcements(self):
+        listener = BroadcastListener(local_node_id="local-node")
+        ann = _make_announcement(node_id="local-node")
+        listener._process_announcement(ann)
+        assert "local-node" not in listener._registry
+
+    def test_updates_existing_node(self):
+        listener = BroadcastListener(local_node_id="local-node")
+        ann1 = _make_announcement(node_id="remote-1", model="model-a")
+        listener._process_announcement(ann1)
+        ann2 = _make_announcement(node_id="remote-1", model="model-b")
+        listener._process_announcement(ann2)
+        assert listener._registry["remote-1"].announcement.model == "model-b"
+
+    def test_on_node_found_callback(self):
+        callback = MagicMock()
+        listener = BroadcastListener(local_node_id="local-node", on_node_found=callback)
+        ann = _make_announcement(node_id="remote-1")
+        listener._process_announcement(ann)
+        callback.assert_called_once_with(ann)
+
+    def test_on_node_found_not_called_on_update(self):
+        callback = MagicMock()
+        listener = BroadcastListener(local_node_id="local-node", on_node_found=callback)
+        ann = _make_announcement(node_id="remote-1")
+        listener._process_announcement(ann)
+        listener._process_announcement(ann)
+        callback.assert_called_once()
+
+    def test_get_nodes_excludes_offline(self):
+        listener = BroadcastListener(local_node_id="local-node")
+        listener._process_announcement(_make_announcement(node_id="online-node"))
+        listener._process_announcement(_make_announcement(node_id="old-node"))
+        listener._registry["old-node"].last_seen = time.time() - (STALE_THRESHOLD + 1)
+        nodes = listener.get_nodes(include_offline=False)
+        assert len(nodes) == 1
+        assert nodes[0].announcement.node_id == "online-node"
+
+    def test_get_nodes_includes_offline(self):
+        listener = BroadcastListener(local_node_id="local-node")
+        listener._process_announcement(_make_announcement(node_id="online-node"))
+        listener._process_announcement(_make_announcement(node_id="old-node"))
+        listener._registry["old-node"].last_seen = time.time() - (STALE_THRESHOLD + 1)
+        nodes = listener.get_nodes(include_offline=True)
+        assert len(nodes) == 2
+
+    def test_get_node(self):
+        listener = BroadcastListener(local_node_id="local-node")
+        ann = _make_announcement(node_id="remote-1")
+        listener._process_announcement(ann)
+        node = listener.get_node("remote-1")
+        assert node is not None
+        assert node.announcement.node_name == "spark-1"
+        assert listener.get_node("nonexistent") is None


### PR DESCRIPTION
## Summary
- Enhanced UDP broadcast system with `NodeAnnouncement` dataclass, `BroadcastSender`/`BroadcastListener`, JSON serialization, and three-tier health tracking (ONLINE <15s, STALE <30s, OFFLINE >30s)
- Added `ClusterState` coordinator with leader election (lowest node_id alphabetically among ONLINE nodes), model routing (`find_model` returns serving nodes), and `cluster_summary` for multi-Spark deployments
- 42 new tests covering announcement serialization, node registry, staleness detection, health transitions, leader election, model routing, and cluster summary

## Test plan
- [x] `pytest tests/test_discovery.py` — 18 tests for broadcast, serialization, health
- [x] `pytest tests/test_cluster.py` — 24 tests for cluster state, leader election, model routing, summary
- [x] Full suite `pytest tests/` — 101 tests all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)