### PR TITLE
Add metrics/monitoring system

### DIFF
--- a/ainode/metrics/__init__.py
+++ b/ainode/metrics/__init__.py
@@ -1,0 +1,5 @@
+"""AINode metrics collection and monitoring."""
+
+from ainode.metrics.collector import MetricsCollector
+
+__all__ = ["MetricsCollector"]

--- a/ainode/metrics/api_routes.py
+++ b/ainode/metrics/api_routes.py
@@ -1,0 +1,40 @@
+"""API route handlers for /api/metrics endpoints."""
+
+from aiohttp import web
+
+from ainode.metrics.collector import MetricsCollector
+
+
+def register_metrics_routes(app: web.Application, collector: MetricsCollector) -> None:
+    """Register metrics endpoints on the aiohttp application.
+
+    Parameters
+    ----------
+    app : web.Application
+        The aiohttp app to add routes to.
+    collector : MetricsCollector
+        Shared collector instance used by these handlers.
+    """
+    app["metrics_collector"] = collector
+
+    app.router.add_get("/api/metrics", handle_metrics)
+    app.router.add_get("/api/metrics/gpu", handle_metrics_gpu)
+    app.router.add_get("/api/metrics/requests", handle_metrics_requests)
+
+
+async def handle_metrics(request: web.Request) -> web.Response:
+    """GET /api/metrics — full metrics snapshot."""
+    collector: MetricsCollector = request.app["metrics_collector"]
+    return web.json_response(collector.get_snapshot())
+
+
+async def handle_metrics_gpu(request: web.Request) -> web.Response:
+    """GET /api/metrics/gpu — real-time GPU stats."""
+    collector: MetricsCollector = request.app["metrics_collector"]
+    return web.json_response(collector.get_gpu_metrics())
+
+
+async def handle_metrics_requests(request: web.Request) -> web.Response:
+    """GET /api/metrics/requests — request stats with latency percentiles."""
+    collector: MetricsCollector = request.app["metrics_collector"]
+    return web.json_response(collector.get_request_stats())

