### PR TITLE
Add model manager: catalog, download, delete, recommend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,10 @@ Thumbs.db
 *.log
 logs/
 
-# Models (don't commit multi-GB files)
+# Models (don't commit multi-GB model weight files)
+# Ignore the data directory but keep the Python package
 models/
+!ainode/models/
 *.bin
 *.safetensors
 *.gguf

--- a/ainode/api/server.py
+++ b/ainode/api/server.py
@@ -10,6 +10,7 @@ from aiohttp import web
 from ainode.core.config import NodeConfig
 from ainode.core.gpu import detect_gpu, GPUInfo
 from ainode.web.serve import get_index_html, get_static_path
+from ainode.models.api_routes import register_model_routes
 
 __version__ = "0.1.0"
 
@@ -50,6 +51,9 @@ def create_app(
     app.router.add_get("/v1/models", proxy_to_vllm)
     app.router.add_post("/v1/chat/completions", proxy_to_vllm)
     app.router.add_post("/v1/completions", proxy_to_vllm)
+
+    # --- Model management routes ---------------------------------------------
+    register_model_routes(app)
 
     # --- Static files --------------------------------------------------------
     app.router.add_static("/static", get_static_path(), name="static")

--- a/ainode/models/__init__.py
+++ b/ainode/models/__init__.py
@@ -1,0 +1,5 @@
+"""AINode model management — download, list, delete, and organize models."""
+
+from ainode.models.registry import ModelManager, MODEL_CATALOG
+
+__all__ = ["ModelManager", "MODEL_CATALOG"]

--- a/ainode/models/api_routes.py
+++ b/ainode/models/api_routes.py
@@ -1,0 +1,133 @@
+"""API route handlers for model management."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Optional
+
+from aiohttp import web
+
+from ainode.core.gpu import detect_gpu
+from ainode.models.registry import ModelManager, MODEL_CATALOG
+
+
+def register_model_routes(app: web.Application, manager: Optional[ModelManager] = None) -> None:
+    """Register model management routes on the aiohttp app."""
+    if manager is None:
+        manager = ModelManager()
+
+    app["model_manager"] = manager
+    app["download_jobs"] = {}
+
+    app.router.add_get("/api/models", handle_list_models)
+    app.router.add_get("/api/models/recommended", handle_recommended)
+    app.router.add_get("/api/models/{model_id}", handle_get_model)
+    app.router.add_post("/api/models/{model_id}/download", handle_download_model)
+    app.router.add_delete("/api/models/{model_id}", handle_delete_model)
+
+
+# -- Handlers ------------------------------------------------------------------
+
+async def handle_list_models(request: web.Request) -> web.Response:
+    """GET /api/models -- list all catalog models with download status."""
+    manager: ModelManager = request.app["model_manager"]
+    models = manager.list_available()
+    return web.json_response({"models": models})
+
+
+async def handle_get_model(request: web.Request) -> web.Response:
+    """GET /api/models/:model_id -- info for a specific model."""
+    model_id = request.match_info["model_id"]
+    manager: ModelManager = request.app["model_manager"]
+    info = manager.get_model_info(model_id)
+    if info is None:
+        return web.json_response(
+            {"error": f"Model '{model_id}' not found in catalog"},
+            status=404,
+        )
+    return web.json_response(info)
+
+
+async def handle_download_model(request: web.Request) -> web.Response:
+    """POST /api/models/:model_id/download -- start async download, return 202."""
+    model_id = request.match_info["model_id"]
+    manager: ModelManager = request.app["model_manager"]
+
+    if model_id not in MODEL_CATALOG:
+        return web.json_response(
+            {"error": f"Model '{model_id}' not found in catalog"},
+            status=404,
+        )
+
+    job_id = str(uuid.uuid4())
+    jobs: dict = request.app["download_jobs"]
+    jobs[job_id] = {"model_id": model_id, "status": "downloading", "error": None}
+
+    loop = asyncio.get_event_loop()
+    loop.create_task(_run_download(manager, model_id, job_id, jobs))
+
+    return web.json_response(
+        {"job_id": job_id, "model_id": model_id, "status": "downloading"},
+        status=202,
+    )
+
+
+async def handle_delete_model(request: web.Request) -> web.Response:
+    """DELETE /api/models/:model_id -- delete a downloaded model."""
+    model_id = request.match_info["model_id"]
+    manager: ModelManager = request.app["model_manager"]
+
+    if model_id not in MODEL_CATALOG:
+        return web.json_response(
+            {"error": f"Model '{model_id}' not found in catalog"},
+            status=404,
+        )
+
+    try:
+        deleted = manager.delete_model(model_id)
+    except Exception as exc:
+        return web.json_response({"error": str(exc)}, status=500)
+
+    if deleted:
+        return web.json_response({"status": "deleted", "model_id": model_id})
+    return web.json_response(
+        {"error": f"Model '{model_id}' is not downloaded"},
+        status=404,
+    )
+
+
+async def handle_recommended(request: web.Request) -> web.Response:
+    """GET /api/models/recommended -- models that fit this node's GPU."""
+    gpu = detect_gpu()
+    if gpu is None:
+        return web.json_response(
+            {"error": "No GPU detected", "models": []},
+            status=200,
+        )
+
+    gpu_memory_gb = gpu.memory_total_mb / 1024
+    manager: ModelManager = request.app["model_manager"]
+    models = manager.recommend_for_gpu(gpu_memory_gb)
+    return web.json_response({
+        "gpu_memory_gb": round(gpu_memory_gb, 1),
+        "models": models,
+    })
+
+
+# -- Background download task -------------------------------------------------
+
+async def _run_download(
+    manager: ModelManager,
+    model_id: str,
+    job_id: str,
+    jobs: dict,
+) -> None:
+    """Run model download in a thread so we don't block the event loop."""
+    loop = asyncio.get_event_loop()
+    try:
+        await loop.run_in_executor(None, manager.download_model, model_id)
+        jobs[job_id]["status"] = "complete"
+    except Exception as exc:
+        jobs[job_id]["status"] = "failed"
+        jobs[job_id]["error"] = str(exc)

--- a/ainode/models/registry.py
+++ b/ainode/models/registry.py
@@ -1,0 +1,268 @@
+"""Model registry and manager — catalog, download, delete, and recommend models."""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Callable, Optional
+
+from ainode.core.config import MODELS_DIR
+
+
+@dataclass
+class ModelInfo:
+    """Metadata for a model in the catalog."""
+
+    id: str
+    name: str
+    hf_repo: str
+    size_gb: float
+    description: str
+    quantization: Optional[str] = None
+    min_memory_gb: float = 0.0
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+# ---- Curated model catalog --------------------------------------------------
+
+MODEL_CATALOG: dict[str, ModelInfo] = {
+    "llama-3.2-3b": ModelInfo(
+        id="llama-3.2-3b",
+        name="Llama 3.2 3B Instruct",
+        hf_repo="meta-llama/Llama-3.2-3B-Instruct",
+        size_gb=6.0,
+        description="Compact, fast model for everyday tasks. Great starter model.",
+        min_memory_gb=8,
+    ),
+    "llama-3.1-8b": ModelInfo(
+        id="llama-3.1-8b",
+        name="Llama 3.1 8B Instruct",
+        hf_repo="meta-llama/Llama-3.1-8B-Instruct",
+        size_gb=16.0,
+        description="Strong general-purpose model. Good balance of quality and speed.",
+        min_memory_gb=16,
+    ),
+    "llama-3.1-70b-awq": ModelInfo(
+        id="llama-3.1-70b-awq",
+        name="Llama 3.1 70B Instruct AWQ",
+        hf_repo="hugging-quants/Meta-Llama-3.1-70B-Instruct-AWQ-INT4",
+        size_gb=38.0,
+        description="Quantized 70B for high-quality output on single-node hardware.",
+        quantization="awq",
+        min_memory_gb=48,
+    ),
+    "qwen-2.5-72b": ModelInfo(
+        id="qwen-2.5-72b",
+        name="Qwen 2.5 72B Instruct",
+        hf_repo="Qwen/Qwen2.5-72B-Instruct",
+        size_gb=145.0,
+        description="Flagship multilingual model. Excellent reasoning and code.",
+        min_memory_gb=160,
+    ),
+    "deepseek-r1-7b": ModelInfo(
+        id="deepseek-r1-7b",
+        name="DeepSeek R1 Distill Qwen 7B",
+        hf_repo="deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
+        size_gb=14.0,
+        description="Reasoning-focused model distilled from DeepSeek R1.",
+        min_memory_gb=16,
+    ),
+    "mistral-7b": ModelInfo(
+        id="mistral-7b",
+        name="Mistral 7B Instruct v0.3",
+        hf_repo="mistralai/Mistral-7B-Instruct-v0.3",
+        size_gb=14.0,
+        description="Fast, efficient 7B with strong instruction following.",
+        min_memory_gb=16,
+    ),
+    "phi-3-mini": ModelInfo(
+        id="phi-3-mini",
+        name="Phi-3 Mini 4K Instruct",
+        hf_repo="microsoft/Phi-3-mini-4k-instruct",
+        size_gb=7.5,
+        description="Microsoft's compact model. Strong reasoning for its size.",
+        min_memory_gb=8,
+    ),
+    "codellama-34b": ModelInfo(
+        id="codellama-34b",
+        name="CodeLlama 34B Instruct",
+        hf_repo="meta-llama/CodeLlama-34b-Instruct-hf",
+        size_gb=63.0,
+        description="Specialized code generation and understanding model.",
+        min_memory_gb=72,
+    ),
+}
+
+
+class ModelManager:
+    """Manage model downloads, listing, and deletion."""
+
+    def __init__(self, models_dir: Optional[str | Path] = None):
+        self.models_dir = Path(models_dir) if models_dir else MODELS_DIR
+        self.models_dir.mkdir(parents=True, exist_ok=True)
+        self._active_downloads: dict[str, dict] = {}
+
+    # -- Catalog queries -------------------------------------------------------
+
+    def list_available(self) -> list[dict]:
+        """Return catalog models annotated with download status."""
+        results = []
+        for model_id, info in MODEL_CATALOG.items():
+            entry = info.to_dict()
+            entry["downloaded"] = self._is_downloaded(model_id)
+            local_size = self._local_size_gb(model_id)
+            if local_size is not None:
+                entry["local_size_gb"] = round(local_size, 2)
+            results.append(entry)
+        return results
+
+    def list_downloaded(self) -> list[dict]:
+        """Scan models_dir and return info for every downloaded model."""
+        downloaded = []
+        if not self.models_dir.exists():
+            return downloaded
+
+        for child in sorted(self.models_dir.iterdir()):
+            if not child.is_dir():
+                continue
+            # Map directory name back to catalog entry
+            catalog_entry = self._find_catalog_by_dir(child.name)
+            if catalog_entry:
+                entry = catalog_entry.to_dict()
+                entry["downloaded"] = True
+                entry["local_size_gb"] = round(self._dir_size_gb(child), 2)
+                downloaded.append(entry)
+            else:
+                # Not in catalog — user-added model
+                downloaded.append({
+                    "id": child.name,
+                    "name": child.name,
+                    "hf_repo": child.name.replace("--", "/", 1),
+                    "size_gb": None,
+                    "description": "User-downloaded model (not in catalog)",
+                    "quantization": None,
+                    "min_memory_gb": 0,
+                    "downloaded": True,
+                    "local_size_gb": round(self._dir_size_gb(child), 2),
+                })
+        return downloaded
+
+    def get_model_info(self, model_id: str) -> Optional[dict]:
+        """Return catalog info for a model, plus local size if downloaded."""
+        info = MODEL_CATALOG.get(model_id)
+        if info is None:
+            return None
+        entry = info.to_dict()
+        entry["downloaded"] = self._is_downloaded(model_id)
+        local_size = self._local_size_gb(model_id)
+        if local_size is not None:
+            entry["local_size_gb"] = round(local_size, 2)
+        return entry
+
+    def recommend_for_gpu(self, gpu_memory_gb: float) -> list[dict]:
+        """Return models that fit within the given GPU memory."""
+        results = []
+        for model_id, info in MODEL_CATALOG.items():
+            if info.min_memory_gb <= gpu_memory_gb:
+                entry = info.to_dict()
+                entry["downloaded"] = self._is_downloaded(model_id)
+                results.append(entry)
+        # Sort by size descending so the most capable fitting model is first
+        results.sort(key=lambda m: m["size_gb"], reverse=True)
+        return results
+
+    # -- Download / Delete -----------------------------------------------------
+
+    def download_model(
+        self,
+        model_id: str,
+        progress_callback: Optional[Callable[[float], None]] = None,
+    ) -> Path:
+        """Download a model from HuggingFace Hub.
+
+        Parameters
+        ----------
+        model_id : str
+            Key from MODEL_CATALOG.
+        progress_callback : callable, optional
+            Called with progress fraction (0.0 to 1.0).
+
+        Returns
+        -------
+        Path
+            Local path where the model was downloaded.
+        """
+        info = MODEL_CATALOG.get(model_id)
+        if info is None:
+            raise ValueError(f"Unknown model: {model_id}. Use a key from MODEL_CATALOG.")
+
+        try:
+            from huggingface_hub import snapshot_download
+        except ImportError:
+            raise RuntimeError(
+                "huggingface_hub is required for model downloads. "
+                "Install it with: pip install huggingface_hub"
+            )
+
+        local_dir = self.models_dir / self._repo_to_dirname(info.hf_repo)
+
+        download_path = snapshot_download(
+            repo_id=info.hf_repo,
+            local_dir=str(local_dir),
+            local_dir_use_symlinks=False,
+        )
+
+        return Path(download_path)
+
+    def delete_model(self, model_id: str) -> bool:
+        """Delete a downloaded model from disk.
+
+        Returns True if deleted, False if not found.
+        """
+        info = MODEL_CATALOG.get(model_id)
+        if info is None:
+            raise ValueError(f"Unknown model: {model_id}")
+
+        model_dir = self.models_dir / self._repo_to_dirname(info.hf_repo)
+        if model_dir.exists():
+            shutil.rmtree(model_dir)
+            return True
+        return False
+
+    # -- Internal helpers ------------------------------------------------------
+
+    @staticmethod
+    def _repo_to_dirname(hf_repo: str) -> str:
+        """Convert 'org/model-name' to 'org--model-name' for filesystem safety."""
+        return hf_repo.replace("/", "--")
+
+    def _model_dir(self, model_id: str) -> Optional[Path]:
+        """Return the local directory for a catalog model, or None."""
+        info = MODEL_CATALOG.get(model_id)
+        if info is None:
+            return None
+        return self.models_dir / self._repo_to_dirname(info.hf_repo)
+
+    def _is_downloaded(self, model_id: str) -> bool:
+        d = self._model_dir(model_id)
+        return d is not None and d.exists() and any(d.iterdir())
+
+    def _local_size_gb(self, model_id: str) -> Optional[float]:
+        d = self._model_dir(model_id)
+        if d is None or not d.exists():
+            return None
+        return self._dir_size_gb(d)
+
+    @staticmethod
+    def _dir_size_gb(path: Path) -> float:
+        total = sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
+        return total / (1024**3)
+
+    def _find_catalog_by_dir(self, dirname: str) -> Optional[ModelInfo]:
+        for info in MODEL_CATALOG.values():
+            if ModelManager._repo_to_dirname(info.hf_repo) == dirname:
+                return info
+        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "psutil>=5.9.0",
     "aiohttp>=3.9.0",
     "rich>=13.0.0",
+    "huggingface_hub>=0.20.0",
 ]
 
 [project.optional-dependencies]
