### PR TITLE
Add training/fine-tuning engine

### DIFF
--- a/ainode/training/__init__.py
+++ b/ainode/training/__init__.py
@@ -1,0 +1,5 @@
+"""AINode training/fine-tuning engine."""
+
+from ainode.training.engine import TrainingConfig, TrainingJob, TrainingManager
+
+__all__ = ["TrainingConfig", "TrainingJob", "TrainingManager"]

--- a/ainode/training/_run_training.py
+++ b/ainode/training/_run_training.py
@@ -1,0 +1,184 @@
+"""Internal training script — launched as a subprocess by TrainingJob.
+
+Reads a config JSON and runs HuggingFace Transformers + PEFT training,
+emitting structured progress lines for the parent process to parse.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="AINode training runner")
+    parser.add_argument("--config", required=True, help="Path to training config JSON")
+    args = parser.parse_args()
+
+    config_path = Path(args.config)
+    if not config_path.exists():
+        print(f"Config file not found: {config_path}", file=sys.stderr)
+        sys.exit(1)
+
+    config = json.loads(config_path.read_text())
+
+    try:
+        import torch
+        from transformers import (
+            AutoModelForCausalLM,
+            AutoTokenizer,
+            TrainingArguments,
+            Trainer,
+            TrainerCallback,
+        )
+        from datasets import load_dataset
+    except ImportError as exc:
+        print(
+            f"Missing training dependency: {exc}. "
+            "Install with: pip install torch transformers datasets peft",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    base_model = config["base_model"]
+    dataset_path = config["dataset_path"]
+    output_dir = config.get("output_dir", "./output")
+    method = config.get("method", "lora")
+    num_epochs = config.get("num_epochs", 3)
+    batch_size = config.get("batch_size", 4)
+    learning_rate = config.get("learning_rate", 2e-4)
+    lora_rank = config.get("lora_rank", 16)
+    lora_alpha = config.get("lora_alpha", 32)
+    max_seq_length = config.get("max_seq_length", 2048)
+
+    print(f"Loading tokenizer: {base_model}")
+    tokenizer = AutoTokenizer.from_pretrained(base_model, trust_remote_code=True)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    print(f"Loading model: {base_model}")
+    model = AutoModelForCausalLM.from_pretrained(
+        base_model,
+        torch_dtype=torch.bfloat16,
+        device_map="auto",
+        trust_remote_code=True,
+    )
+
+    if method == "lora":
+        try:
+            from peft import LoraConfig, get_peft_model, TaskType
+        except ImportError:
+            print("PEFT is required for LoRA training: pip install peft", file=sys.stderr)
+            sys.exit(1)
+
+        peft_config = LoraConfig(
+            task_type=TaskType.CAUSAL_LM,
+            r=lora_rank,
+            lora_alpha=lora_alpha,
+            lora_dropout=0.05,
+            target_modules=["q_proj", "v_proj", "k_proj", "o_proj"],
+        )
+        model = get_peft_model(model, peft_config)
+        model.print_trainable_parameters()
+
+    # Load dataset (supports JSON, JSONL, CSV, or HF dataset name)
+    print(f"Loading dataset: {dataset_path}")
+    if Path(dataset_path).exists():
+        ext = Path(dataset_path).suffix.lower()
+        if ext in (".json", ".jsonl"):
+            dataset = load_dataset("json", data_files=dataset_path, split="train")
+        elif ext == ".csv":
+            dataset = load_dataset("csv", data_files=dataset_path, split="train")
+        else:
+            dataset = load_dataset("json", data_files=dataset_path, split="train")
+    else:
+        # Treat as HuggingFace dataset name
+        dataset = load_dataset(dataset_path, split="train")
+
+    # Tokenize
+    def tokenize_fn(examples):
+        # Support common dataset formats
+        if "text" in examples:
+            texts = examples["text"]
+        elif "instruction" in examples and "output" in examples:
+            texts = [
+                f"### Instruction:\n{inst}\n\n### Response:\n{out}"
+                for inst, out in zip(examples["instruction"], examples["output"])
+            ]
+        elif "prompt" in examples and "completion" in examples:
+            texts = [
+                f"{p}{c}" for p, c in zip(examples["prompt"], examples["completion"])
+            ]
+        else:
+            # Fallback: concatenate all string fields
+            keys = [k for k in examples.keys() if isinstance(examples[k][0], str)]
+            texts = [" ".join(examples[k][i] for k in keys) for i in range(len(examples[keys[0]]))]
+
+        return tokenizer(
+            texts,
+            truncation=True,
+            max_length=max_seq_length,
+            padding="max_length",
+        )
+
+    dataset = dataset.map(tokenize_fn, batched=True, remove_columns=dataset.column_names)
+    dataset = dataset.rename_column("input_ids", "input_ids")
+    # Set labels = input_ids for causal LM
+    dataset = dataset.map(lambda x: {"labels": x["input_ids"]})
+
+    # Progress callback
+    class ProgressCallback(TrainerCallback):
+        def __init__(self, total_epochs):
+            self.total_epochs = total_epochs
+
+        def on_log(self, _args, state, control, logs=None, **kwargs):
+            if logs and "loss" in logs:
+                epoch = state.epoch or 0
+                progress = (epoch / self.total_epochs) * 100 if self.total_epochs > 0 else 0
+                payload = {
+                    "epoch": int(epoch),
+                    "loss": round(logs["loss"], 4),
+                    "progress": round(progress, 1),
+                    "step": state.global_step,
+                }
+                print(f"AINODE_PROGRESS:{json.dumps(payload)}", flush=True)
+
+    training_args = TrainingArguments(
+        output_dir=output_dir,
+        num_train_epochs=num_epochs,
+        per_device_train_batch_size=batch_size,
+        learning_rate=learning_rate,
+        bf16=True,
+        logging_steps=10,
+        save_strategy="epoch",
+        save_total_limit=2,
+        report_to="none",
+        gradient_accumulation_steps=max(1, 8 // batch_size),
+        warmup_ratio=0.03,
+        lr_scheduler_type="cosine",
+        optim="adamw_torch",
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=dataset,
+        callbacks=[ProgressCallback(num_epochs)],
+    )
+
+    print("Starting training...")
+    trainer.train()
+
+    # Save final model
+    print(f"Saving model to {output_dir}")
+    trainer.save_model(output_dir)
+    tokenizer.save_pretrained(output_dir)
+
+    print(f"AINODE_PROGRESS:{json.dumps({'epoch': num_epochs, 'loss': 0, 'progress': 100.0})}")
+    print("Training complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/ainode/training/api_routes.py
+++ b/ainode/training/api_routes.py
@@ -1,0 +1,119 @@
+"""API routes for the training engine — mounted under /api/training/."""
+
+from __future__ import annotations
+
+from aiohttp import web
+
+from ainode.training.engine import TrainingConfig, TrainingManager
+
+
+def setup_training_routes(app: web.Application, manager: TrainingManager) -> None:
+    """Register training API routes on the aiohttp app."""
+    app["training_manager"] = manager
+
+    app.router.add_post("/api/training/jobs", handle_submit_job)
+    app.router.add_get("/api/training/jobs", handle_list_jobs)
+    app.router.add_get("/api/training/jobs/{job_id}", handle_get_job)
+    app.router.add_delete("/api/training/jobs/{job_id}", handle_cancel_job)
+    app.router.add_get("/api/training/jobs/{job_id}/logs", handle_get_logs)
+
+
+async def handle_submit_job(request: web.Request) -> web.Response:
+    """POST /api/training/jobs — submit a new training job."""
+    manager: TrainingManager = request.app["training_manager"]
+
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response(
+            {"error": "Invalid JSON body"}, status=400
+        )
+
+    try:
+        config = TrainingConfig.from_dict(body)
+    except Exception as exc:
+        return web.json_response(
+            {"error": f"Invalid config: {exc}"}, status=400
+        )
+
+    try:
+        job = manager.submit_job(config)
+    except ValueError as exc:
+        return web.json_response(
+            {"error": str(exc)}, status=400
+        )
+
+    # Attempt to start if nothing is running
+    await manager.start_next()
+
+    return web.json_response(job.get_status(), status=201)
+
+
+async def handle_list_jobs(request: web.Request) -> web.Response:
+    """GET /api/training/jobs — list all training jobs."""
+    manager: TrainingManager = request.app["training_manager"]
+    return web.json_response({"jobs": manager.list_jobs()})
+
+
+async def handle_get_job(request: web.Request) -> web.Response:
+    """GET /api/training/jobs/:job_id — get job status + progress."""
+    manager: TrainingManager = request.app["training_manager"]
+    job_id = request.match_info["job_id"]
+
+    job = manager.get_job(job_id)
+    if job is None:
+        return web.json_response(
+            {"error": f"Job not found: {job_id}"}, status=404
+        )
+
+    return web.json_response(job.get_status())
+
+
+async def handle_cancel_job(request: web.Request) -> web.Response:
+    """DELETE /api/training/jobs/:job_id — cancel a running or pending job."""
+    manager: TrainingManager = request.app["training_manager"]
+    job_id = request.match_info["job_id"]
+
+    job = manager.get_job(job_id)
+    if job is None:
+        return web.json_response(
+            {"error": f"Job not found: {job_id}"}, status=404
+        )
+
+    cancelled = await manager.cancel_job(job_id)
+    if not cancelled:
+        return web.json_response(
+            {"error": f"Job {job_id} cannot be cancelled (status: {job.status.value})"},
+            status=409,
+        )
+
+    return web.json_response({"status": "cancelled", "job_id": job_id})
+
+
+async def handle_get_logs(request: web.Request) -> web.Response:
+    """GET /api/training/jobs/:job_id/logs — return training logs."""
+    manager: TrainingManager = request.app["training_manager"]
+    job_id = request.match_info["job_id"]
+
+    job = manager.get_job(job_id)
+    if job is None:
+        return web.json_response(
+            {"error": f"Job not found: {job_id}"}, status=404
+        )
+
+    # Support ?tail=N to get only the last N log lines
+    tail = request.query.get("tail")
+    logs = job.logs
+    if tail is not None:
+        try:
+            n = int(tail)
+            logs = logs[-n:]
+        except ValueError:
+            pass
+
+    return web.json_response({
+        "job_id": job_id,
+        "status": job.status.value,
+        "logs": logs,
+        "total_lines": len(job.logs),
+    })

--- a/ainode/training/engine.py
+++ b/ainode/training/engine.py
@@ -1,0 +1,368 @@
+"""Training engine — run fine-tuning jobs on local GPUs using HuggingFace + PEFT."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import dataclass, field, asdict
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+from ainode.core.config import AINODE_HOME
+
+
+TRAINING_DIR = AINODE_HOME / "training"
+JOBS_DIR = TRAINING_DIR / "jobs"
+
+
+class TrainingMethod(str, Enum):
+    LORA = "lora"
+    FULL = "full"
+
+
+class JobStatus(str, Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+@dataclass
+class TrainingConfig:
+    """Configuration for a training/fine-tuning job."""
+
+    base_model: str
+    dataset_path: str
+    output_dir: Optional[str] = None
+    method: str = "lora"
+    num_epochs: int = 3
+    batch_size: int = 4
+    learning_rate: float = 2e-4
+    lora_rank: int = 16
+    lora_alpha: int = 32
+    max_seq_length: int = 2048
+
+    def validate(self) -> list[str]:
+        """Return a list of validation errors (empty means valid)."""
+        errors: list[str] = []
+
+        if not self.base_model or not self.base_model.strip():
+            errors.append("base_model is required")
+
+        if not self.dataset_path or not self.dataset_path.strip():
+            errors.append("dataset_path is required")
+
+        if self.method not in ("lora", "full"):
+            errors.append(f"method must be 'lora' or 'full', got '{self.method}'")
+
+        if self.num_epochs < 1:
+            errors.append("num_epochs must be >= 1")
+
+        if self.batch_size < 1:
+            errors.append("batch_size must be >= 1")
+
+        if self.learning_rate <= 0:
+            errors.append("learning_rate must be > 0")
+
+        if self.lora_rank < 1:
+            errors.append("lora_rank must be >= 1")
+
+        if self.lora_alpha < 1:
+            errors.append("lora_alpha must be >= 1")
+
+        if self.max_seq_length < 1:
+            errors.append("max_seq_length must be >= 1")
+
+        return errors
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "TrainingConfig":
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+
+class TrainingJob:
+    """Represents a single training job with lifecycle management."""
+
+    def __init__(self, config: TrainingConfig, job_id: Optional[str] = None):
+        self.job_id: str = job_id or uuid.uuid4().hex[:12]
+        self.config = config
+        self.status: JobStatus = JobStatus.PENDING
+        self.progress: float = 0.0
+        self.current_epoch: int = 0
+        self.current_loss: Optional[float] = None
+        self.start_time: Optional[float] = None
+        self.end_time: Optional[float] = None
+        self.logs: list[str] = []
+        self._process: Optional[subprocess.Popen] = None
+        self._monitor_task: Optional[asyncio.Task] = None
+
+        # Set output directory
+        if self.config.output_dir is None:
+            self.config.output_dir = str(JOBS_DIR / self.job_id / "output")
+
+        # Job working directory
+        self._job_dir = JOBS_DIR / self.job_id
+        self._job_dir.mkdir(parents=True, exist_ok=True)
+
+    async def start(self) -> None:
+        """Launch the training subprocess."""
+        if self.status != JobStatus.PENDING:
+            raise RuntimeError(f"Cannot start job in '{self.status.value}' state")
+
+        self.status = JobStatus.RUNNING
+        self.start_time = time.time()
+        self._log(f"Starting {self.config.method} training on {self.config.base_model}")
+
+        # Write config to job directory for the training script
+        config_path = self._job_dir / "config.json"
+        config_path.write_text(json.dumps(self.config.to_dict(), indent=2))
+
+        # Build the training command
+        cmd = self._build_command(config_path)
+        self._log(f"Command: {' '.join(cmd)}")
+
+        try:
+            # Ensure output dir exists
+            Path(self.config.output_dir).mkdir(parents=True, exist_ok=True)
+
+            self._process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                cwd=str(self._job_dir),
+                env={**os.environ, "PYTHONUNBUFFERED": "1"},
+            )
+            # Start monitoring in background
+            self._monitor_task = asyncio.create_task(self._monitor())
+        except Exception as exc:
+            self.status = JobStatus.FAILED
+            self.end_time = time.time()
+            self._log(f"Failed to start: {exc}")
+            raise
+
+    async def stop(self) -> None:
+        """Gracefully cancel a running job."""
+        if self.status == JobStatus.PENDING:
+            self.status = JobStatus.CANCELLED
+            self.end_time = time.time()
+            self._log("Job cancelled before start")
+            return
+
+        if self.status != JobStatus.RUNNING:
+            return
+
+        self._log("Cancelling job...")
+        if self._process and self._process.poll() is None:
+            # Send SIGTERM for graceful shutdown
+            self._process.send_signal(signal.SIGTERM)
+            try:
+                self._process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+                self._process.wait(timeout=5)
+
+        self.status = JobStatus.CANCELLED
+        self.end_time = time.time()
+        self._log("Job cancelled")
+
+        if self._monitor_task and not self._monitor_task.done():
+            self._monitor_task.cancel()
+
+    def get_status(self) -> dict:
+        """Return a summary of the current job state."""
+        elapsed = None
+        if self.start_time:
+            end = self.end_time or time.time()
+            elapsed = round(end - self.start_time, 1)
+
+        return {
+            "job_id": self.job_id,
+            "status": self.status.value,
+            "progress": round(self.progress, 1),
+            "current_epoch": self.current_epoch,
+            "current_loss": self.current_loss,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "elapsed_seconds": elapsed,
+            "config": self.config.to_dict(),
+        }
+
+    def _build_command(self, config_path: Path) -> list[str]:
+        """Build the CLI command to run training."""
+        c = self.config
+
+        if c.method == "lora":
+            # Use a Python training script via module invocation
+            return [
+                sys.executable, "-m", "ainode.training._run_training",
+                "--config", str(config_path),
+            ]
+        else:
+            # Full fine-tuning — use torchrun for potential multi-GPU
+            return [
+                sys.executable, "-m", "torch.distributed.run",
+                "--nproc_per_node=1",
+                "-m", "ainode.training._run_training",
+                "--config", str(config_path),
+            ]
+
+    async def _monitor(self) -> None:
+        """Read subprocess output and update progress."""
+        proc = self._process
+        if proc is None or proc.stdout is None:
+            return
+
+        loop = asyncio.get_event_loop()
+        try:
+            while True:
+                line = await loop.run_in_executor(None, proc.stdout.readline)
+                if not line and proc.poll() is not None:
+                    break
+                if line:
+                    line = line.rstrip()
+                    self._log(line)
+                    self._parse_progress(line)
+
+            rc = proc.wait()
+            if self.status == JobStatus.RUNNING:
+                if rc == 0:
+                    self.status = JobStatus.COMPLETED
+                    self.progress = 100.0
+                    self._log("Training completed successfully")
+                else:
+                    self.status = JobStatus.FAILED
+                    self._log(f"Training process exited with code {rc}")
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self.end_time = time.time()
+
+    def _parse_progress(self, line: str) -> None:
+        """Parse structured progress output from the training script.
+
+        Expected format: AINODE_PROGRESS:{"epoch":1,"loss":0.5,"progress":33.3}
+        """
+        marker = "AINODE_PROGRESS:"
+        if marker in line:
+            try:
+                payload = json.loads(line.split(marker, 1)[1])
+                if "epoch" in payload:
+                    self.current_epoch = payload["epoch"]
+                if "loss" in payload:
+                    self.current_loss = payload["loss"]
+                if "progress" in payload:
+                    self.progress = payload["progress"]
+            except (json.JSONDecodeError, IndexError):
+                pass
+
+    def _log(self, msg: str) -> None:
+        """Append a timestamped log entry."""
+        ts = time.strftime("%H:%M:%S")
+        self.logs.append(f"[{ts}] {msg}")
+
+
+class TrainingManager:
+    """Manage training jobs — one active at a time (GPU shared with inference)."""
+
+    def __init__(self):
+        self._jobs: dict[str, TrainingJob] = {}
+        self._queue: list[str] = []  # job_ids in queue order
+        self._active_job_id: Optional[str] = None
+
+    def submit_job(self, config: TrainingConfig) -> TrainingJob:
+        """Validate config and queue a new training job.
+
+        Returns the created TrainingJob.
+        Raises ValueError if config is invalid.
+        """
+        errors = config.validate()
+        if errors:
+            raise ValueError(f"Invalid training config: {'; '.join(errors)}")
+
+        job = TrainingJob(config)
+        self._jobs[job.job_id] = job
+        self._queue.append(job.job_id)
+        return job
+
+    def list_jobs(self) -> list[dict]:
+        """Return all jobs with their current status."""
+        return [job.get_status() for job in self._jobs.values()]
+
+    def get_job(self, job_id: str) -> Optional[TrainingJob]:
+        """Get a specific job by ID."""
+        return self._jobs.get(job_id)
+
+    async def cancel_job(self, job_id: str) -> bool:
+        """Cancel a running or pending job. Returns True if cancelled."""
+        job = self._jobs.get(job_id)
+        if job is None:
+            return False
+
+        if job.status in (JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED):
+            return False
+
+        await job.stop()
+
+        # Remove from queue if pending
+        if job_id in self._queue:
+            self._queue.remove(job_id)
+
+        # Clear active if this was the running job
+        if self._active_job_id == job_id:
+            self._active_job_id = None
+
+        return True
+
+    async def start_next(self) -> Optional[TrainingJob]:
+        """Start the next pending job if no job is currently running.
+
+        Returns the started job, or None if nothing to start.
+        """
+        if self._active_job_id is not None:
+            active = self._jobs.get(self._active_job_id)
+            if active and active.status == JobStatus.RUNNING:
+                return None  # Something is already running
+            # Active job finished — clear it
+            self._active_job_id = None
+
+        # Find next pending job in queue
+        while self._queue:
+            job_id = self._queue[0]
+            job = self._jobs.get(job_id)
+            if job and job.status == JobStatus.PENDING:
+                self._queue.pop(0)
+                self._active_job_id = job_id
+                await job.start()
+                return job
+            else:
+                self._queue.pop(0)  # Skip cancelled/missing jobs
+
+        return None
+
+    @property
+    def active_job(self) -> Optional[TrainingJob]:
+        """Return the currently running job, if any."""
+        if self._active_job_id:
+            return self._jobs.get(self._active_job_id)
+        return None
+
+    @property
+    def queue_size(self) -> int:
+        """Number of pending jobs in the queue."""
+        return len([
+            jid for jid in self._queue
+            if jid in self._jobs and self._jobs[jid].status == JobStatus.PENDING
+        ])

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,296 @@
+"""Tests for ainode.training — config validation, job lifecycle, manager queue."""
+
+import asyncio
+import pytest
+
+from ainode.training.engine import (
+    TrainingConfig,
+    TrainingJob,
+    TrainingManager,
+    JobStatus,
+)
+
+
+# =============================================================================
+# TrainingConfig validation
+# =============================================================================
+
+
+class TestTrainingConfig:
+    def test_valid_config(self):
+        config = TrainingConfig(
+            base_model="meta-llama/Llama-3.2-3B-Instruct",
+            dataset_path="/data/train.jsonl",
+        )
+        assert config.validate() == []
+
+    def test_missing_base_model(self):
+        config = TrainingConfig(base_model="", dataset_path="/data/train.jsonl")
+        errors = config.validate()
+        assert any("base_model" in e for e in errors)
+
+    def test_missing_dataset_path(self):
+        config = TrainingConfig(base_model="some-model", dataset_path="")
+        errors = config.validate()
+        assert any("dataset_path" in e for e in errors)
+
+    def test_invalid_method(self):
+        config = TrainingConfig(
+            base_model="model", dataset_path="/data", method="qlora"
+        )
+        errors = config.validate()
+        assert any("method" in e for e in errors)
+
+    def test_invalid_num_epochs(self):
+        config = TrainingConfig(
+            base_model="model", dataset_path="/data", num_epochs=0
+        )
+        errors = config.validate()
+        assert any("num_epochs" in e for e in errors)
+
+    def test_invalid_batch_size(self):
+        config = TrainingConfig(
+            base_model="model", dataset_path="/data", batch_size=-1
+        )
+        errors = config.validate()
+        assert any("batch_size" in e for e in errors)
+
+    def test_invalid_learning_rate(self):
+        config = TrainingConfig(
+            base_model="model", dataset_path="/data", learning_rate=0
+        )
+        errors = config.validate()
+        assert any("learning_rate" in e for e in errors)
+
+    def test_invalid_lora_rank(self):
+        config = TrainingConfig(
+            base_model="model", dataset_path="/data", lora_rank=0
+        )
+        errors = config.validate()
+        assert any("lora_rank" in e for e in errors)
+
+    def test_invalid_lora_alpha(self):
+        config = TrainingConfig(
+            base_model="model", dataset_path="/data", lora_alpha=0
+        )
+        errors = config.validate()
+        assert any("lora_alpha" in e for e in errors)
+
+    def test_invalid_max_seq_length(self):
+        config = TrainingConfig(
+            base_model="model", dataset_path="/data", max_seq_length=0
+        )
+        errors = config.validate()
+        assert any("max_seq_length" in e for e in errors)
+
+    def test_multiple_errors(self):
+        config = TrainingConfig(
+            base_model="",
+            dataset_path="",
+            method="bad",
+            num_epochs=0,
+        )
+        errors = config.validate()
+        assert len(errors) >= 3
+
+    def test_defaults(self):
+        config = TrainingConfig(base_model="m", dataset_path="/d")
+        assert config.method == "lora"
+        assert config.num_epochs == 3
+        assert config.batch_size == 4
+        assert config.learning_rate == 2e-4
+        assert config.lora_rank == 16
+        assert config.lora_alpha == 32
+        assert config.max_seq_length == 2048
+
+    def test_to_dict(self):
+        config = TrainingConfig(base_model="m", dataset_path="/d")
+        d = config.to_dict()
+        assert d["base_model"] == "m"
+        assert d["dataset_path"] == "/d"
+        assert isinstance(d, dict)
+
+    def test_from_dict(self):
+        data = {
+            "base_model": "model-x",
+            "dataset_path": "/data/file.json",
+            "method": "full",
+            "num_epochs": 5,
+            "extra_field": "ignored",
+        }
+        config = TrainingConfig.from_dict(data)
+        assert config.base_model == "model-x"
+        assert config.method == "full"
+        assert config.num_epochs == 5
+
+    def test_from_dict_defaults(self):
+        config = TrainingConfig.from_dict({
+            "base_model": "m",
+            "dataset_path": "/d",
+        })
+        assert config.lora_rank == 16
+
+
+# =============================================================================
+# TrainingJob lifecycle
+# =============================================================================
+
+
+class TestTrainingJob:
+    def test_initial_state(self):
+        config = TrainingConfig(base_model="m", dataset_path="/d")
+        job = TrainingJob(config)
+        assert job.status == JobStatus.PENDING
+        assert job.progress == 0.0
+        assert job.current_epoch == 0
+        assert job.current_loss is None
+        assert job.start_time is None
+        assert job.end_time is None
+        assert len(job.job_id) == 12
+
+    def test_custom_job_id(self):
+        config = TrainingConfig(base_model="m", dataset_path="/d")
+        job = TrainingJob(config, job_id="custom123")
+        assert job.job_id == "custom123"
+
+    def test_get_status(self):
+        config = TrainingConfig(base_model="m", dataset_path="/d")
+        job = TrainingJob(config)
+        status = job.get_status()
+        assert status["job_id"] == job.job_id
+        assert status["status"] == "pending"
+        assert status["progress"] == 0.0
+        assert status["config"]["base_model"] == "m"
+
+    def test_output_dir_default(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
+        config = TrainingConfig(base_model="m", dataset_path="/d")
+        job = TrainingJob(config)
+        assert "output" in job.config.output_dir
+        assert job.job_id in job.config.output_dir
+
+    def test_output_dir_custom(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
+        config = TrainingConfig(
+            base_model="m", dataset_path="/d", output_dir="/custom/out"
+        )
+        job = TrainingJob(config)
+        assert job.config.output_dir == "/custom/out"
+
+    @pytest.mark.asyncio
+    async def test_cancel_pending_job(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
+        config = TrainingConfig(base_model="m", dataset_path="/d")
+        job = TrainingJob(config)
+        assert job.status == JobStatus.PENDING
+        await job.stop()
+        assert job.status == JobStatus.CANCELLED
+        assert job.end_time is not None
+
+    def test_parse_progress(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
+        config = TrainingConfig(base_model="m", dataset_path="/d")
+        job = TrainingJob(config)
+        line = 'AINODE_PROGRESS:{"epoch":2,"loss":0.45,"progress":66.7}'
+        job._parse_progress(line)
+        assert job.current_epoch == 2
+        assert job.current_loss == 0.45
+        assert job.progress == 66.7
+
+    def test_parse_progress_invalid_json(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
+        config = TrainingConfig(base_model="m", dataset_path="/d")
+        job = TrainingJob(config)
+        job._parse_progress("AINODE_PROGRESS:{invalid}")
+        assert job.current_epoch == 0  # Unchanged
+
+    def test_parse_progress_no_marker(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
+        config = TrainingConfig(base_model="m", dataset_path="/d")
+        job = TrainingJob(config)
+        job._parse_progress("some random log line")
+        assert job.current_epoch == 0  # Unchanged
+
+
+# =============================================================================
+# TrainingManager queue operations
+# =============================================================================
+
+
+class TestTrainingManager:
+    def _make_config(self, model="m", dataset="/d"):
+        return TrainingConfig(base_model=model, dataset_path=dataset)
+
+    def test_submit_job(self):
+        mgr = TrainingManager()
+        job = mgr.submit_job(self._make_config())
+        assert job.status == JobStatus.PENDING
+        assert mgr.get_job(job.job_id) is job
+
+    def test_submit_invalid_config(self):
+        mgr = TrainingManager()
+        config = TrainingConfig(base_model="", dataset_path="")
+        with pytest.raises(ValueError, match="Invalid training config"):
+            mgr.submit_job(config)
+
+    def test_list_jobs(self):
+        mgr = TrainingManager()
+        mgr.submit_job(self._make_config())
+        mgr.submit_job(self._make_config(model="model-2"))
+        jobs = mgr.list_jobs()
+        assert len(jobs) == 2
+        assert all(j["status"] == "pending" for j in jobs)
+
+    def test_list_jobs_empty(self):
+        mgr = TrainingManager()
+        assert mgr.list_jobs() == []
+
+    def test_get_job_not_found(self):
+        mgr = TrainingManager()
+        assert mgr.get_job("nonexistent") is None
+
+    @pytest.mark.asyncio
+    async def test_cancel_pending_job(self):
+        mgr = TrainingManager()
+        job = mgr.submit_job(self._make_config())
+        result = await mgr.cancel_job(job.job_id)
+        assert result is True
+        assert job.status == JobStatus.CANCELLED
+
+    @pytest.mark.asyncio
+    async def test_cancel_nonexistent_job(self):
+        mgr = TrainingManager()
+        result = await mgr.cancel_job("nope")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_cancel_already_cancelled(self):
+        mgr = TrainingManager()
+        job = mgr.submit_job(self._make_config())
+        await mgr.cancel_job(job.job_id)
+        result = await mgr.cancel_job(job.job_id)
+        assert result is False
+
+    def test_queue_size(self):
+        mgr = TrainingManager()
+        mgr.submit_job(self._make_config())
+        mgr.submit_job(self._make_config())
+        assert mgr.queue_size == 2
+
+    @pytest.mark.asyncio
+    async def test_queue_size_after_cancel(self):
+        mgr = TrainingManager()
+        j1 = mgr.submit_job(self._make_config())
+        mgr.submit_job(self._make_config())
+        await mgr.cancel_job(j1.job_id)
+        assert mgr.queue_size == 1
+
+    def test_active_job_none(self):
+        mgr = TrainingManager()
+        assert mgr.active_job is None
+
+    def test_submit_preserves_order(self):
+        mgr = TrainingManager()
+        j1 = mgr.submit_job(self._make_config(model="first"))
+        j2 = mgr.submit_job(self._make_config(model="second"))
+        assert mgr._queue == [j1.job_id, j2.job_id]


### PR DESCRIPTION
## Summary
- Training engine backend with `TrainingConfig`, `TrainingJob`, and `TrainingManager` classes
- Supports LoRA (via PEFT) and full fine-tuning using HuggingFace Transformers
- Single-active-job queue to share GPU with inference engine
- REST API routes: submit, list, get status, cancel, and stream logs for training jobs
- Internal subprocess runner with structured progress reporting (`AINODE_PROGRESS:` protocol)
- 36 unit tests covering config validation, job lifecycle, and manager queue operations

## Test plan
- [x] `pytest tests/test_training.py` — all 36 tests pass
- [ ] End-to-end test on DGX Spark with real dataset and LoRA fine-tuning
- [ ] Verify API routes via `curl` against running AINode instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)