--- a/ainode/metrics/collector.py
+++ b/ainode/metrics/collector.py
@@ -1,0 +1,149 @@
+"""Metrics collector — GPU stats, request counters, latency tracking."""
+
+import threading
+import time
+from collections import defaultdict
+from typing import Any, Optional
+
+
+class MetricsCollector:
+    """Thread-safe metrics collector for AINode.
+
+    Tracks GPU utilization, request counts/latency, tokens per second, and uptime.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._start_time = time.time()
+
+        # Request counters
+        self._total_requests: int = 0
+        self._error_count: int = 0
+        self._requests_by_model: dict[str, int] = defaultdict(int)
+
+        # Latency tracking (store raw values for percentile computation)
+        self._latencies: list[float] = []
+
+        # Token tracking
+        self._total_tokens: int = 0
+
+    # ------------------------------------------------------------------
+    # Recording
+    # ------------------------------------------------------------------
+
+    def record_request(
+        self,
+        model: str,
+        latency_ms: float,
+        tokens_generated: int = 0,
+        error: bool = False,
+    ) -> None:
+        """Record a completed inference request.
+
+        Parameters
+        ----------
+        model : str
+            Model name that served the request.
+        latency_ms : float
+            End-to-end latency in milliseconds.
+        tokens_generated : int
+            Number of tokens produced (0 if unknown).
+        error : bool
+            Whether the request resulted in an error.
+        """
+        with self._lock:
+            self._total_requests += 1
+            self._requests_by_model[model] += 1
+            self._latencies.append(latency_ms)
+            self._total_tokens += tokens_generated
+            if error:
+                self._error_count += 1
+
+    # ------------------------------------------------------------------
+    # Snapshots
+    # ------------------------------------------------------------------
+
+    def get_snapshot(self) -> dict[str, Any]:
+        """Return a full metrics snapshot (requests, latency, GPU, uptime)."""
+        with self._lock:
+            request_stats = self._request_stats_locked()
+        gpu = self.get_gpu_metrics()
+        return {
+            "uptime_seconds": round(time.time() - self._start_time, 1),
+            "requests": request_stats,
+            "gpu": gpu,
+        }
+
+    def get_request_stats(self) -> dict[str, Any]:
+        """Return request-only stats (count, latency percentiles, errors)."""
+        with self._lock:
+            return self._request_stats_locked()
+
+    def get_gpu_metrics(self) -> dict[str, Any]:
+        """Query real-time GPU stats via pynvml.
+
+        Returns a dict with utilization_percent, memory_used_mb, memory_total_mb,
+        and temperature_c.  Returns an error dict if pynvml is unavailable.
+        """
+        try:
+            import pynvml
+
+            pynvml.nvmlInit()
+            handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+
+            util = pynvml.nvmlDeviceGetUtilizationRates(handle)
+            mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
+            temp = pynvml.nvmlDeviceGetTemperature(handle, pynvml.NVML_TEMPERATURE_GPU)
+
+            pynvml.nvmlShutdown()
+
+            return {
+                "utilization_percent": util.gpu,
+                "memory_used_mb": round(mem.used / (1024 * 1024)),
+                "memory_total_mb": round(mem.total / (1024 * 1024)),
+                "temperature_c": temp,
+            }
+        except Exception as exc:
+            return {"error": str(exc)}
+
+    # ------------------------------------------------------------------
+    # Internal helpers (caller must hold self._lock)
+    # ------------------------------------------------------------------
+
+    def _request_stats_locked(self) -> dict[str, Any]:
+        latencies = sorted(self._latencies) if self._latencies else []
+        uptime = time.time() - self._start_time
+
+        stats: dict[str, Any] = {
+            "total": self._total_requests,
+            "errors": self._error_count,
+            "by_model": dict(self._requests_by_model),
+            "tokens_generated": self._total_tokens,
+        }
+
+        if latencies:
+            stats["latency_ms"] = {
+                "p50": self._percentile(latencies, 50),
+                "p95": self._percentile(latencies, 95),
+                "p99": self._percentile(latencies, 99),
+            }
+        else:
+            stats["latency_ms"] = {"p50": 0, "p95": 0, "p99": 0}
+
+        if uptime > 0 and self._total_tokens > 0:
+            stats["tokens_per_second"] = round(self._total_tokens / uptime, 2)
+        else:
+            stats["tokens_per_second"] = 0
+
+        return stats
+
+    @staticmethod
+    def _percentile(sorted_data: list[float], pct: int) -> float:
+        """Compute the *pct*-th percentile from pre-sorted data."""
+        if not sorted_data:
+            return 0.0
+        k = (len(sorted_data) - 1) * (pct / 100)
+        f = int(k)
+        c = f + 1 if f + 1 < len(sorted_data) else f
+        d = k - f
+        return round(sorted_data[f] + d * (sorted_data[c] - sorted_data[f]), 2)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,144 @@
+"""Tests for ainode.metrics."""
+
+import time
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from ainode.metrics.collector import MetricsCollector
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_pynvml():
+    """Return a mock pynvml module with realistic GPU stats."""
+    mod = MagicMock()
+
+    util = MagicMock()
+    util.gpu = 42
+    mod.nvmlDeviceGetUtilizationRates.return_value = util
+
+    mem = MagicMock()
+    mem.used = 8 * 1024 * 1024 * 1024  # 8 GB
+    mem.total = 128 * 1024 * 1024 * 1024  # 128 GB
+    mod.nvmlDeviceGetMemoryInfo.return_value = mem
+
+    mod.NVML_TEMPERATURE_GPU = 0
+    mod.nvmlDeviceGetTemperature.return_value = 55
+
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# MetricsCollector — recording & snapshot
+# ---------------------------------------------------------------------------
+
+class TestRecordAndSnapshot:
+    def test_initial_snapshot_is_empty(self):
+        mc = MetricsCollector()
+        snap = mc.get_snapshot()
+        assert snap["requests"]["total"] == 0
+        assert snap["requests"]["errors"] == 0
+        assert snap["requests"]["latency_ms"]["p50"] == 0
+        assert snap["uptime_seconds"] >= 0
+
+    def test_record_single_request(self):
+        mc = MetricsCollector()
+        mc.record_request("llama-3", 120.5, tokens_generated=50)
+        stats = mc.get_request_stats()
+        assert stats["total"] == 1
+        assert stats["errors"] == 0
+        assert stats["by_model"]["llama-3"] == 1
+        assert stats["tokens_generated"] == 50
+        assert stats["latency_ms"]["p50"] == 120.5
+
+    def test_record_error(self):
+        mc = MetricsCollector()
+        mc.record_request("llama-3", 500.0, error=True)
+        stats = mc.get_request_stats()
+        assert stats["total"] == 1
+        assert stats["errors"] == 1
+
+    def test_multiple_models(self):
+        mc = MetricsCollector()
+        mc.record_request("llama-3", 100.0)
+        mc.record_request("llama-3", 110.0)
+        mc.record_request("mistral-7b", 80.0)
+        stats = mc.get_request_stats()
+        assert stats["by_model"]["llama-3"] == 2
+        assert stats["by_model"]["mistral-7b"] == 1
+        assert stats["total"] == 3
+
+    def test_latency_percentiles(self):
+        mc = MetricsCollector()
+        # Record 100 requests with latencies 1..100
+        for i in range(1, 101):
+            mc.record_request("m", float(i))
+        stats = mc.get_request_stats()
+        lat = stats["latency_ms"]
+        assert lat["p50"] == pytest.approx(50.5, abs=1)
+        assert lat["p95"] == pytest.approx(95.05, abs=1)
+        assert lat["p99"] == pytest.approx(99.01, abs=1)
+
+    def test_tokens_per_second(self):
+        mc = MetricsCollector()
+        # Backdate start_time to get predictable tps
+        mc._start_time = time.time() - 10.0
+        mc.record_request("m", 50.0, tokens_generated=500)
+        stats = mc.get_request_stats()
+        # 500 tokens / 10s = 50 tps (approximately)
+        assert stats["tokens_per_second"] == pytest.approx(50.0, abs=5)
+
+
+# ---------------------------------------------------------------------------
+# GPU metrics
+# ---------------------------------------------------------------------------
+
+class TestGPUMetrics:
+    def test_gpu_metrics_with_pynvml(self):
+        mock_mod = _mock_pynvml()
+        with patch.dict("sys.modules", {"pynvml": mock_mod}):
+            mc = MetricsCollector()
+            gpu = mc.get_gpu_metrics()
+        assert gpu["utilization_percent"] == 42
+        assert gpu["memory_used_mb"] == 8192
+        assert gpu["memory_total_mb"] == 131072
+        assert gpu["temperature_c"] == 55
+
+    def test_gpu_metrics_without_pynvml(self):
+        mc = MetricsCollector()
+        with patch.dict("sys.modules", {"pynvml": None}):
+            gpu = mc.get_gpu_metrics()
+        assert "error" in gpu
+
+
+# ---------------------------------------------------------------------------
+# Thread safety (smoke test)
+# ---------------------------------------------------------------------------
+
+class TestThreadSafety:
+    def test_concurrent_recording(self):
+        import threading
+
+        mc = MetricsCollector()
+        errors: list[Exception] = []
+
+        def worker():
+            try:
+                for _ in range(100):
+                    mc.record_request("m", 10.0, tokens_generated=1)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        stats = mc.get_request_stats()
+        assert stats["total"] == 800
+        assert stats["tokens_generated"] == 800


### PR DESCRIPTION
## Summary
- New `ainode/metrics/` package with `MetricsCollector` class that tracks GPU utilization, request counts (total/by-model/errors), latency percentiles (p50/p95/p99), tokens per second, and uptime
- Thread-safe counters via `record_request()` for use from the API proxy
- Three API endpoints: `GET /api/metrics` (full snapshot), `GET /api/metrics/gpu` (GPU only), `GET /api/metrics/requests` (request stats only)
- `api_routes.py` with `register_metrics_routes()` for clean integration into the aiohttp app

## Test plan
- [x] 9 new tests covering recording, snapshots, percentile math, GPU metrics (mocked pynvml), and concurrent thread safety
- [x] Full suite passes (75/75 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)