### PR TITLE
Add systemd service management for auto-start on boot

### DIFF
--- a/ainode/cli/main.py
+++ b/ainode/cli/main.py
@@ -156,6 +156,79 @@ def cmd_models(args):
     print()
 
 
+def cmd_service(args):
+    """Manage AINode systemd service."""
+    from ainode.service.systemd import (
+        install_service,
+        enable_service,
+        start_service,
+        stop_service,
+        disable_service,
+        uninstall_service,
+        status_service,
+        get_journal_lines,
+        is_installed,
+    )
+
+    user_mode = getattr(args, "user", False)
+    action = getattr(args, "service_action", None)
+
+    if action == "install":
+        if is_installed(user_mode=user_mode):
+            console.print("  [yellow]AINode service is already installed.[/yellow]")
+        else:
+            console.print("  Installing AINode service...")
+            install_service(user_mode=user_mode)
+            console.print("  [green]✓[/green] Unit file written")
+        console.print("  Enabling service...")
+        enable_service(user_mode=user_mode)
+        console.print("  [green]✓[/green] Service enabled")
+        console.print("  Starting service...")
+        start_service(user_mode=user_mode)
+        console.print("  [green]✓[/green] Service started")
+        console.print()
+        console.print("  AINode will now start automatically on boot.")
+        console.print("  Powered by argentos.ai")
+
+    elif action == "uninstall":
+        if not is_installed(user_mode=user_mode):
+            console.print("  [yellow]AINode service is not installed.[/yellow]")
+            return
+        console.print("  Stopping and removing AINode service...")
+        uninstall_service(user_mode=user_mode)
+        console.print("  [green]✓[/green] Service removed")
+        console.print("  Powered by argentos.ai")
+
+    elif action == "status":
+        if not is_installed(user_mode=user_mode):
+            console.print("  AINode service: [dim]not installed[/dim]")
+            return
+        info = status_service(user_mode=user_mode)
+        state = info["state"]
+        color = {"active": "green", "inactive": "dim", "failed": "red"}.get(state, "yellow")
+        console.print(f"  AINode service: [{color}]{state}[/{color}]")
+        console.print(f"  Enabled: {'yes' if info['enabled'] else 'no'}")
+        if info["journal_lines"]:
+            console.print()
+            console.print("  Recent logs:")
+            for line in info["journal_lines"][-10:]:
+                console.print(f"    {line}")
+        console.print()
+        console.print("  Powered by argentos.ai")
+
+    elif action == "logs":
+        lines = getattr(args, "lines", 50)
+        journal = get_journal_lines(user_mode=user_mode, lines=lines)
+        if journal:
+            for line in journal:
+                console.print(line)
+        else:
+            console.print("  No journal entries found for AINode.")
+
+    else:
+        console.print("  Usage: ainode service {install|uninstall|status|logs}")
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="ainode",
@@ -182,6 +255,19 @@ def main():
     # models
     models_parser = subparsers.add_parser("models", help="List available models")
     models_parser.set_defaults(func=cmd_models)
+
+    # service
+    service_parser = subparsers.add_parser("service", help="Manage AINode systemd service")
+    service_parser.add_argument(
+        "--user", action="store_true", help="Use user-level systemd (no sudo required)"
+    )
+    service_sub = service_parser.add_subparsers(dest="service_action")
+    service_sub.add_parser("install", help="Install, enable, and start AINode service")
+    service_sub.add_parser("uninstall", help="Stop, disable, and remove AINode service")
+    service_sub.add_parser("status", help="Show AINode service status")
+    logs_parser = service_sub.add_parser("logs", help="Show AINode service logs")
+    logs_parser.add_argument("-n", "--lines", type=int, default=50, help="Number of log lines")
+    service_parser.set_defaults(func=cmd_service)
 
     args = parser.parse_args()
 

--- a/ainode/service/__init__.py
+++ b/ainode/service/__init__.py
@@ -1,0 +1,1 @@
+"""AINode systemd service management."""