@@ -39,6 +40,8 @@ engine = [
 ]
 dev = [
     "pytest>=7.0",
+    "pytest-asyncio>=0.23.0",
+    "pytest-aiohttp>=1.0.0",
     "ruff>=0.1.0",
 ]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,305 @@
+"""Tests for the model registry, manager, and API routes."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from ainode.models.registry import MODEL_CATALOG, ModelInfo, ModelManager
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tmp_models_dir(tmp_path: Path) -> Path:
+    """Provide a temporary models directory."""
+    d = tmp_path / "models"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def manager(tmp_models_dir: Path) -> ModelManager:
+    return ModelManager(models_dir=tmp_models_dir)
+
+
+def _fake_downloaded(manager: ModelManager, model_id: str) -> Path:
+    """Create a fake downloaded model directory with a dummy file."""
+    info = MODEL_CATALOG[model_id]
+    dirname = ModelManager._repo_to_dirname(info.hf_repo)
+    model_dir = manager.models_dir / dirname
+    model_dir.mkdir(parents=True, exist_ok=True)
+    (model_dir / "config.json").write_text('{"test": true}')
+    (model_dir / "model.safetensors").write_bytes(b"\x00" * 1024)
+    return model_dir
+
+
+# ---------------------------------------------------------------------------
+# Catalog tests
+# ---------------------------------------------------------------------------
+
+class TestCatalog:
+    def test_catalog_has_expected_models(self):
+        expected = {
+            "llama-3.2-3b",
+            "llama-3.1-8b",
+            "llama-3.1-70b-awq",
+            "qwen-2.5-72b",
+            "deepseek-r1-7b",
+            "mistral-7b",
+            "phi-3-mini",
+            "codellama-34b",
+        }
+        assert set(MODEL_CATALOG.keys()) == expected
+
+    def test_all_entries_are_model_info(self):
+        for model_id, info in MODEL_CATALOG.items():
+            assert isinstance(info, ModelInfo), f"{model_id} is not ModelInfo"
+            assert info.id == model_id
+            assert info.hf_repo
+            assert info.size_gb > 0
+            assert info.min_memory_gb > 0
+
+    def test_model_info_to_dict(self):
+        info = MODEL_CATALOG["llama-3.2-3b"]
+        d = info.to_dict()
+        assert d["id"] == "llama-3.2-3b"
+        assert "hf_repo" in d
+        assert "size_gb" in d
+
+
+# ---------------------------------------------------------------------------
+# Manager — list / info tests
+# ---------------------------------------------------------------------------
+
+class TestManagerList:
+    def test_list_available_all_not_downloaded(self, manager: ModelManager):
+        models = manager.list_available()
+        assert len(models) == len(MODEL_CATALOG)
+        for m in models:
+            assert m["downloaded"] is False
+
+    def test_list_available_with_downloaded(self, manager: ModelManager):
+        _fake_downloaded(manager, "llama-3.2-3b")
+        models = manager.list_available()
+        by_id = {m["id"]: m for m in models}
+        assert by_id["llama-3.2-3b"]["downloaded"] is True
+        assert by_id["mistral-7b"]["downloaded"] is False
+
+    def test_list_downloaded_empty(self, manager: ModelManager):
+        assert manager.list_downloaded() == []
+
+    def test_list_downloaded_with_model(self, manager: ModelManager):
+        _fake_downloaded(manager, "phi-3-mini")
+        downloaded = manager.list_downloaded()
+        assert len(downloaded) == 1
+        assert downloaded[0]["id"] == "phi-3-mini"
+        assert downloaded[0]["downloaded"] is True
+        assert downloaded[0]["local_size_gb"] >= 0
+
+    def test_list_downloaded_unknown_dir(self, manager: ModelManager):
+        """Directories not in catalog show as user-added."""
+        custom_dir = manager.models_dir / "some-org--custom-model"
+        custom_dir.mkdir()
+        (custom_dir / "weights.bin").write_bytes(b"\x00" * 512)
+        downloaded = manager.list_downloaded()
+        assert len(downloaded) == 1
+        assert downloaded[0]["id"] == "some-org--custom-model"
+        assert "not in catalog" in downloaded[0]["description"].lower()
+
+
+class TestManagerInfo:
+    def test_get_model_info_exists(self, manager: ModelManager):
+        info = manager.get_model_info("mistral-7b")
+        assert info is not None
+        assert info["id"] == "mistral-7b"
+        assert info["downloaded"] is False
+
+    def test_get_model_info_downloaded(self, manager: ModelManager):
+        _fake_downloaded(manager, "mistral-7b")
+        info = manager.get_model_info("mistral-7b")
+        assert info["downloaded"] is True
+        assert "local_size_gb" in info
+
+    def test_get_model_info_unknown(self, manager: ModelManager):
+        assert manager.get_model_info("nonexistent") is None
+
+
+# ---------------------------------------------------------------------------
+# Recommendations
+# ---------------------------------------------------------------------------
+
+class TestRecommendations:
+    def test_recommend_small_gpu(self, manager: ModelManager):
+        recs = manager.recommend_for_gpu(8)
+        ids = {r["id"] for r in recs}
+        assert "llama-3.2-3b" in ids
+        assert "phi-3-mini" in ids
+        # 70B should NOT fit
+        assert "llama-3.1-70b-awq" not in ids
+
+    def test_recommend_large_gpu(self, manager: ModelManager):
+        recs = manager.recommend_for_gpu(256)
+        # Everything should fit on 256 GB
+        assert len(recs) == len(MODEL_CATALOG)
+
+    def test_recommend_tiny_gpu(self, manager: ModelManager):
+        recs = manager.recommend_for_gpu(4)
+        assert len(recs) == 0
+
+    def test_recommend_sorted_by_size_desc(self, manager: ModelManager):
+        recs = manager.recommend_for_gpu(256)
+        sizes = [r["size_gb"] for r in recs]
+        assert sizes == sorted(sizes, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# Download (mocked)
+# ---------------------------------------------------------------------------
+
+class TestDownload:
+    def test_download_unknown_model_raises(self, manager: ModelManager):
+        with pytest.raises(ValueError, match="Unknown model"):
+            manager.download_model("nonexistent")
+
+    def test_download_missing_huggingface_hub(self, manager: ModelManager):
+        """If huggingface_hub is not installed, raise RuntimeError."""
+        import builtins
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "huggingface_hub":
+                raise ImportError("no module")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            with pytest.raises(RuntimeError, match="huggingface_hub"):
+                manager.download_model("llama-3.2-3b")
+
+    @patch("ainode.models.registry.snapshot_download", create=True)
+    def test_download_calls_snapshot_download(self, mock_sd, manager: ModelManager):
+        """Verify download_model calls huggingface_hub.snapshot_download correctly."""
+        expected_dir = manager.models_dir / "meta-llama--Llama-3.2-3B-Instruct"
+        mock_sd.return_value = str(expected_dir)
+
+        with patch.dict("sys.modules", {"huggingface_hub": MagicMock(snapshot_download=mock_sd)}):
+            result = manager.download_model("llama-3.2-3b")
+
+        mock_sd.assert_called_once_with(
+            repo_id="meta-llama/Llama-3.2-3B-Instruct",
+            local_dir=str(expected_dir),
+            local_dir_use_symlinks=False,
+        )
+        assert result == expected_dir
+
+
+# ---------------------------------------------------------------------------
+# Delete
+# ---------------------------------------------------------------------------
+
+class TestDelete:
+    def test_delete_downloaded_model(self, manager: ModelManager):
+        model_dir = _fake_downloaded(manager, "deepseek-r1-7b")
+        assert model_dir.exists()
+        assert manager.delete_model("deepseek-r1-7b") is True
+        assert not model_dir.exists()
+
+    def test_delete_not_downloaded(self, manager: ModelManager):
+        assert manager.delete_model("deepseek-r1-7b") is False
+
+    def test_delete_unknown_raises(self, manager: ModelManager):
+        with pytest.raises(ValueError, match="Unknown model"):
+            manager.delete_model("nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# API routes (aiohttp test client)
+# ---------------------------------------------------------------------------
+
+pytest.importorskip("aiohttp")
+from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
+from aiohttp import web
+from ainode.models.api_routes import register_model_routes
+
+
+class TestModelAPI:
+    """Test API routes using aiohttp test client via pytest-aiohttp."""
+
+    @pytest.fixture
+    def app(self, manager: ModelManager) -> web.Application:
+        app = web.Application()
+        register_model_routes(app, manager=manager)
+        return app
+
+    @pytest.fixture
+    def client(self, app, aiohttp_client, event_loop):
+        """Create aiohttp test client. Requires pytest-aiohttp."""
+        return event_loop.run_until_complete(aiohttp_client(app))
+
+    @pytest.mark.asyncio
+    async def test_list_models(self, app, aiohttp_client):
+        client = await aiohttp_client(app)
+        resp = await client.get("/api/models")
+        assert resp.status == 200
+        data = await resp.json()
+        assert "models" in data
+        assert len(data["models"]) == len(MODEL_CATALOG)
+
+    @pytest.mark.asyncio
+    async def test_get_model(self, app, aiohttp_client):
+        client = await aiohttp_client(app)
+        resp = await client.get("/api/models/llama-3.2-3b")
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["id"] == "llama-3.2-3b"
+
+    @pytest.mark.asyncio
+    async def test_get_model_not_found(self, app, aiohttp_client):
+        client = await aiohttp_client(app)
+        resp = await client.get("/api/models/nonexistent")
+        assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_download_model(self, app, aiohttp_client):
+        client = await aiohttp_client(app)
+        resp = await client.post("/api/models/llama-3.2-3b/download")
+        assert resp.status == 202
+        data = await resp.json()
+        assert data["status"] == "downloading"
+        assert "job_id" in data
+
+    @pytest.mark.asyncio
+    async def test_download_unknown(self, app, aiohttp_client):
+        client = await aiohttp_client(app)
+        resp = await client.post("/api/models/nonexistent/download")
+        assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_model_not_downloaded(self, app, aiohttp_client):
+        client = await aiohttp_client(app)
+        resp = await client.delete("/api/models/llama-3.2-3b")
+        assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_model_downloaded(self, app, aiohttp_client, manager):
+        _fake_downloaded(manager, "llama-3.2-3b")
+        client = await aiohttp_client(app)
+        resp = await client.delete("/api/models/llama-3.2-3b")
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["status"] == "deleted"
+
+    @pytest.mark.asyncio
+    async def test_recommended_no_gpu(self, app, aiohttp_client):
+        with patch("ainode.models.api_routes.detect_gpu", return_value=None):
+            client = await aiohttp_client(app)
+            resp = await client.get("/api/models/recommended")
+            assert resp.status == 200
+            data = await resp.json()
+            assert "error" in data


### PR DESCRIPTION
## Summary
- Adds `ainode/models/` package with `ModelManager` class and curated catalog of 8 recommended models (Llama 3.2 3B, Llama 3.1 8B, Llama 3.1 70B AWQ, Qwen 2.5 72B, DeepSeek R1 7B, Mistral 7B, Phi-3 Mini, CodeLlama 34B)
- Implements HuggingFace Hub download, filesystem-based listing/deletion, and GPU-aware model recommendations
- Adds aiohttp API routes: GET/POST/DELETE `/api/models/*` with async download jobs
- Wires model routes into the existing API server
- Adds `huggingface_hub` dependency and test dependencies (`pytest-asyncio`, `pytest-aiohttp`)
- 29 new tests covering catalog validation, manager operations, and API endpoints

## Test plan
- [x] `pytest tests/test_models.py` -- 29 tests pass
- [x] `pytest tests/` -- full suite (119 tests) passes
- [ ] Manual test: `GET /api/models` returns catalog with download status
- [ ] Manual test: `POST /api/models/llama-3.2-3b/download` triggers HF download
- [ ] Manual test: `GET /api/models/recommended` returns GPU-appropriate models

🤖 Generated with [Claude Code](https://claude.com/claude-code)