--- a/ainode/service/systemd.py
+++ b/ainode/service/systemd.py
@@ -1,0 +1,190 @@
+"""Systemd service management for AINode.
+
+Provides install, uninstall, enable, disable, start, stop, restart,
+status, and is_installed operations for running AINode as a systemd service.
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+
+SERVICE_NAME = "ainode.service"
+
+SYSTEM_UNIT_DIR = Path("/etc/systemd/system")
+USER_UNIT_DIR = Path.home() / ".config" / "systemd" / "user"
+
+UNIT_FILE_TEMPLATE = """\
+[Unit]
+Description=AINode — Local AI inference platform
+Documentation=https://ainode.dev
+After=network.target nvidia-persistenced.service nvidia-fabricmanager.service
+Wants=nvidia-persistenced.service
+
+[Service]
+Type=simple
+ExecStart={exec_start}
+Restart=on-failure
+RestartSec=10
+TimeoutStartSec=600
+TimeoutStopSec=30
+
+# GPU environment
+Environment=NVIDIA_VISIBLE_DEVICES=all
+Environment=CUDA_DEVICE_ORDER=PCI_BUS_ID
+Environment=AINODE_HOME={ainode_home}
+
+# Hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths={ainode_home}
+
+[Install]
+WantedBy={wanted_by}
+"""
+
+
+def _ainode_bin() -> str:
+    """Return the path to the ainode executable."""
+    return shutil.which("ainode") or "ainode"
+
+
+def _ainode_home() -> str:
+    """Return the AINODE_HOME directory."""
+    return os.environ.get("AINODE_HOME", str(Path.home() / ".ainode"))
+
+
+def _unit_dir(user_mode: bool) -> Path:
+    if user_mode:
+        return USER_UNIT_DIR
+    return SYSTEM_UNIT_DIR
+
+
+def _unit_path(user_mode: bool) -> Path:
+    return _unit_dir(user_mode) / SERVICE_NAME
+
+
+def _systemctl(args: list[str], user_mode: bool = False, capture: bool = False):
+    """Run a systemctl command."""
+    cmd = ["systemctl"]
+    if user_mode:
+        cmd.append("--user")
+    cmd.extend(args)
+    if capture:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        return result
+    subprocess.run(cmd, check=True, timeout=30)
+
+
+def generate_unit_file(user_mode: bool = False) -> str:
+    """Generate the systemd unit file content."""
+    wanted_by = "default.target" if user_mode else "multi-user.target"
+    return UNIT_FILE_TEMPLATE.format(
+        exec_start=f"{_ainode_bin()} start",
+        ainode_home=_ainode_home(),
+        wanted_by=wanted_by,
+    )
+
+
+def is_installed(user_mode: bool = False) -> bool:
+    """Check if the AINode service unit file exists."""
+    return _unit_path(user_mode).exists()
+
+
+def install_service(user_mode: bool = False) -> None:
+    """Write the unit file and reload the systemd daemon."""
+    unit_dir = _unit_dir(user_mode)
+    unit_dir.mkdir(parents=True, exist_ok=True)
+
+    unit_path = _unit_path(user_mode)
+    unit_content = generate_unit_file(user_mode=user_mode)
+    unit_path.write_text(unit_content)
+
+    _systemctl(["daemon-reload"], user_mode=user_mode)
+
+
+def uninstall_service(user_mode: bool = False) -> None:
+    """Stop, disable, and remove the unit file."""
+    if not is_installed(user_mode):
+        return
+
+    # Best-effort stop and disable before removal
+    try:
+        stop_service(user_mode=user_mode)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+    try:
+        disable_service(user_mode=user_mode)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+
+    _unit_path(user_mode).unlink(missing_ok=True)
+    _systemctl(["daemon-reload"], user_mode=user_mode)
+
+
+def enable_service(user_mode: bool = False) -> None:
+    """Enable AINode to start on boot."""
+    _systemctl(["enable", SERVICE_NAME], user_mode=user_mode)
+
+
+def disable_service(user_mode: bool = False) -> None:
+    """Disable AINode from starting on boot."""
+    _systemctl(["disable", SERVICE_NAME], user_mode=user_mode)
+
+
+def start_service(user_mode: bool = False) -> None:
+    """Start the AINode service."""
+    _systemctl(["start", SERVICE_NAME], user_mode=user_mode)
+
+
+def stop_service(user_mode: bool = False) -> None:
+    """Stop the AINode service."""
+    _systemctl(["stop", SERVICE_NAME], user_mode=user_mode)
+
+
+def restart_service(user_mode: bool = False) -> None:
+    """Restart the AINode service."""
+    _systemctl(["restart", SERVICE_NAME], user_mode=user_mode)
+
+
+def status_service(user_mode: bool = False) -> dict:
+    """Return service status and recent journal lines.
+
+    Returns dict with keys: state, enabled, journal_lines.
+    """
+    result = {"state": "unknown", "enabled": False, "journal_lines": []}
+
+    # Active state
+    r = _systemctl(["is-active", SERVICE_NAME], user_mode=user_mode, capture=True)
+    result["state"] = r.stdout.strip() or "unknown"
+
+    # Enabled state
+    r = _systemctl(["is-enabled", SERVICE_NAME], user_mode=user_mode, capture=True)
+    result["enabled"] = r.stdout.strip() == "enabled"
+
+    # Recent journal lines
+    result["journal_lines"] = get_journal_lines(user_mode=user_mode, lines=20)
+
+    return result
+
+
+def get_journal_lines(
+    user_mode: bool = False,
+    lines: int = 50,
+    follow: bool = False,
+) -> list[str]:
+    """Fetch recent journal lines for the AINode service."""
+    cmd = ["journalctl"]
+    if user_mode:
+        cmd.append("--user")
+    cmd.extend(["-u", SERVICE_NAME, "-n", str(lines), "--no-pager"])
+    if follow:
+        cmd.append("-f")
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        return r.stdout.strip().splitlines() if r.stdout else []
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return []

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -102,14 +102,43 @@ fi
 echo ""
 echo "    ────────────────────────────────────"
 echo ""
-echo "    To start AINode:"
-echo ""
-echo "      source ${SHELL_RC}"
-echo "      ainode start"
-echo ""
-echo "    Or run directly:"
-echo ""
-echo "      $AINODE_BIN/ainode start"
+
+# Optionally install systemd service
+INSTALL_SERVICE="${AINODE_SERVICE:-}"
+if [ -z "$INSTALL_SERVICE" ]; then
+    echo -n "    Install AINode as a systemd service (auto-start on boot)? [y/N] "
+    read -r INSTALL_SERVICE
+fi
+
+if [[ "$INSTALL_SERVICE" =~ ^[Yy]$ ]]; then
+    echo ""
+    echo "    Installing systemd service..."
+    if [ "$(id -u)" -eq 0 ]; then
+        "$AINODE_BIN/ainode" service install
+    else
+        "$AINODE_BIN/ainode" service install --user
+    fi
+    echo -e "    ${GREEN}✓${NC} AINode service installed and enabled"
+    echo ""
+    echo "    Manage with:"
+    echo "      ainode service status"
+    echo "      ainode service logs"
+    echo "      ainode service uninstall"
+else
+    echo ""
+    echo "    To start AINode:"
+    echo ""
+    echo "      source ${SHELL_RC}"
+    echo "      ainode start"
+    echo ""
+    echo "    Or run directly:"
+    echo ""
+    echo "      $AINODE_BIN/ainode start"
+    echo ""
+    echo "    To install as a service later:"
+    echo "      ainode service install"
+fi
+
 echo ""
 echo -e "    Powered by ${BLUE}argentos.ai${NC}"
 echo ""

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,230 @@
+"""Tests for ainode.service.systemd — unit file generation and service management."""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from ainode.service import systemd
+
+
+class TestUnitFileGeneration:
+    """Test systemd unit file content generation."""
+
+    def test_generate_system_unit(self):
+        """System-level unit file uses multi-user.target."""
+        content = systemd.generate_unit_file(user_mode=False)
+        assert "WantedBy=multi-user.target" in content
+        assert "ainode start" in content
+        assert "NVIDIA_VISIBLE_DEVICES=all" in content
+        assert "After=network.target nvidia-persistenced.service" in content
+        assert "Restart=on-failure" in content
+
+    def test_generate_user_unit(self):
+        """User-level unit file uses default.target."""
+        content = systemd.generate_unit_file(user_mode=True)
+        assert "WantedBy=default.target" in content
+        assert "ainode start" in content
+
+    def test_unit_has_gpu_env_vars(self):
+        content = systemd.generate_unit_file()
+        assert "NVIDIA_VISIBLE_DEVICES=all" in content
+        assert "CUDA_DEVICE_ORDER=PCI_BUS_ID" in content
+
+    def test_unit_has_hardening(self):
+        content = systemd.generate_unit_file()
+        assert "NoNewPrivileges=true" in content
+        assert "ProtectSystem=strict" in content
+
+    def test_unit_has_restart_policy(self):
+        content = systemd.generate_unit_file()
+        assert "Restart=on-failure" in content
+        assert "RestartSec=10" in content
+
+    def test_unit_has_description(self):
+        content = systemd.generate_unit_file()
+        assert "Description=AINode" in content
+        assert "Documentation=https://ainode.dev" in content
+
+
+class TestIsInstalled:
+    """Test is_installed checks."""
+
+    def test_not_installed(self, tmp_path):
+        with patch.object(systemd, "SYSTEM_UNIT_DIR", tmp_path):
+            assert systemd.is_installed(user_mode=False) is False
+
+    def test_installed(self, tmp_path):
+        unit_file = tmp_path / "ainode.service"
+        unit_file.write_text("[Unit]\nDescription=test\n")
+        with patch.object(systemd, "SYSTEM_UNIT_DIR", tmp_path):
+            assert systemd.is_installed(user_mode=False) is True
+
+    def test_user_mode_not_installed(self, tmp_path):
+        with patch.object(systemd, "USER_UNIT_DIR", tmp_path):
+            assert systemd.is_installed(user_mode=True) is False
+
+
+class TestInstallService:
+    """Test install_service writes unit file and reloads daemon."""
+
+    def test_install_writes_unit_file(self, tmp_path):
+        with (
+            patch.object(systemd, "SYSTEM_UNIT_DIR", tmp_path),
+            patch.object(systemd, "_systemctl") as mock_ctl,
+        ):
+            systemd.install_service(user_mode=False)
+
+            unit_path = tmp_path / "ainode.service"
+            assert unit_path.exists()
+            content = unit_path.read_text()
+            assert "ainode start" in content
+            mock_ctl.assert_called_once_with(["daemon-reload"], user_mode=False)
+
+    def test_install_user_mode(self, tmp_path):
+        with (
+            patch.object(systemd, "USER_UNIT_DIR", tmp_path),
+            patch.object(systemd, "_systemctl") as mock_ctl,
+        ):
+            systemd.install_service(user_mode=True)
+
+            unit_path = tmp_path / "ainode.service"
+            assert unit_path.exists()
+            content = unit_path.read_text()
+            assert "WantedBy=default.target" in content
+            mock_ctl.assert_called_once_with(["daemon-reload"], user_mode=True)
+
+
+class TestUninstallService:
+    """Test uninstall_service stops, disables, removes, and reloads."""
+
+    def test_uninstall_removes_unit(self, tmp_path):
+        unit_file = tmp_path / "ainode.service"
+        unit_file.write_text("[Unit]\nDescription=test\n")
+
+        with (
+            patch.object(systemd, "SYSTEM_UNIT_DIR", tmp_path),
+            patch.object(systemd, "_systemctl") as mock_ctl,
+        ):
+            systemd.uninstall_service(user_mode=False)
+
+            assert not unit_file.exists()
+            # Should have called stop, disable, daemon-reload
+            calls = mock_ctl.call_args_list
+            assert any("stop" in str(c) for c in calls)
+            assert any("disable" in str(c) for c in calls)
+            assert any("daemon-reload" in str(c) for c in calls)
+
+    def test_uninstall_noop_if_not_installed(self, tmp_path):
+        with (
+            patch.object(systemd, "SYSTEM_UNIT_DIR", tmp_path),
+            patch.object(systemd, "_systemctl") as mock_ctl,
+        ):
+            systemd.uninstall_service(user_mode=False)
+            mock_ctl.assert_not_called()
+
+
+class TestServiceActions:
+    """Test enable, disable, start, stop, restart delegate to systemctl."""
+
+    @patch.object(systemd, "_systemctl")
+    def test_enable(self, mock_ctl):
+        systemd.enable_service(user_mode=False)
+        mock_ctl.assert_called_once_with(["enable", "ainode.service"], user_mode=False)
+
+    @patch.object(systemd, "_systemctl")
+    def test_disable(self, mock_ctl):
+        systemd.disable_service(user_mode=True)
+        mock_ctl.assert_called_once_with(["disable", "ainode.service"], user_mode=True)
+
+    @patch.object(systemd, "_systemctl")
+    def test_start(self, mock_ctl):
+        systemd.start_service()
+        mock_ctl.assert_called_once_with(["start", "ainode.service"], user_mode=False)
+
+    @patch.object(systemd, "_systemctl")
+    def test_stop(self, mock_ctl):
+        systemd.stop_service()
+        mock_ctl.assert_called_once_with(["stop", "ainode.service"], user_mode=False)
+
+    @patch.object(systemd, "_systemctl")
+    def test_restart(self, mock_ctl):
+        systemd.restart_service()
+        mock_ctl.assert_called_once_with(["restart", "ainode.service"], user_mode=False)
+
+
+class TestStatusService:
+    """Test status_service returns structured info."""
+
+    @patch.object(systemd, "get_journal_lines", return_value=["line1", "line2"])
+    @patch.object(systemd, "_systemctl")
+    def test_status_active(self, mock_ctl, mock_journal):
+        mock_ctl.side_effect = [
+            MagicMock(stdout="active\n"),   # is-active
+            MagicMock(stdout="enabled\n"),  # is-enabled
+        ]
+        info = systemd.status_service(user_mode=False)
+        assert info["state"] == "active"
+        assert info["enabled"] is True
+        assert info["journal_lines"] == ["line1", "line2"]
+
+    @patch.object(systemd, "get_journal_lines", return_value=[])
+    @patch.object(systemd, "_systemctl")
+    def test_status_inactive(self, mock_ctl, mock_journal):
+        mock_ctl.side_effect = [
+            MagicMock(stdout="inactive\n"),
+            MagicMock(stdout="disabled\n"),
+        ]
+        info = systemd.status_service()
+        assert info["state"] == "inactive"
+        assert info["enabled"] is False
+
+
+class TestGetJournalLines:
+    """Test journal line fetching."""
+
+    @patch("subprocess.run")
+    def test_returns_lines(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="line1\nline2\nline3\n")
+        lines = systemd.get_journal_lines(lines=3)
+        assert lines == ["line1", "line2", "line3"]
+
+    @patch("subprocess.run", side_effect=FileNotFoundError)
+    def test_returns_empty_on_missing_journalctl(self, mock_run):
+        lines = systemd.get_journal_lines()
+        assert lines == []
+
+    @patch("subprocess.run", side_effect=subprocess.TimeoutExpired("journalctl", 10))
+    def test_returns_empty_on_timeout(self, mock_run):
+        lines = systemd.get_journal_lines()
+        assert lines == []
+
+
+class TestSystemctlHelper:
+    """Test _systemctl builds the correct command."""
+
+    @patch("subprocess.run")
+    def test_system_mode(self, mock_run):
+        systemd._systemctl(["start", "ainode.service"], user_mode=False)
+        mock_run.assert_called_once_with(
+            ["systemctl", "start", "ainode.service"], check=True, timeout=30
+        )
+
+    @patch("subprocess.run")
+    def test_user_mode(self, mock_run):
+        systemd._systemctl(["start", "ainode.service"], user_mode=True)
+        mock_run.assert_called_once_with(
+            ["systemctl", "--user", "start", "ainode.service"], check=True, timeout=30
+        )
+
+    @patch("subprocess.run")
+    def test_capture_mode(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="active\n")
+        result = systemd._systemctl(["is-active", "ainode.service"], capture=True)
+        mock_run.assert_called_once_with(
+            ["systemctl", "is-active", "ainode.service"],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert result.stdout == "active\n"


### PR DESCRIPTION
## Summary
- Adds `ainode/service/systemd.py` with full systemd unit file generation, install/uninstall/enable/disable/start/stop/restart/status operations
- Adds `ainode service` CLI subcommand group (`install`, `uninstall`, `status`, `logs`) with `--user` flag for user-level systemd
- Updates `scripts/install.sh` to optionally install the systemd service during curl-pipe installation
- Unit file includes GPU env vars (NVIDIA_VISIBLE_DEVICES, CUDA_DEVICE_ORDER), service hardening, and restart-on-failure policy

## Test plan
- [x] 26 new tests in `tests/test_service.py` covering unit file generation, install/uninstall logic, service actions, status parsing, journal fetching, and systemctl command building — all with mocked subprocess calls
- [x] All 30 tests pass (26 service + 4 existing CLI)
- [ ] Manual test on Linux with systemd: `ainode service install` / `ainode service status` / `ainode service uninstall`

🤖 Generated with [Claude Code](https://claude.com/claude-code)