### PR TITLE
AINode v0.1.0: Full platform build — engine, dashboard, API, clustering, training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,10 @@ Thumbs.db
 *.log
 logs/
 
-# Models (don't commit multi-GB files)
+# Models (don't commit multi-GB model weight files)
+# Ignore the data directory but keep the Python package
 models/
+!ainode/models/
 *.bin
 *.safetensors
 *.gguf

--- a/ainode/api/server.py
+++ b/ainode/api/server.py
@@ -11,6 +11,8 @@ from ainode.core.config import NodeConfig
 from ainode.core.gpu import detect_gpu, GPUInfo
 from ainode.web.serve import get_index_html, get_static_path
 from ainode.models.api_routes import register_model_routes
+from ainode.auth.middleware import AuthConfig, auth_middleware
+from ainode.auth.api_routes import register_auth_routes
 
 __version__ = "0.1.0"
 
@@ -31,8 +33,12 @@ def create_app(
     if config is None:
         config = NodeConfig()
 
-    app = web.Application(middlewares=[cors_middleware])
+    # Load auth config from disk
+    auth_config = AuthConfig.load()
+
+    app = web.Application(middlewares=[cors_middleware, auth_middleware])
     app["config"] = config
+    app["auth_config"] = auth_config
     app["engine"] = engine
     app["start_time"] = time.time()
     app["client_session"] = None  # lazy-init in startup
@@ -54,6 +60,9 @@ def create_app(
 
     # --- Model management routes ---------------------------------------------
     register_model_routes(app)
+
+    # --- Auth management routes ----------------------------------------------
+    register_auth_routes(app)
 
     # --- Static files --------------------------------------------------------
     app.router.add_static("/static", get_static_path(), name="static")

--- a/ainode/api/server.py
+++ b/ainode/api/server.py
@@ -1,0 +1,231 @@
+"""AINode API proxy server — aiohttp app that serves the web UI and proxies to vLLM."""
+
+import time
+from dataclasses import asdict
+from typing import Optional
+
+import aiohttp
+from aiohttp import web
+
+from ainode.core.config import NodeConfig
+from ainode.core.gpu import detect_gpu, GPUInfo
+from ainode.web.serve import get_index_html, get_static_path
+from ainode.models.api_routes import register_model_routes
+
+__version__ = "0.1.0"
+
+
+def create_app(
+    config: Optional[NodeConfig] = None,
+    engine=None,
+) -> web.Application:
+    """Create and return the aiohttp application.
+
+    Parameters
+    ----------
+    config : NodeConfig
+        Node configuration (defaults created if None).
+    engine : VLLMEngine | None
+        Optional engine instance for health/status queries.
+    """
+    if config is None:
+        config = NodeConfig()
+
+    app = web.Application(middlewares=[cors_middleware])
+    app["config"] = config
+    app["engine"] = engine
+    app["start_time"] = time.time()
+    app["client_session"] = None  # lazy-init in startup
+
+    # --- Lifecycle -----------------------------------------------------------
+    app.on_startup.append(_on_startup)
+    app.on_cleanup.append(_on_cleanup)
+
+    # --- AINode routes -------------------------------------------------------
+    app.router.add_get("/", handle_index)
+    app.router.add_get("/api/health", handle_health)
+    app.router.add_get("/api/status", handle_status)
+    app.router.add_get("/api/nodes", handle_nodes)
+
+    # --- OpenAI-compatible proxy routes --------------------------------------
+    app.router.add_get("/v1/models", proxy_to_vllm)
+    app.router.add_post("/v1/chat/completions", proxy_to_vllm)
+    app.router.add_post("/v1/completions", proxy_to_vllm)
+
+    # --- Model management routes ---------------------------------------------
+    register_model_routes(app)
+
+    # --- Static files --------------------------------------------------------
+    app.router.add_static("/static", get_static_path(), name="static")
+
+    return app
+
+
+# =============================================================================
+# Lifecycle helpers
+# =============================================================================
+
+async def _on_startup(app: web.Application) -> None:
+    app["client_session"] = aiohttp.ClientSession()
+
+
+async def _on_cleanup(app: web.Application) -> None:
+    session: Optional[aiohttp.ClientSession] = app.get("client_session")
+    if session and not session.closed:
+        await session.close()
+
+
+# =============================================================================
+# Middleware
+# =============================================================================
+
+@web.middleware
+async def cors_middleware(request: web.Request, handler):
+    """Add CORS headers to every response so the dashboard can fetch freely."""
+    if request.method == "OPTIONS":
+        resp = web.Response(status=204)
+    else:
+        try:
+            resp = await handler(request)
+        except web.HTTPException as exc:
+            resp = exc
+
+    resp.headers["Access-Control-Allow-Origin"] = "*"
+    resp.headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, DELETE, OPTIONS"
+    resp.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
+    return resp
+
+
+# =============================================================================
+# Web UI
+# =============================================================================
+
+async def handle_index(_request: web.Request) -> web.Response:
+    """Serve the embedded dashboard HTML."""
+    html = get_index_html()
+    return web.Response(text=html, content_type="text/html")
+
+
+# =============================================================================
+# AINode API endpoints
+# =============================================================================
+
+async def handle_health(_request: web.Request) -> web.Response:
+    """Simple liveness probe."""
+    return web.json_response({"status": "ok"})
+
+
+async def handle_status(request: web.Request) -> web.Response:
+    """Return rich node status."""
+    config: NodeConfig = request.app["config"]
+    engine = request.app["engine"]
+    start_time: float = request.app["start_time"]
+
+    gpu: Optional[GPUInfo] = detect_gpu()
+    gpu_info = asdict(gpu) if gpu else None
+
+    engine_ready = False
+    models_loaded: list[str] = []
+    if engine is not None:
+        engine_ready = getattr(engine, "ready", False)
+        try:
+            hc = engine.health_check()
+            models_loaded = hc.get("models_loaded", [])
+        except Exception:
+            pass
+
+    return web.json_response({
+        "node_id": config.node_id,
+        "node_name": config.node_name,
+        "model": config.model,
+        "gpu": gpu_info,
+        "engine_ready": engine_ready,
+        "uptime": round(time.time() - start_time, 1),
+        "version": __version__,
+        "powered_by": "argentos.ai",
+        "models_loaded": models_loaded,
+        "api_port": config.api_port,
+    })
+
+
+async def handle_nodes(request: web.Request) -> web.Response:
+    """Return the list of known cluster nodes (stub: just this node)."""
+    config: NodeConfig = request.app["config"]
+    engine = request.app["engine"]
+    engine_ready = False
+    if engine is not None:
+        engine_ready = getattr(engine, "ready", False)
+
+    node = {
+        "node_id": config.node_id,
+        "node_name": config.node_name,
+        "host": config.host,
+        "api_port": config.api_port,
+        "web_port": config.web_port,
+        "model": config.model,
+        "engine_ready": engine_ready,
+    }
+    return web.json_response({"nodes": [node]})
+
+
+# =============================================================================
+# vLLM proxy
+# =============================================================================
+
+async def proxy_to_vllm(request: web.Request) -> web.StreamResponse:
+    """Forward the request to the local vLLM server and stream the response back."""
+    config: NodeConfig = request.app["config"]
+    session: aiohttp.ClientSession = request.app["client_session"]
+    vllm_url = f"http://localhost:{config.api_port}{request.path}"
+
+    # Build upstream request kwargs
+    kwargs: dict = {
+        "headers": {k: v for k, v in request.headers.items()
+                    if k.lower() not in ("host", "transfer-encoding")},
+    }
+    if request.method == "POST":
+        kwargs["data"] = await request.read()
+
+    try:
+        async with session.request(request.method, vllm_url, **kwargs) as upstream:
+            # Detect SSE streaming
+            is_sse = "text/event-stream" in upstream.headers.get("Content-Type", "")
+
+            if is_sse:
+                resp = web.StreamResponse(
+                    status=upstream.status,
+                    headers={
+                        "Content-Type": "text/event-stream",
+                        "Cache-Control": "no-cache",
+                        "X-Accel-Buffering": "no",
+                    },
+                )
+                await resp.prepare(request)
+                async for chunk in upstream.content.iter_any():
+                    await resp.write(chunk)
+                await resp.write_eof()
+                return resp
+            else:
+                body = await upstream.read()
+                return web.Response(
+                    status=upstream.status,
+                    body=body,
+                    content_type=upstream.headers.get("Content-Type", "application/json"),
+                )
+    except aiohttp.ClientError:
+        return web.json_response(
+            {"error": {"message": "vLLM engine not reachable", "type": "server_error"}},
+            status=502,
+        )
+
+
+# =============================================================================
+# Convenience runner
+# =============================================================================
+
+def run_server(config: Optional[NodeConfig] = None, engine=None) -> None:
+    """Start the API server (blocking)."""
+    if config is None:
+        config = NodeConfig()
+    app = create_app(config=config, engine=engine)
+    web.run_app(app, host=config.host, port=config.web_port, print=None)

--- a/ainode/api/server.py
+++ b/ainode/api/server.py
@@ -1,0 +1,227 @@
+"""AINode API proxy server — aiohttp app that serves the web UI and proxies to vLLM."""
+
+import time
+from dataclasses import asdict
+from typing import Optional
+
+import aiohttp
+from aiohttp import web
+
+from ainode.core.config import NodeConfig
+from ainode.core.gpu import detect_gpu, GPUInfo
+from ainode.web.serve import get_index_html, get_static_path
+
+__version__ = "0.1.0"
+
+
+def create_app(
+    config: Optional[NodeConfig] = None,
+    engine=None,
+) -> web.Application:
+    """Create and return the aiohttp application.
+
+    Parameters
+    ----------
+    config : NodeConfig
+        Node configuration (defaults created if None).
+    engine : VLLMEngine | None
+        Optional engine instance for health/status queries.
+    """
+    if config is None:
+        config = NodeConfig()
+
+    app = web.Application(middlewares=[cors_middleware])
+    app["config"] = config
+    app["engine"] = engine
+    app["start_time"] = time.time()
+    app["client_session"] = None  # lazy-init in startup
+
+    # --- Lifecycle -----------------------------------------------------------
+    app.on_startup.append(_on_startup)
+    app.on_cleanup.append(_on_cleanup)
+
+    # --- AINode routes -------------------------------------------------------
+    app.router.add_get("/", handle_index)
+    app.router.add_get("/api/health", handle_health)
+    app.router.add_get("/api/status", handle_status)
+    app.router.add_get("/api/nodes", handle_nodes)
+
+    # --- OpenAI-compatible proxy routes --------------------------------------
+    app.router.add_get("/v1/models", proxy_to_vllm)
+    app.router.add_post("/v1/chat/completions", proxy_to_vllm)
+    app.router.add_post("/v1/completions", proxy_to_vllm)
+
+    # --- Static files --------------------------------------------------------
+    app.router.add_static("/static", get_static_path(), name="static")
+
+    return app
+
+
+# =============================================================================
+# Lifecycle helpers
+# =============================================================================
+
+async def _on_startup(app: web.Application) -> None:
+    app["client_session"] = aiohttp.ClientSession()
+
+
+async def _on_cleanup(app: web.Application) -> None:
+    session: Optional[aiohttp.ClientSession] = app.get("client_session")
+    if session and not session.closed:
+        await session.close()
+
+
+# =============================================================================
+# Middleware
+# =============================================================================
+
+@web.middleware
+async def cors_middleware(request: web.Request, handler):
+    """Add CORS headers to every response so the dashboard can fetch freely."""
+    if request.method == "OPTIONS":
+        resp = web.Response(status=204)
+    else:
+        try:
+            resp = await handler(request)
+        except web.HTTPException as exc:
+            resp = exc
+
+    resp.headers["Access-Control-Allow-Origin"] = "*"
+    resp.headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, DELETE, OPTIONS"
+    resp.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
+    return resp
+
+
+# =============================================================================
+# Web UI
+# =============================================================================
+
+async def handle_index(_request: web.Request) -> web.Response:
+    """Serve the embedded dashboard HTML."""
+    html = get_index_html()
+    return web.Response(text=html, content_type="text/html")
+
+
+# =============================================================================
+# AINode API endpoints
+# =============================================================================
+
+async def handle_health(_request: web.Request) -> web.Response:
+    """Simple liveness probe."""
+    return web.json_response({"status": "ok"})
+
+
+async def handle_status(request: web.Request) -> web.Response:
+    """Return rich node status."""
+    config: NodeConfig = request.app["config"]
+    engine = request.app["engine"]
+    start_time: float = request.app["start_time"]
+
+    gpu: Optional[GPUInfo] = detect_gpu()
+    gpu_info = asdict(gpu) if gpu else None
+
+    engine_ready = False
+    models_loaded: list[str] = []
+    if engine is not None:
+        engine_ready = getattr(engine, "ready", False)
+        try:
+            hc = engine.health_check()
+            models_loaded = hc.get("models_loaded", [])
+        except Exception:
+            pass
+
+    return web.json_response({
+        "node_id": config.node_id,
+        "node_name": config.node_name,
+        "model": config.model,
+        "gpu": gpu_info,
+        "engine_ready": engine_ready,
+        "uptime": round(time.time() - start_time, 1),
+        "version": __version__,
+        "powered_by": "argentos.ai",
+        "models_loaded": models_loaded,
+        "api_port": config.api_port,
+    })
+
+
+async def handle_nodes(request: web.Request) -> web.Response:
+    """Return the list of known cluster nodes (stub: just this node)."""
+    config: NodeConfig = request.app["config"]
+    engine = request.app["engine"]
+    engine_ready = False
+    if engine is not None:
+        engine_ready = getattr(engine, "ready", False)
+
+    node = {
+        "node_id": config.node_id,
+        "node_name": config.node_name,
+        "host": config.host,
+        "api_port": config.api_port,
+        "web_port": config.web_port,
+        "model": config.model,
+        "engine_ready": engine_ready,
+    }
+    return web.json_response({"nodes": [node]})
+
+
+# =============================================================================
+# vLLM proxy
+# =============================================================================
+
+async def proxy_to_vllm(request: web.Request) -> web.StreamResponse:
+    """Forward the request to the local vLLM server and stream the response back."""
+    config: NodeConfig = request.app["config"]
+    session: aiohttp.ClientSession = request.app["client_session"]
+    vllm_url = f"http://localhost:{config.api_port}{request.path}"
+
+    # Build upstream request kwargs
+    kwargs: dict = {
+        "headers": {k: v for k, v in request.headers.items()
+                    if k.lower() not in ("host", "transfer-encoding")},
+    }
+    if request.method == "POST":
+        kwargs["data"] = await request.read()
+
+    try:
+        async with session.request(request.method, vllm_url, **kwargs) as upstream:
+            # Detect SSE streaming
+            is_sse = "text/event-stream" in upstream.headers.get("Content-Type", "")
+
+            if is_sse:
+                resp = web.StreamResponse(
+                    status=upstream.status,
+                    headers={
+                        "Content-Type": "text/event-stream",
+                        "Cache-Control": "no-cache",
+                        "X-Accel-Buffering": "no",
+                    },
+                )
+                await resp.prepare(request)
+                async for chunk in upstream.content.iter_any():
+                    await resp.write(chunk)
+                await resp.write_eof()
+                return resp
+            else:
+                body = await upstream.read()
+                return web.Response(
+                    status=upstream.status,
+                    body=body,
+                    content_type=upstream.headers.get("Content-Type", "application/json"),
+                )
+    except aiohttp.ClientError:
+        return web.json_response(
+            {"error": {"message": "vLLM engine not reachable", "type": "server_error"}},
+            status=502,
+        )
+
+
+# =============================================================================
+# Convenience runner
+# =============================================================================
+
+def run_server(config: Optional[NodeConfig] = None, engine=None) -> None:
+    """Start the API server (blocking)."""
+    if config is None:
+        config = NodeConfig()
+    app = create_app(config=config, engine=engine)
+    web.run_app(app, host=config.host, port=config.web_port, print=None)

--- a/ainode/api/server.py
+++ b/ainode/api/server.py
@@ -9,8 +9,11 @@ from aiohttp import web
 
 from ainode.core.config import NodeConfig
 from ainode.core.gpu import detect_gpu, GPUInfo
-from ainode.web.serve import get_index_html, get_static_path
+from ainode.web.serve import get_index_html, get_onboarding_html, get_static_path
 from ainode.models.api_routes import register_model_routes
+from ainode.onboarding.api_routes import register_onboarding_routes
+from ainode.auth.middleware import AuthConfig, auth_middleware
+from ainode.auth.api_routes import register_auth_routes
 
 __version__ = "0.1.0"
 
@@ -31,8 +34,12 @@ def create_app(
     if config is None:
         config = NodeConfig()
 
-    app = web.Application(middlewares=[cors_middleware])
+    # Load auth config from disk
+    auth_config = AuthConfig.load()
+
+    app = web.Application(middlewares=[cors_middleware, auth_middleware])
     app["config"] = config
+    app["auth_config"] = auth_config
     app["engine"] = engine
     app["start_time"] = time.time()
     app["client_session"] = None  # lazy-init in startup
@@ -43,6 +50,7 @@ def create_app(
 
     # --- AINode routes -------------------------------------------------------
     app.router.add_get("/", handle_index)
+    app.router.add_get("/onboarding", handle_onboarding)
     app.router.add_get("/api/health", handle_health)
     app.router.add_get("/api/status", handle_status)
     app.router.add_get("/api/nodes", handle_nodes)
@@ -54,6 +62,12 @@ def create_app(
 
     # --- Model management routes ---------------------------------------------
     register_model_routes(app)
+
+    # --- Onboarding routes ---------------------------------------------------
+    register_onboarding_routes(app)
+
+    # --- Auth management routes ----------------------------------------------
+    register_auth_routes(app)
 
     # --- Static files --------------------------------------------------------
     app.router.add_static("/static", get_static_path(), name="static")
@@ -100,9 +114,21 @@ async def cors_middleware(request: web.Request, handler):
 # Web UI
 # =============================================================================
 
-async def handle_index(_request: web.Request) -> web.Response:
-    """Serve the embedded dashboard HTML."""
+async def handle_index(request: web.Request) -> web.Response:
+    """Serve the dashboard, or redirect to onboarding if not set up."""
+    config: NodeConfig = request.app["config"]
+    if not config.onboarded:
+        raise web.HTTPFound("/onboarding")
     html = get_index_html()
+    return web.Response(text=html, content_type="text/html")
+
+
+async def handle_onboarding(request: web.Request) -> web.Response:
+    """Serve the onboarding wizard. Redirect to dashboard if already onboarded."""
+    config: NodeConfig = request.app["config"]
+    if config.onboarded:
+        raise web.HTTPFound("/")
+    html = get_onboarding_html()
     return web.Response(text=html, content_type="text/html")
 
 

--- a/ainode/api/server.py
+++ b/ainode/api/server.py
@@ -9,8 +9,9 @@ from aiohttp import web
 
 from ainode.core.config import NodeConfig
 from ainode.core.gpu import detect_gpu, GPUInfo
-from ainode.web.serve import get_index_html, get_static_path
+from ainode.web.serve import get_index_html, get_onboarding_html, get_static_path
 from ainode.models.api_routes import register_model_routes
+from ainode.onboarding.api_routes import register_onboarding_routes
 from ainode.auth.middleware import AuthConfig, auth_middleware
 from ainode.auth.api_routes import register_auth_routes
 
@@ -49,6 +50,7 @@ def create_app(
 
     # --- AINode routes -------------------------------------------------------
     app.router.add_get("/", handle_index)
+    app.router.add_get("/onboarding", handle_onboarding)
     app.router.add_get("/api/health", handle_health)
     app.router.add_get("/api/status", handle_status)
     app.router.add_get("/api/nodes", handle_nodes)
@@ -60,6 +62,9 @@ def create_app(
 
     # --- Model management routes ---------------------------------------------
     register_model_routes(app)
+
+    # --- Onboarding routes ---------------------------------------------------
+    register_onboarding_routes(app)
 
     # --- Auth management routes ----------------------------------------------
     register_auth_routes(app)
@@ -109,9 +114,21 @@ async def cors_middleware(request: web.Request, handler):
 # Web UI
 # =============================================================================
 
-async def handle_index(_request: web.Request) -> web.Response:
-    """Serve the embedded dashboard HTML."""
+async def handle_index(request: web.Request) -> web.Response:
+    """Serve the dashboard, or redirect to onboarding if not set up."""
+    config: NodeConfig = request.app["config"]
+    if not config.onboarded:
+        raise web.HTTPFound("/onboarding")
     html = get_index_html()
+    return web.Response(text=html, content_type="text/html")
+
+
+async def handle_onboarding(request: web.Request) -> web.Response:
+    """Serve the onboarding wizard. Redirect to dashboard if already onboarded."""
+    config: NodeConfig = request.app["config"]
+    if config.onboarded:
+        raise web.HTTPFound("/")
+    html = get_onboarding_html()
     return web.Response(text=html, content_type="text/html")
 
 

--- a/ainode/api/server.py
+++ b/ainode/api/server.py
@@ -10,6 +10,7 @@ from aiohttp import web
 from ainode.core.config import NodeConfig
 from ainode.core.gpu import detect_gpu, GPUInfo
 from ainode.web.serve import get_index_html, get_static_path
+from ainode.models.api_routes import register_model_routes
 
 __version__ = "0.1.0"
 
@@ -50,6 +51,9 @@ def create_app(
     app.router.add_get("/v1/models", proxy_to_vllm)
     app.router.add_post("/v1/chat/completions", proxy_to_vllm)
     app.router.add_post("/v1/completions", proxy_to_vllm)
+
+    # --- Model management routes ---------------------------------------------
+    register_model_routes(app)
 
     # --- Static files --------------------------------------------------------
     app.router.add_static("/static", get_static_path(), name="static")

--- a/ainode/auth/__init__.py
+++ b/ainode/auth/__init__.py
@@ -1,0 +1,1 @@
+"""AINode authentication — optional API key auth for network-exposed instances."""

--- a/ainode/auth/api_routes.py
+++ b/ainode/auth/api_routes.py
@@ -1,0 +1,68 @@
+"""API routes for auth management (enable/disable, key CRUD)."""
+
+from __future__ import annotations
+
+from aiohttp import web
+
+from ainode.auth.middleware import AuthConfig
+
+
+def register_auth_routes(app: web.Application) -> None:
+    """Register auth management routes on the aiohttp app."""
+    app.router.add_get("/api/auth/status", handle_auth_status)
+    app.router.add_post("/api/auth/enable", handle_auth_enable)
+    app.router.add_post("/api/auth/disable", handle_auth_disable)
+    app.router.add_post("/api/auth/keys", handle_create_key)
+    app.router.add_delete("/api/auth/keys/{key_id}", handle_revoke_key)
+
+
+# -- Handlers ------------------------------------------------------------------
+
+async def handle_auth_status(request: web.Request) -> web.Response:
+    """GET /api/auth/status -- return auth state."""
+    auth_cfg: AuthConfig = request.app["auth_config"]
+    return web.json_response({
+        "enabled": auth_cfg.enabled,
+        "key_count": len(auth_cfg.api_keys),
+    })
+
+
+async def handle_auth_enable(request: web.Request) -> web.Response:
+    """POST /api/auth/enable -- enable auth, return the (first) API key."""
+    auth_cfg: AuthConfig = request.app["auth_config"]
+    entry = auth_cfg.enable()
+    return web.json_response({
+        "enabled": True,
+        "api_key": entry["key"],
+        "key_id": entry["id"],
+    })
+
+
+async def handle_auth_disable(request: web.Request) -> web.Response:
+    """POST /api/auth/disable -- disable auth."""
+    auth_cfg: AuthConfig = request.app["auth_config"]
+    auth_cfg.disable()
+    return web.json_response({"enabled": False})
+
+
+async def handle_create_key(request: web.Request) -> web.Response:
+    """POST /api/auth/keys -- generate a new API key."""
+    auth_cfg: AuthConfig = request.app["auth_config"]
+    entry = auth_cfg.generate_key()
+    return web.json_response({
+        "api_key": entry["key"],
+        "key_id": entry["id"],
+    })
+
+
+async def handle_revoke_key(request: web.Request) -> web.Response:
+    """DELETE /api/auth/keys/:key_id -- revoke a key."""
+    key_id = request.match_info["key_id"]
+    auth_cfg: AuthConfig = request.app["auth_config"]
+    revoked = auth_cfg.revoke_key(key_id)
+    if not revoked:
+        return web.json_response(
+            {"error": f"Key '{key_id}' not found"},
+            status=404,
+        )
+    return web.json_response({"revoked": True, "key_id": key_id})

--- a/ainode/auth/middleware.py
+++ b/ainode/auth/middleware.py
@@ -1,0 +1,131 @@
+"""API key authentication middleware for aiohttp."""
+
+from __future__ import annotations
+
+import json
+import secrets
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import List
+
+from aiohttp import web
+
+from ainode.core.config import AINODE_HOME
+
+AUTH_FILE = AINODE_HOME / "auth.json"
+
+# Paths that never require authentication
+SKIP_PATHS: set[str] = {
+    "/",
+    "/onboarding",
+    "/api/health",
+}
+SKIP_PREFIXES: tuple[str, ...] = (
+    "/static/",
+    "/api/onboarding/",
+)
+
+
+@dataclass
+class AuthConfig:
+    """Persisted auth state."""
+
+    enabled: bool = False
+    api_keys: List[dict] = field(default_factory=list)
+    # Each key entry: {"id": "<short-id>", "key": "<hex>"}
+
+    # -- persistence ----------------------------------------------------------
+
+    def save(self) -> None:
+        AINODE_HOME.mkdir(parents=True, exist_ok=True)
+        AUTH_FILE.write_text(json.dumps(asdict(self), indent=2))
+
+    @classmethod
+    def load(cls) -> "AuthConfig":
+        if AUTH_FILE.exists():
+            data = json.loads(AUTH_FILE.read_text())
+            return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+        return cls()
+
+    # -- key management -------------------------------------------------------
+
+    def generate_key(self) -> dict:
+        """Create a new API key, append it, save, and return the entry."""
+        key = secrets.token_hex(16)  # 32-char hex string
+        key_id = key[:8]
+        entry = {"id": key_id, "key": key}
+        self.api_keys.append(entry)
+        self.save()
+        return entry
+
+    def revoke_key(self, key_id: str) -> bool:
+        """Remove a key by its id. Returns True if found and removed."""
+        before = len(self.api_keys)
+        self.api_keys = [k for k in self.api_keys if k["id"] != key_id]
+        if len(self.api_keys) != before:
+            self.save()
+            return True
+        return False
+
+    def valid_keys(self) -> set[str]:
+        """Return the set of currently valid raw key strings."""
+        return {k["key"] for k in self.api_keys}
+
+    def enable(self) -> dict:
+        """Enable auth. Generates a default key if none exist. Returns the key entry."""
+        self.enabled = True
+        if not self.api_keys:
+            entry = self.generate_key()  # also saves
+        else:
+            entry = self.api_keys[0]
+            self.save()
+        return entry
+
+    def disable(self) -> None:
+        """Disable auth (keys are kept but not enforced)."""
+        self.enabled = False
+        self.save()
+
+
+def _should_skip(request: web.Request) -> bool:
+    """Return True if this request should bypass auth checks."""
+    path = request.path
+    if path in SKIP_PATHS:
+        return True
+    if path.startswith(SKIP_PREFIXES):
+        return True
+    # GET requests to onboarding pages
+    if request.method == "GET" and path.startswith("/api/onboarding"):
+        return True
+    return False
+
+
+@web.middleware
+async def auth_middleware(request: web.Request, handler):
+    """Check Bearer token when auth is enabled."""
+    auth_cfg: AuthConfig | None = request.app.get("auth_config")
+
+    # If auth is not configured or disabled, pass through
+    if auth_cfg is None or not auth_cfg.enabled:
+        return await handler(request)
+
+    # Skip exempt paths
+    if _should_skip(request):
+        return await handler(request)
+
+    # Check Authorization header
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return web.json_response(
+            {"error": {"message": "Missing or invalid Authorization header", "type": "auth_error"}},
+            status=401,
+        )
+
+    token = auth_header[7:]  # strip "Bearer "
+    if token not in auth_cfg.valid_keys():
+        return web.json_response(
+            {"error": {"message": "Invalid API key", "type": "auth_error"}},
+            status=401,
+        )
+
+    return await handler(request)

--- a/ainode/cli/main.py
+++ b/ainode/cli/main.py
@@ -156,6 +156,44 @@ def cmd_models(args):
     print()
 
 
+def cmd_auth(args):
+    """Manage API key authentication."""
+    from ainode.auth.middleware import AuthConfig
+
+    action = getattr(args, "auth_action", None)
+    auth_cfg = AuthConfig.load()
+
+    if action == "enable":
+        entry = auth_cfg.enable()
+        console.print("  [green]Auth enabled.[/green]")
+        console.print(f"  API key: {entry['key']}")
+        console.print(f"  Key ID:  {entry['id']}")
+        console.print()
+        console.print("  Use: Authorization: Bearer <key>")
+        console.print("  Powered by argentos.ai")
+
+    elif action == "disable":
+        auth_cfg.disable()
+        console.print("  [yellow]Auth disabled.[/yellow] All requests allowed.")
+        console.print("  Powered by argentos.ai")
+
+    elif action == "status":
+        state = "[green]enabled[/green]" if auth_cfg.enabled else "[dim]disabled[/dim]"
+        console.print(f"  Auth: {state}")
+        console.print(f"  Keys: {len(auth_cfg.api_keys)}")
+        console.print("  Powered by argentos.ai")
+
+    elif action == "new-key":
+        entry = auth_cfg.generate_key()
+        console.print("  [green]New API key generated.[/green]")
+        console.print(f"  API key: {entry['key']}")
+        console.print(f"  Key ID:  {entry['id']}")
+        console.print("  Powered by argentos.ai")
+
+    else:
+        console.print("  Usage: ainode auth {enable|disable|status|new-key}")
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="ainode",
@@ -182,6 +220,16 @@ def main():
     # models
     models_parser = subparsers.add_parser("models", help="List available models")
     models_parser.set_defaults(func=cmd_models)
+
+
+    # auth
+    auth_parser = subparsers.add_parser("auth", help="Manage API key authentication")
+    auth_sub = auth_parser.add_subparsers(dest="auth_action")
+    auth_sub.add_parser("enable", help="Enable API key auth")
+    auth_sub.add_parser("disable", help="Disable API key auth")
+    auth_sub.add_parser("status", help="Show auth status")
+    auth_sub.add_parser("new-key", help="Generate a new API key")
+    auth_parser.set_defaults(func=cmd_auth)
 
     args = parser.parse_args()
 

--- a/ainode/cli/main.py
+++ b/ainode/cli/main.py
@@ -1,48 +1,135 @@
-"""AINode CLI — main entry point."""
+"""AINode CLI — main entry point with Rich terminal output."""
 
 import argparse
+import os
+import signal
 import sys
-import uuid
 import time
-import threading
+import uuid
 
 from rich.console import Console
 from rich.live import Live
+from rich.panel import Panel
 from rich.spinner import Spinner
+from rich.table import Table
 from rich.text import Text
 
 from ainode import __version__
-from ainode.core.config import NodeConfig, ensure_dirs
-from ainode.core.gpu import gpu_summary, detect_gpu
+from ainode.core.config import NodeConfig, ensure_dirs, AINODE_HOME, LOGS_DIR
 
 console = Console()
 
+PID_FILE = AINODE_HOME / "ainode.pid"
+VLLM_LOG = LOGS_DIR / "vllm.log"
 
-def _tail_log(path, lines=10):
-    """Print the last N lines of a log file."""
+
+# ---------------------------------------------------------------------------
+# Banner
+# ---------------------------------------------------------------------------
+
+def _banner():
+    """Return a Rich Panel banner for AINode."""
+    title_text = Text()
+    title_text.append("A", style="bold cyan")
+    title_text.append("I", style="bold cyan")
+    title_text.append("N", style="bold cyan")
+    title_text.append("ode", style="bold white")
+    title_text.append("  v" + __version__, style="dim")
+
+    body = Text.from_markup(
+        "[bold white]Turn any NVIDIA GPU into a local AI platform[/bold white]\n"
+        "[dim]Inference + fine-tuning in your browser. One command to start.[/dim]"
+    )
+
+    return Panel(
+        body,
+        title=title_text,
+        subtitle="[dim italic]Powered by argentos.ai[/dim italic]",
+        border_style="cyan",
+        padding=(1, 4),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_pid():
+    """Write current PID to the PID file."""
+    AINODE_HOME.mkdir(parents=True, exist_ok=True)
+    PID_FILE.write_text(str(os.getpid()))
+
+
+def _read_pid():
+    """Read PID from file, return int or None."""
     try:
-        with open(path) as f:
-            all_lines = f.readlines()
-        for line in all_lines[-lines:]:
-            console.print(f"    {line.rstrip()}")
+        return int(PID_FILE.read_text().strip())
+    except Exception:
+        return None
+
+
+def _remove_pid():
+    """Remove the PID file."""
+    try:
+        PID_FILE.unlink(missing_ok=True)
     except Exception:
         pass
 
 
-BANNER = """
-    ╔══════════════════════════════════════╗
-    ║            A I N o d e               ║
-    ║   Your local AI platform for NVIDIA  ║
-    ╚══════════════════════════════════════╝
-"""
+def _pid_alive(pid):
+    """Check if a PID is alive."""
+    if pid is None:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except (OSError, ProcessLookupError):
+        return False
 
+
+def _tail_log(path, lines=10):
+    """Return the last N lines of a log file."""
+    try:
+        with open(path) as f:
+            all_lines = f.readlines()
+        return all_lines[-lines:]
+    except Exception:
+        return []
+
+
+def _gpu_info_table(gpu):
+    """Build a Rich table for GPU info."""
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("key", style="bold cyan", no_wrap=True)
+    table.add_column("value")
+
+    mem_gb = gpu.memory_total_mb / 1024
+    um = " (unified memory)" if gpu.unified_memory else ""
+    table.add_row("GPU", f"{gpu.name} | {mem_gb:.0f} GB{um}")
+    table.add_row("CUDA", f"{gpu.cuda_version} | Driver {gpu.driver_version}")
+    table.add_row("Compute", f"SM {gpu.compute_capability}")
+    return table
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
 
 def cmd_start(args):
     """Start AINode."""
-    print(BANNER)
+    from ainode.core.gpu import gpu_summary, detect_gpu
+    console.print(_banner())
     ensure_dirs()
 
     config = NodeConfig.load()
+
+    # Override from CLI flags
+    if hasattr(args, "model") and args.model:
+        config.model = args.model
+        config.save()
+    if hasattr(args, "port") and args.port:
+        config.api_port = args.port
+        config.save()
 
     # First run — onboarding
     if not config.onboarded:
@@ -57,69 +144,139 @@ def cmd_start(args):
     # Detect GPU
     gpu = detect_gpu()
     if gpu:
-        mem_gb = gpu.memory_total_mb / 1024
-        um = " (unified memory)" if gpu.unified_memory else ""
-        print(f"  GPU:   {gpu.name} | {mem_gb:.0f} GB{um}")
-        print(f"  CUDA:  {gpu.cuda_version} | Driver {gpu.driver_version}")
+        console.print(_gpu_info_table(gpu))
     else:
-        print("  GPU:   No NVIDIA GPU detected (CPU mode)")
-    print()
-
-    # Start vLLM engine
-    console.print(f"  Model: {config.model}")
-    console.print(f"  API:   http://localhost:{config.api_port}/v1")
-    console.print(f"  Web:   http://localhost:{config.web_port}")
+        console.print("  [yellow]No NVIDIA GPU detected[/yellow] — running in CPU mode")
     console.print()
 
+    # Service info
+    info_table = Table(show_header=False, box=None, padding=(0, 2))
+    info_table.add_column("key", style="bold green", no_wrap=True)
+    info_table.add_column("value")
+    info_table.add_row("Model", config.model)
+    info_table.add_row("API", f"http://localhost:{config.api_port}/v1")
+    info_table.add_row("Web", f"http://localhost:{config.web_port}")
+    info_table.add_row("Node", config.node_id or "pending")
+    console.print(info_table)
+    console.print()
+
+    # Write PID file
+    _write_pid()
+
+    # Start vLLM engine
     from ainode.engine.vllm_engine import VLLMEngine
 
     engine = VLLMEngine(config)
     if not engine.start():
         console.print("  [red]Failed to start engine.[/red] Check logs in ~/.ainode/logs/")
+        _remove_pid()
         sys.exit(1)
 
-    # Wait for readiness with spinner and log tailing
+    # Wait for readiness with spinner
     with Live(Spinner("dots", text="Starting inference engine..."), console=console, transient=True):
         ready = engine.wait_ready(timeout=300)
 
     if not ready:
         console.print("  [red]Engine failed to become ready within 5 minutes.[/red]")
         if engine.log_path and engine.log_path.exists():
-            console.print(f"  Last log lines:")
-            _tail_log(engine.log_path, lines=10)
+            console.print("  [dim]Last log lines:[/dim]")
+            for line in _tail_log(engine.log_path, lines=10):
+                console.print(f"    [dim]{line.rstrip()}[/dim]")
         engine.stop()
+        _remove_pid()
         sys.exit(1)
 
-    console.print("  [green]Engine ready.[/green] Open your browser to get started.")
-    console.print()
-    console.print("  Powered by argentos.ai")
-    console.print()
+    console.print("  [bold green]Engine ready.[/bold green] Open your browser to get started.\n")
 
     # Keep running until interrupted
     try:
         engine.process.wait()
     except KeyboardInterrupt:
-        console.print("\n  Shutting down...")
+        console.print("\n  [yellow]Shutting down...[/yellow]")
         engine.stop()
+    finally:
+        _remove_pid()
 
 
 def cmd_stop(args):
-    """Stop AINode."""
-    print("Stopping AINode...")
-    # TODO: Signal running instance to stop
-    print("Done.")
+    """Stop a running AINode instance."""
+    console.print(_banner())
+
+    pid = _read_pid()
+
+    if pid and _pid_alive(pid):
+        console.print(f"  Stopping AINode (PID {pid})...")
+        try:
+            os.kill(pid, signal.SIGTERM)
+            # Wait up to 10 seconds for graceful shutdown
+            for _ in range(20):
+                if not _pid_alive(pid):
+                    break
+                time.sleep(0.5)
+            else:
+                # Force kill if still alive
+                console.print("  [yellow]Process did not exit gracefully, sending SIGKILL...[/yellow]")
+                os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        _remove_pid()
+        console.print("  [green]AINode stopped.[/green]\n")
+        return
+
+    # No PID file or stale PID — try to find the process
+    _remove_pid()
+
+    # Fallback: check for python processes running ainode
+    import subprocess
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", "ainode.cli.main|ainode start"],
+            capture_output=True, text=True
+        )
+        pids = [int(p) for p in result.stdout.strip().split("\n") if p.strip() and int(p) != os.getpid()]
+    except Exception:
+        pids = []
+
+    if pids:
+        for p in pids:
+            console.print(f"  Stopping AINode process (PID {p})...")
+            try:
+                os.kill(p, signal.SIGTERM)
+            except (OSError, ProcessLookupError):
+                pass
+        console.print("  [green]AINode stopped.[/green]\n")
+    else:
+        console.print("  [dim]No running AINode instance found.[/dim]\n")
 
 
 def cmd_status(args):
-    """Show cluster status."""
-    print(BANNER)
-    console.print(f"  GPU: {gpu_summary()}")
+    """Show cluster status with Rich formatting."""
+    from ainode.core.gpu import gpu_summary, detect_gpu
+    console.print(_banner())
 
     config = NodeConfig.load()
-    console.print(f"  Node ID: {config.node_id or 'not configured'}")
-    console.print(f"  Model: {config.model}")
-    console.print(f"  API: http://localhost:{config.api_port}/v1")
-    console.print(f"  Email: {config.email or 'not set'}")
+    gpu = detect_gpu()
+
+    # Node info table
+    table = Table(title="Node Info", border_style="cyan", show_lines=False)
+    table.add_column("Property", style="bold cyan", no_wrap=True)
+    table.add_column("Value")
+
+    table.add_row("Node ID", config.node_id or "[dim]not configured[/dim]")
+    table.add_row("Model", config.model)
+    table.add_row("API", f"http://localhost:{config.api_port}/v1")
+    table.add_row("Web", f"http://localhost:{config.web_port}")
+    table.add_row("Email", config.email or "[dim]not set[/dim]")
+
+    if gpu:
+        mem_gb = gpu.memory_total_mb / 1024
+        um = " (unified)" if gpu.unified_memory else ""
+        table.add_row("GPU", f"{gpu.name} | {mem_gb:.0f} GB{um}")
+        table.add_row("CUDA", f"{gpu.cuda_version} | Driver {gpu.driver_version}")
+    else:
+        table.add_row("GPU", "[yellow]No NVIDIA GPU detected[/yellow]")
+
+    console.print(table)
     console.print()
 
     # Engine health check
@@ -128,19 +285,29 @@ def cmd_status(args):
     health = engine.health_check()
 
     if health["api_responding"]:
-        console.print("  Engine: [green]running[/green]")
+        console.print("  Engine:  [bold green]running[/bold green]")
         if health["models_loaded"]:
-            console.print(f"  Models: {', '.join(health['models_loaded'])}")
+            console.print(f"  Models:  {', '.join(health['models_loaded'])}")
     elif health["process_alive"]:
-        console.print("  Engine: [yellow]starting[/yellow] (process alive, API not ready)")
+        console.print("  Engine:  [bold yellow]starting[/bold yellow] (process alive, API not ready)")
     else:
-        console.print("  Engine: [red]stopped[/red]")
+        console.print("  Engine:  [bold red]stopped[/bold red]")
+
+    # PID file status
+    pid = _read_pid()
+    if pid and _pid_alive(pid):
+        console.print(f"  PID:     {pid}")
     console.print()
 
 
 def cmd_models(args):
-    """List available models."""
-    print("Popular models for AINode:\n")
+    """List available models with Rich table and GPU-aware recommendations."""
+    from ainode.core.gpu import detect_gpu
+    console.print(_banner())
+
+    gpu = detect_gpu()
+    gpu_mem_gb = (gpu.memory_total_mb / 1024) if gpu else 0
+
     models = [
         ("llama-3.2-3b", "Llama 3.2 3B Instruct", "~6 GB", "Quick start"),
         ("llama-3.1-8b", "Llama 3.1 8B Instruct", "~16 GB", "Recommended"),
@@ -148,12 +315,193 @@ def cmd_models(args):
         ("qwen-2.5-72b", "Qwen 2.5 72B Instruct", "~40 GB", "Coding + multilingual"),
         ("deepseek-r1-7b", "DeepSeek R1 Distill 7B", "~14 GB", "Reasoning"),
     ]
+
+    # Memory thresholds for recommendations
+    mem_thresholds = {
+        "~6 GB": 6,
+        "~14 GB": 14,
+        "~16 GB": 16,
+        "~35 GB": 35,
+        "~40 GB": 40,
+    }
+
+    table = Table(title="Available Models", border_style="cyan")
+    table.add_column("Name", style="bold white", no_wrap=True)
+    table.add_column("Size", justify="right")
+    table.add_column("Description")
+    table.add_column("Tag")
+
     for short, name, mem, note in models:
-        print(f"  {short:<25} {mem:<10} {note}")
-    print()
-    print("  Set model: ainode config --model <name>")
-    print("  Full list: https://ainode.dev/models")
-    print()
+        threshold = mem_thresholds.get(mem, 999)
+        fits = gpu_mem_gb >= threshold
+
+        if note == "Recommended":
+            tag_style = "bold green" if fits else "dim green"
+        elif fits:
+            tag_style = "green"
+        else:
+            tag_style = "dim red"
+
+        tag = Text(note, style=tag_style)
+        if not fits and gpu_mem_gb > 0:
+            tag.append(" (needs more VRAM)", style="dim")
+
+        table.add_row(short, mem, name, tag)
+
+    console.print(table)
+    console.print()
+    console.print("  Set model:  [bold]ainode config --model <name>[/bold]")
+    console.print("  Full list:  [link=https://ainode.dev/models]https://ainode.dev/models[/link]")
+    console.print()
+
+
+def cmd_config(args):
+    """Show or update AINode configuration."""
+    config = NodeConfig.load()
+
+    if args.model:
+        config.model = args.model
+        config.save()
+        console.print(f"  [green]Model set to:[/green] {args.model}")
+        return
+
+    if args.port:
+        config.api_port = args.port
+        config.save()
+        console.print(f"  [green]API port set to:[/green] {args.port}")
+        return
+
+    # Default: --show
+    console.print(_banner())
+
+    from dataclasses import asdict
+    data = asdict(config)
+
+    table = Table(title="Configuration", border_style="cyan")
+    table.add_column("Key", style="bold cyan", no_wrap=True)
+    table.add_column("Value")
+
+    for key, value in data.items():
+        display = str(value) if value is not None else "[dim]not set[/dim]"
+        table.add_row(key, display)
+
+    console.print(table)
+    console.print()
+    console.print(f"  Config file: [dim]{AINODE_HOME / 'config.json'}[/dim]")
+    console.print()
+
+
+def cmd_logs(args):
+    """Show or tail vLLM logs."""
+    log_file = VLLM_LOG
+
+    if not log_file.exists():
+        console.print("  [dim]No log file found at[/dim] ~/.ainode/logs/vllm.log")
+        console.print("  [dim]Start AINode first: [bold]ainode start[/bold][/dim]")
+        return
+
+    if args.follow:
+        console.print(f"  [dim]Tailing {log_file} (Ctrl+C to stop)[/dim]\n")
+        try:
+            import subprocess
+            proc = subprocess.Popen(
+                ["tail", "-f", str(log_file)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            for line in proc.stdout:
+                console.print(line.rstrip())
+        except KeyboardInterrupt:
+            console.print("\n  [dim]Stopped tailing.[/dim]")
+            if proc:
+                proc.terminate()
+    else:
+        lines = _tail_log(log_file, lines=args.lines)
+        if not lines:
+            console.print("  [dim]Log file is empty.[/dim]")
+            return
+        console.print(f"  [dim]Last {len(lines)} lines of {log_file}:[/dim]\n")
+        for line in lines:
+            console.print(f"  {line.rstrip()}")
+        console.print()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def cmd_service(args):
+    """Manage AINode systemd service."""
+    from ainode.service.systemd import (
+        install_service,
+        enable_service,
+        start_service,
+        stop_service,
+        disable_service,
+        uninstall_service,
+        status_service,
+        get_journal_lines,
+        is_installed,
+    )
+
+    user_mode = getattr(args, "user", False)
+    action = getattr(args, "service_action", None)
+
+    if action == "install":
+        if is_installed(user_mode=user_mode):
+            console.print("  [yellow]AINode service is already installed.[/yellow]")
+        else:
+            console.print("  Installing AINode service...")
+            install_service(user_mode=user_mode)
+            console.print("  [green]✓[/green] Unit file written")
+        console.print("  Enabling service...")
+        enable_service(user_mode=user_mode)
+        console.print("  [green]✓[/green] Service enabled")
+        console.print("  Starting service...")
+        start_service(user_mode=user_mode)
+        console.print("  [green]✓[/green] Service started")
+        console.print()
+        console.print("  AINode will now start automatically on boot.")
+        console.print("  Powered by argentos.ai")
+
+    elif action == "uninstall":
+        if not is_installed(user_mode=user_mode):
+            console.print("  [yellow]AINode service is not installed.[/yellow]")
+            return
+        console.print("  Stopping and removing AINode service...")
+        uninstall_service(user_mode=user_mode)
+        console.print("  [green]✓[/green] Service removed")
+        console.print("  Powered by argentos.ai")
+
+    elif action == "status":
+        if not is_installed(user_mode=user_mode):
+            console.print("  AINode service: [dim]not installed[/dim]")
+            return
+        info = status_service(user_mode=user_mode)
+        state = info["state"]
+        color = {"active": "green", "inactive": "dim", "failed": "red"}.get(state, "yellow")
+        console.print(f"  AINode service: [{color}]{state}[/{color}]")
+        console.print(f"  Enabled: {'yes' if info['enabled'] else 'no'}")
+        if info["journal_lines"]:
+            console.print()
+            console.print("  Recent logs:")
+            for line in info["journal_lines"][-10:]:
+                console.print(f"    {line}")
+        console.print()
+        console.print("  Powered by argentos.ai")
+
+    elif action == "logs":
+        lines = getattr(args, "lines", 50)
+        journal = get_journal_lines(user_mode=user_mode, lines=lines)
+        if journal:
+            for line in journal:
+                console.print(line)
+        else:
+            console.print("  No journal entries found for AINode.")
+
+    else:
+        console.print("  Usage: ainode service {install|uninstall|status|logs}")
 
 
 def cmd_auth(args):
@@ -197,7 +545,7 @@ def cmd_auth(args):
 def main():
     parser = argparse.ArgumentParser(
         prog="ainode",
-        description="AINode — Turn any NVIDIA GPU into a local AI platform.",
+        description="AINode -- Turn any NVIDIA GPU into a local AI platform.",
     )
     parser.add_argument("--version", action="version", version=f"ainode {__version__}")
 
@@ -221,6 +569,31 @@ def main():
     models_parser = subparsers.add_parser("models", help="List available models")
     models_parser.set_defaults(func=cmd_models)
 
+    # config
+    config_parser = subparsers.add_parser("config", help="Show or update configuration")
+    config_parser.add_argument("--show", action="store_true", default=True, help="Show current config")
+    config_parser.add_argument("--model", help="Set the model")
+    config_parser.add_argument("--port", type=int, help="Set the API port")
+    config_parser.set_defaults(func=cmd_config)
+
+    # logs
+    logs_parser = subparsers.add_parser("logs", help="Show vLLM logs")
+    logs_parser.add_argument("--follow", "-f", action="store_true", help="Tail logs in real-time")
+    logs_parser.add_argument("--lines", "-n", type=int, default=50, help="Number of lines to show (default: 50)")
+    logs_parser.set_defaults(func=cmd_logs)
+
+    # service
+    service_parser = subparsers.add_parser("service", help="Manage AINode systemd service")
+    service_parser.add_argument(
+        "--user", action="store_true", help="Use user-level systemd (no sudo required)"
+    )
+    service_sub = service_parser.add_subparsers(dest="service_action")
+    service_sub.add_parser("install", help="Install, enable, and start AINode service")
+    service_sub.add_parser("uninstall", help="Stop, disable, and remove AINode service")
+    service_sub.add_parser("status", help="Show AINode service status")
+    svc_logs_parser = service_sub.add_parser("logs", help="Show AINode service logs")
+    svc_logs_parser.add_argument("-n", "--lines", type=int, default=50, help="Number of log lines")
+    service_parser.set_defaults(func=cmd_service)
 
     # auth
     auth_parser = subparsers.add_parser("auth", help="Manage API key authentication")

--- a/ainode/cli/main.py
+++ b/ainode/cli/main.py
@@ -156,6 +156,79 @@ def cmd_models(args):
     print()
 
 
+def cmd_service(args):
+    """Manage AINode systemd service."""
+    from ainode.service.systemd import (
+        install_service,
+        enable_service,
+        start_service,
+        stop_service,
+        disable_service,
+        uninstall_service,
+        status_service,
+        get_journal_lines,
+        is_installed,
+    )
+
+    user_mode = getattr(args, "user", False)
+    action = getattr(args, "service_action", None)
+
+    if action == "install":
+        if is_installed(user_mode=user_mode):
+            console.print("  [yellow]AINode service is already installed.[/yellow]")
+        else:
+            console.print("  Installing AINode service...")
+            install_service(user_mode=user_mode)
+            console.print("  [green]✓[/green] Unit file written")
+        console.print("  Enabling service...")
+        enable_service(user_mode=user_mode)
+        console.print("  [green]✓[/green] Service enabled")
+        console.print("  Starting service...")
+        start_service(user_mode=user_mode)
+        console.print("  [green]✓[/green] Service started")
+        console.print()
+        console.print("  AINode will now start automatically on boot.")
+        console.print("  Powered by argentos.ai")
+
+    elif action == "uninstall":
+        if not is_installed(user_mode=user_mode):
+            console.print("  [yellow]AINode service is not installed.[/yellow]")
+            return
+        console.print("  Stopping and removing AINode service...")
+        uninstall_service(user_mode=user_mode)
+        console.print("  [green]✓[/green] Service removed")
+        console.print("  Powered by argentos.ai")
+
+    elif action == "status":
+        if not is_installed(user_mode=user_mode):
+            console.print("  AINode service: [dim]not installed[/dim]")
+            return
+        info = status_service(user_mode=user_mode)
+        state = info["state"]
+        color = {"active": "green", "inactive": "dim", "failed": "red"}.get(state, "yellow")
+        console.print(f"  AINode service: [{color}]{state}[/{color}]")
+        console.print(f"  Enabled: {'yes' if info['enabled'] else 'no'}")
+        if info["journal_lines"]:
+            console.print()
+            console.print("  Recent logs:")
+            for line in info["journal_lines"][-10:]:
+                console.print(f"    {line}")
+        console.print()
+        console.print("  Powered by argentos.ai")
+
+    elif action == "logs":
+        lines = getattr(args, "lines", 50)
+        journal = get_journal_lines(user_mode=user_mode, lines=lines)
+        if journal:
+            for line in journal:
+                console.print(line)
+        else:
+            console.print("  No journal entries found for AINode.")
+
+    else:
+        console.print("  Usage: ainode service {install|uninstall|status|logs}")
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="ainode",
@@ -182,6 +255,19 @@ def main():
     # models
     models_parser = subparsers.add_parser("models", help="List available models")
     models_parser.set_defaults(func=cmd_models)
+
+    # service
+    service_parser = subparsers.add_parser("service", help="Manage AINode systemd service")
+    service_parser.add_argument(
+        "--user", action="store_true", help="Use user-level systemd (no sudo required)"
+    )
+    service_sub = service_parser.add_subparsers(dest="service_action")
+    service_sub.add_parser("install", help="Install, enable, and start AINode service")
+    service_sub.add_parser("uninstall", help="Stop, disable, and remove AINode service")
+    service_sub.add_parser("status", help="Show AINode service status")
+    logs_parser = service_sub.add_parser("logs", help="Show AINode service logs")
+    logs_parser.add_argument("-n", "--lines", type=int, default=50, help="Number of log lines")
+    service_parser.set_defaults(func=cmd_service)
 
     args = parser.parse_args()
 

--- a/ainode/cli/main.py
+++ b/ainode/cli/main.py
@@ -431,6 +431,79 @@ def cmd_logs(args):
 # Entry point
 # ---------------------------------------------------------------------------
 
+def cmd_service(args):
+    """Manage AINode systemd service."""
+    from ainode.service.systemd import (
+        install_service,
+        enable_service,
+        start_service,
+        stop_service,
+        disable_service,
+        uninstall_service,
+        status_service,
+        get_journal_lines,
+        is_installed,
+    )
+
+    user_mode = getattr(args, "user", False)
+    action = getattr(args, "service_action", None)
+
+    if action == "install":
+        if is_installed(user_mode=user_mode):
+            console.print("  [yellow]AINode service is already installed.[/yellow]")
+        else:
+            console.print("  Installing AINode service...")
+            install_service(user_mode=user_mode)
+            console.print("  [green]✓[/green] Unit file written")
+        console.print("  Enabling service...")
+        enable_service(user_mode=user_mode)
+        console.print("  [green]✓[/green] Service enabled")
+        console.print("  Starting service...")
+        start_service(user_mode=user_mode)
+        console.print("  [green]✓[/green] Service started")
+        console.print()
+        console.print("  AINode will now start automatically on boot.")
+        console.print("  Powered by argentos.ai")
+
+    elif action == "uninstall":
+        if not is_installed(user_mode=user_mode):
+            console.print("  [yellow]AINode service is not installed.[/yellow]")
+            return
+        console.print("  Stopping and removing AINode service...")
+        uninstall_service(user_mode=user_mode)
+        console.print("  [green]✓[/green] Service removed")
+        console.print("  Powered by argentos.ai")
+
+    elif action == "status":
+        if not is_installed(user_mode=user_mode):
+            console.print("  AINode service: [dim]not installed[/dim]")
+            return
+        info = status_service(user_mode=user_mode)
+        state = info["state"]
+        color = {"active": "green", "inactive": "dim", "failed": "red"}.get(state, "yellow")
+        console.print(f"  AINode service: [{color}]{state}[/{color}]")
+        console.print(f"  Enabled: {'yes' if info['enabled'] else 'no'}")
+        if info["journal_lines"]:
+            console.print()
+            console.print("  Recent logs:")
+            for line in info["journal_lines"][-10:]:
+                console.print(f"    {line}")
+        console.print()
+        console.print("  Powered by argentos.ai")
+
+    elif action == "logs":
+        lines = getattr(args, "lines", 50)
+        journal = get_journal_lines(user_mode=user_mode, lines=lines)
+        if journal:
+            for line in journal:
+                console.print(line)
+        else:
+            console.print("  No journal entries found for AINode.")
+
+    else:
+        console.print("  Usage: ainode service {install|uninstall|status|logs}")
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="ainode",
@@ -470,6 +543,19 @@ def main():
     logs_parser.add_argument("--follow", "-f", action="store_true", help="Tail logs in real-time")
     logs_parser.add_argument("--lines", "-n", type=int, default=50, help="Number of lines to show (default: 50)")
     logs_parser.set_defaults(func=cmd_logs)
+
+    # service
+    service_parser = subparsers.add_parser("service", help="Manage AINode systemd service")
+    service_parser.add_argument(
+        "--user", action="store_true", help="Use user-level systemd (no sudo required)"
+    )
+    service_sub = service_parser.add_subparsers(dest="service_action")
+    service_sub.add_parser("install", help="Install, enable, and start AINode service")
+    service_sub.add_parser("uninstall", help="Stop, disable, and remove AINode service")
+    service_sub.add_parser("status", help="Show AINode service status")
+    svc_logs_parser = service_sub.add_parser("logs", help="Show AINode service logs")
+    svc_logs_parser.add_argument("-n", "--lines", type=int, default=50, help="Number of log lines")
+    service_parser.set_defaults(func=cmd_service)
 
     args = parser.parse_args()
 

--- a/ainode/cli/main.py
+++ b/ainode/cli/main.py
@@ -3,10 +3,30 @@
 import argparse
 import sys
 import uuid
+import time
+import threading
+
+from rich.console import Console
+from rich.live import Live
+from rich.spinner import Spinner
+from rich.text import Text
 
 from ainode import __version__
 from ainode.core.config import NodeConfig, ensure_dirs
 from ainode.core.gpu import gpu_summary, detect_gpu
+
+console = Console()
+
+
+def _tail_log(path, lines=10):
+    """Print the last N lines of a log file."""
+    try:
+        with open(path) as f:
+            all_lines = f.readlines()
+        for line in all_lines[-lines:]:
+            console.print(f"    {line.rstrip()}")
+    except Exception:
+        pass
 
 
 BANNER = """
@@ -46,30 +66,41 @@ def cmd_start(args):
     print()
 
     # Start vLLM engine
-    print(f"  Model: {config.model}")
-    print(f"  API:   http://localhost:{config.api_port}/v1")
-    print(f"  Web:   http://localhost:{config.web_port}")
-    print()
-    print("  Starting inference engine...")
+    console.print(f"  Model: {config.model}")
+    console.print(f"  API:   http://localhost:{config.api_port}/v1")
+    console.print(f"  Web:   http://localhost:{config.web_port}")
+    console.print()
 
     from ainode.engine.vllm_engine import VLLMEngine
 
     engine = VLLMEngine(config)
-    if engine.start():
-        print("  Engine started. Open your browser to get started.")
-        print()
-        print(f"  Powered by argentos.ai")
-        print()
-
-        # Keep running until interrupted
-        try:
-            engine.process.wait()
-        except KeyboardInterrupt:
-            print("\n  Shutting down...")
-            engine.stop()
-    else:
-        print("  Failed to start engine. Check logs in ~/.ainode/logs/")
+    if not engine.start():
+        console.print("  [red]Failed to start engine.[/red] Check logs in ~/.ainode/logs/")
         sys.exit(1)
+
+    # Wait for readiness with spinner and log tailing
+    with Live(Spinner("dots", text="Starting inference engine..."), console=console, transient=True):
+        ready = engine.wait_ready(timeout=300)
+
+    if not ready:
+        console.print("  [red]Engine failed to become ready within 5 minutes.[/red]")
+        if engine.log_path and engine.log_path.exists():
+            console.print(f"  Last log lines:")
+            _tail_log(engine.log_path, lines=10)
+        engine.stop()
+        sys.exit(1)
+
+    console.print("  [green]Engine ready.[/green] Open your browser to get started.")
+    console.print()
+    console.print("  Powered by argentos.ai")
+    console.print()
+
+    # Keep running until interrupted
+    try:
+        engine.process.wait()
+    except KeyboardInterrupt:
+        console.print("\n  Shutting down...")
+        engine.stop()
 
 
 def cmd_stop(args):
@@ -82,14 +113,29 @@ def cmd_stop(args):
 def cmd_status(args):
     """Show cluster status."""
     print(BANNER)
-    print(f"  GPU: {gpu_summary()}")
+    console.print(f"  GPU: {gpu_summary()}")
 
     config = NodeConfig.load()
-    print(f"  Node ID: {config.node_id or 'not configured'}")
-    print(f"  Model: {config.model}")
-    print(f"  API: http://localhost:{config.api_port}/v1")
-    print(f"  Email: {config.email or 'not set'}")
-    print()
+    console.print(f"  Node ID: {config.node_id or 'not configured'}")
+    console.print(f"  Model: {config.model}")
+    console.print(f"  API: http://localhost:{config.api_port}/v1")
+    console.print(f"  Email: {config.email or 'not set'}")
+    console.print()
+
+    # Engine health check
+    from ainode.engine.vllm_engine import VLLMEngine
+    engine = VLLMEngine(config)
+    health = engine.health_check()
+
+    if health["api_responding"]:
+        console.print("  Engine: [green]running[/green]")
+        if health["models_loaded"]:
+            console.print(f"  Models: {', '.join(health['models_loaded'])}")
+    elif health["process_alive"]:
+        console.print("  Engine: [yellow]starting[/yellow] (process alive, API not ready)")
+    else:
+        console.print("  Engine: [red]stopped[/red]")
+    console.print()
 
 
 def cmd_models(args):

--- a/ainode/cli/main.py
+++ b/ainode/cli/main.py
@@ -1,48 +1,135 @@
-"""AINode CLI — main entry point."""
+"""AINode CLI — main entry point with Rich terminal output."""
 
 import argparse
+import os
+import signal
 import sys
-import uuid
 import time
-import threading
+import uuid
 
 from rich.console import Console
 from rich.live import Live
+from rich.panel import Panel
 from rich.spinner import Spinner
+from rich.table import Table
 from rich.text import Text
 
 from ainode import __version__
-from ainode.core.config import NodeConfig, ensure_dirs
-from ainode.core.gpu import gpu_summary, detect_gpu
+from ainode.core.config import NodeConfig, ensure_dirs, AINODE_HOME, LOGS_DIR
 
 console = Console()
 
+PID_FILE = AINODE_HOME / "ainode.pid"
+VLLM_LOG = LOGS_DIR / "vllm.log"
 
-def _tail_log(path, lines=10):
-    """Print the last N lines of a log file."""
+
+# ---------------------------------------------------------------------------
+# Banner
+# ---------------------------------------------------------------------------
+
+def _banner():
+    """Return a Rich Panel banner for AINode."""
+    title_text = Text()
+    title_text.append("A", style="bold cyan")
+    title_text.append("I", style="bold cyan")
+    title_text.append("N", style="bold cyan")
+    title_text.append("ode", style="bold white")
+    title_text.append("  v" + __version__, style="dim")
+
+    body = Text.from_markup(
+        "[bold white]Turn any NVIDIA GPU into a local AI platform[/bold white]\n"
+        "[dim]Inference + fine-tuning in your browser. One command to start.[/dim]"
+    )
+
+    return Panel(
+        body,
+        title=title_text,
+        subtitle="[dim italic]Powered by argentos.ai[/dim italic]",
+        border_style="cyan",
+        padding=(1, 4),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_pid():
+    """Write current PID to the PID file."""
+    AINODE_HOME.mkdir(parents=True, exist_ok=True)
+    PID_FILE.write_text(str(os.getpid()))
+
+
+def _read_pid():
+    """Read PID from file, return int or None."""
     try:
-        with open(path) as f:
-            all_lines = f.readlines()
-        for line in all_lines[-lines:]:
-            console.print(f"    {line.rstrip()}")
+        return int(PID_FILE.read_text().strip())
+    except Exception:
+        return None
+
+
+def _remove_pid():
+    """Remove the PID file."""
+    try:
+        PID_FILE.unlink(missing_ok=True)
     except Exception:
         pass
 
 
-BANNER = """
-    ╔══════════════════════════════════════╗
-    ║            A I N o d e               ║
-    ║   Your local AI platform for NVIDIA  ║
-    ╚══════════════════════════════════════╝
-"""
+def _pid_alive(pid):
+    """Check if a PID is alive."""
+    if pid is None:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except (OSError, ProcessLookupError):
+        return False
 
+
+def _tail_log(path, lines=10):
+    """Return the last N lines of a log file."""
+    try:
+        with open(path) as f:
+            all_lines = f.readlines()
+        return all_lines[-lines:]
+    except Exception:
+        return []
+
+
+def _gpu_info_table(gpu):
+    """Build a Rich table for GPU info."""
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("key", style="bold cyan", no_wrap=True)
+    table.add_column("value")
+
+    mem_gb = gpu.memory_total_mb / 1024
+    um = " (unified memory)" if gpu.unified_memory else ""
+    table.add_row("GPU", f"{gpu.name} | {mem_gb:.0f} GB{um}")
+    table.add_row("CUDA", f"{gpu.cuda_version} | Driver {gpu.driver_version}")
+    table.add_row("Compute", f"SM {gpu.compute_capability}")
+    return table
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
 
 def cmd_start(args):
     """Start AINode."""
-    print(BANNER)
+    from ainode.core.gpu import gpu_summary, detect_gpu
+    console.print(_banner())
     ensure_dirs()
 
     config = NodeConfig.load()
+
+    # Override from CLI flags
+    if hasattr(args, "model") and args.model:
+        config.model = args.model
+        config.save()
+    if hasattr(args, "port") and args.port:
+        config.api_port = args.port
+        config.save()
 
     # First run — onboarding
     if not config.onboarded:
@@ -57,69 +144,139 @@ def cmd_start(args):
     # Detect GPU
     gpu = detect_gpu()
     if gpu:
-        mem_gb = gpu.memory_total_mb / 1024
-        um = " (unified memory)" if gpu.unified_memory else ""
-        print(f"  GPU:   {gpu.name} | {mem_gb:.0f} GB{um}")
-        print(f"  CUDA:  {gpu.cuda_version} | Driver {gpu.driver_version}")
+        console.print(_gpu_info_table(gpu))
     else:
-        print("  GPU:   No NVIDIA GPU detected (CPU mode)")
-    print()
-
-    # Start vLLM engine
-    console.print(f"  Model: {config.model}")
-    console.print(f"  API:   http://localhost:{config.api_port}/v1")
-    console.print(f"  Web:   http://localhost:{config.web_port}")
+        console.print("  [yellow]No NVIDIA GPU detected[/yellow] — running in CPU mode")
     console.print()
 
+    # Service info
+    info_table = Table(show_header=False, box=None, padding=(0, 2))
+    info_table.add_column("key", style="bold green", no_wrap=True)
+    info_table.add_column("value")
+    info_table.add_row("Model", config.model)
+    info_table.add_row("API", f"http://localhost:{config.api_port}/v1")
+    info_table.add_row("Web", f"http://localhost:{config.web_port}")
+    info_table.add_row("Node", config.node_id or "pending")
+    console.print(info_table)
+    console.print()
+
+    # Write PID file
+    _write_pid()
+
+    # Start vLLM engine
     from ainode.engine.vllm_engine import VLLMEngine
 
     engine = VLLMEngine(config)
     if not engine.start():
         console.print("  [red]Failed to start engine.[/red] Check logs in ~/.ainode/logs/")
+        _remove_pid()
         sys.exit(1)
 
-    # Wait for readiness with spinner and log tailing
+    # Wait for readiness with spinner
     with Live(Spinner("dots", text="Starting inference engine..."), console=console, transient=True):
         ready = engine.wait_ready(timeout=300)
 
     if not ready:
         console.print("  [red]Engine failed to become ready within 5 minutes.[/red]")
         if engine.log_path and engine.log_path.exists():
-            console.print(f"  Last log lines:")
-            _tail_log(engine.log_path, lines=10)
+            console.print("  [dim]Last log lines:[/dim]")
+            for line in _tail_log(engine.log_path, lines=10):
+                console.print(f"    [dim]{line.rstrip()}[/dim]")
         engine.stop()
+        _remove_pid()
         sys.exit(1)
 
-    console.print("  [green]Engine ready.[/green] Open your browser to get started.")
-    console.print()
-    console.print("  Powered by argentos.ai")
-    console.print()
+    console.print("  [bold green]Engine ready.[/bold green] Open your browser to get started.\n")
 
     # Keep running until interrupted
     try:
         engine.process.wait()
     except KeyboardInterrupt:
-        console.print("\n  Shutting down...")
+        console.print("\n  [yellow]Shutting down...[/yellow]")
         engine.stop()
+    finally:
+        _remove_pid()
 
 
 def cmd_stop(args):
-    """Stop AINode."""
-    print("Stopping AINode...")
-    # TODO: Signal running instance to stop
-    print("Done.")
+    """Stop a running AINode instance."""
+    console.print(_banner())
+
+    pid = _read_pid()
+
+    if pid and _pid_alive(pid):
+        console.print(f"  Stopping AINode (PID {pid})...")
+        try:
+            os.kill(pid, signal.SIGTERM)
+            # Wait up to 10 seconds for graceful shutdown
+            for _ in range(20):
+                if not _pid_alive(pid):
+                    break
+                time.sleep(0.5)
+            else:
+                # Force kill if still alive
+                console.print("  [yellow]Process did not exit gracefully, sending SIGKILL...[/yellow]")
+                os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        _remove_pid()
+        console.print("  [green]AINode stopped.[/green]\n")
+        return
+
+    # No PID file or stale PID — try to find the process
+    _remove_pid()
+
+    # Fallback: check for python processes running ainode
+    import subprocess
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", "ainode.cli.main|ainode start"],
+            capture_output=True, text=True
+        )
+        pids = [int(p) for p in result.stdout.strip().split("\n") if p.strip() and int(p) != os.getpid()]
+    except Exception:
+        pids = []
+
+    if pids:
+        for p in pids:
+            console.print(f"  Stopping AINode process (PID {p})...")
+            try:
+                os.kill(p, signal.SIGTERM)
+            except (OSError, ProcessLookupError):
+                pass
+        console.print("  [green]AINode stopped.[/green]\n")
+    else:
+        console.print("  [dim]No running AINode instance found.[/dim]\n")
 
 
 def cmd_status(args):
-    """Show cluster status."""
-    print(BANNER)
-    console.print(f"  GPU: {gpu_summary()}")
+    """Show cluster status with Rich formatting."""
+    from ainode.core.gpu import gpu_summary, detect_gpu
+    console.print(_banner())
 
     config = NodeConfig.load()
-    console.print(f"  Node ID: {config.node_id or 'not configured'}")
-    console.print(f"  Model: {config.model}")
-    console.print(f"  API: http://localhost:{config.api_port}/v1")
-    console.print(f"  Email: {config.email or 'not set'}")
+    gpu = detect_gpu()
+
+    # Node info table
+    table = Table(title="Node Info", border_style="cyan", show_lines=False)
+    table.add_column("Property", style="bold cyan", no_wrap=True)
+    table.add_column("Value")
+
+    table.add_row("Node ID", config.node_id or "[dim]not configured[/dim]")
+    table.add_row("Model", config.model)
+    table.add_row("API", f"http://localhost:{config.api_port}/v1")
+    table.add_row("Web", f"http://localhost:{config.web_port}")
+    table.add_row("Email", config.email or "[dim]not set[/dim]")
+
+    if gpu:
+        mem_gb = gpu.memory_total_mb / 1024
+        um = " (unified)" if gpu.unified_memory else ""
+        table.add_row("GPU", f"{gpu.name} | {mem_gb:.0f} GB{um}")
+        table.add_row("CUDA", f"{gpu.cuda_version} | Driver {gpu.driver_version}")
+    else:
+        table.add_row("GPU", "[yellow]No NVIDIA GPU detected[/yellow]")
+
+    console.print(table)
     console.print()
 
     # Engine health check
@@ -128,19 +285,29 @@ def cmd_status(args):
     health = engine.health_check()
 
     if health["api_responding"]:
-        console.print("  Engine: [green]running[/green]")
+        console.print("  Engine:  [bold green]running[/bold green]")
         if health["models_loaded"]:
-            console.print(f"  Models: {', '.join(health['models_loaded'])}")
+            console.print(f"  Models:  {', '.join(health['models_loaded'])}")
     elif health["process_alive"]:
-        console.print("  Engine: [yellow]starting[/yellow] (process alive, API not ready)")
+        console.print("  Engine:  [bold yellow]starting[/bold yellow] (process alive, API not ready)")
     else:
-        console.print("  Engine: [red]stopped[/red]")
+        console.print("  Engine:  [bold red]stopped[/bold red]")
+
+    # PID file status
+    pid = _read_pid()
+    if pid and _pid_alive(pid):
+        console.print(f"  PID:     {pid}")
     console.print()
 
 
 def cmd_models(args):
-    """List available models."""
-    print("Popular models for AINode:\n")
+    """List available models with Rich table and GPU-aware recommendations."""
+    from ainode.core.gpu import detect_gpu
+    console.print(_banner())
+
+    gpu = detect_gpu()
+    gpu_mem_gb = (gpu.memory_total_mb / 1024) if gpu else 0
+
     models = [
         ("llama-3.2-3b", "Llama 3.2 3B Instruct", "~6 GB", "Quick start"),
         ("llama-3.1-8b", "Llama 3.1 8B Instruct", "~16 GB", "Recommended"),
@@ -148,18 +315,126 @@ def cmd_models(args):
         ("qwen-2.5-72b", "Qwen 2.5 72B Instruct", "~40 GB", "Coding + multilingual"),
         ("deepseek-r1-7b", "DeepSeek R1 Distill 7B", "~14 GB", "Reasoning"),
     ]
-    for short, name, mem, note in models:
-        print(f"  {short:<25} {mem:<10} {note}")
-    print()
-    print("  Set model: ainode config --model <name>")
-    print("  Full list: https://ainode.dev/models")
-    print()
 
+    # Memory thresholds for recommendations
+    mem_thresholds = {
+        "~6 GB": 6,
+        "~14 GB": 14,
+        "~16 GB": 16,
+        "~35 GB": 35,
+        "~40 GB": 40,
+    }
+
+    table = Table(title="Available Models", border_style="cyan")
+    table.add_column("Name", style="bold white", no_wrap=True)
+    table.add_column("Size", justify="right")
+    table.add_column("Description")
+    table.add_column("Tag")
+
+    for short, name, mem, note in models:
+        threshold = mem_thresholds.get(mem, 999)
+        fits = gpu_mem_gb >= threshold
+
+        if note == "Recommended":
+            tag_style = "bold green" if fits else "dim green"
+        elif fits:
+            tag_style = "green"
+        else:
+            tag_style = "dim red"
+
+        tag = Text(note, style=tag_style)
+        if not fits and gpu_mem_gb > 0:
+            tag.append(" (needs more VRAM)", style="dim")
+
+        table.add_row(short, mem, name, tag)
+
+    console.print(table)
+    console.print()
+    console.print("  Set model:  [bold]ainode config --model <name>[/bold]")
+    console.print("  Full list:  [link=https://ainode.dev/models]https://ainode.dev/models[/link]")
+    console.print()
+
+
+def cmd_config(args):
+    """Show or update AINode configuration."""
+    config = NodeConfig.load()
+
+    if args.model:
+        config.model = args.model
+        config.save()
+        console.print(f"  [green]Model set to:[/green] {args.model}")
+        return
+
+    if args.port:
+        config.api_port = args.port
+        config.save()
+        console.print(f"  [green]API port set to:[/green] {args.port}")
+        return
+
+    # Default: --show
+    console.print(_banner())
+
+    from dataclasses import asdict
+    data = asdict(config)
+
+    table = Table(title="Configuration", border_style="cyan")
+    table.add_column("Key", style="bold cyan", no_wrap=True)
+    table.add_column("Value")
+
+    for key, value in data.items():
+        display = str(value) if value is not None else "[dim]not set[/dim]"
+        table.add_row(key, display)
+
+    console.print(table)
+    console.print()
+    console.print(f"  Config file: [dim]{AINODE_HOME / 'config.json'}[/dim]")
+    console.print()
+
+
+def cmd_logs(args):
+    """Show or tail vLLM logs."""
+    log_file = VLLM_LOG
+
+    if not log_file.exists():
+        console.print("  [dim]No log file found at[/dim] ~/.ainode/logs/vllm.log")
+        console.print("  [dim]Start AINode first: [bold]ainode start[/bold][/dim]")
+        return
+
+    if args.follow:
+        console.print(f"  [dim]Tailing {log_file} (Ctrl+C to stop)[/dim]\n")
+        try:
+            import subprocess
+            proc = subprocess.Popen(
+                ["tail", "-f", str(log_file)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            for line in proc.stdout:
+                console.print(line.rstrip())
+        except KeyboardInterrupt:
+            console.print("\n  [dim]Stopped tailing.[/dim]")
+            if proc:
+                proc.terminate()
+    else:
+        lines = _tail_log(log_file, lines=args.lines)
+        if not lines:
+            console.print("  [dim]Log file is empty.[/dim]")
+            return
+        console.print(f"  [dim]Last {len(lines)} lines of {log_file}:[/dim]\n")
+        for line in lines:
+            console.print(f"  {line.rstrip()}")
+        console.print()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
 
 def main():
     parser = argparse.ArgumentParser(
         prog="ainode",
-        description="AINode — Turn any NVIDIA GPU into a local AI platform.",
+        description="AINode -- Turn any NVIDIA GPU into a local AI platform.",
     )
     parser.add_argument("--version", action="version", version=f"ainode {__version__}")
 
@@ -182,6 +457,19 @@ def main():
     # models
     models_parser = subparsers.add_parser("models", help="List available models")
     models_parser.set_defaults(func=cmd_models)
+
+    # config
+    config_parser = subparsers.add_parser("config", help="Show or update configuration")
+    config_parser.add_argument("--show", action="store_true", default=True, help="Show current config")
+    config_parser.add_argument("--model", help="Set the model")
+    config_parser.add_argument("--port", type=int, help="Set the API port")
+    config_parser.set_defaults(func=cmd_config)
+
+    # logs
+    logs_parser = subparsers.add_parser("logs", help="Show vLLM logs")
+    logs_parser.add_argument("--follow", "-f", action="store_true", help="Tail logs in real-time")
+    logs_parser.add_argument("--lines", "-n", type=int, default=50, help="Number of lines to show (default: 50)")
+    logs_parser.set_defaults(func=cmd_logs)
 
     args = parser.parse_args()
 

--- a/ainode/cli/main.py
+++ b/ainode/cli/main.py
@@ -1,48 +1,135 @@
-"""AINode CLI — main entry point."""
+"""AINode CLI — main entry point with Rich terminal output."""
 
 import argparse
+import os
+import signal
 import sys
-import uuid
 import time
-import threading
+import uuid
 
 from rich.console import Console
 from rich.live import Live
+from rich.panel import Panel
 from rich.spinner import Spinner
+from rich.table import Table
 from rich.text import Text
 
 from ainode import __version__
-from ainode.core.config import NodeConfig, ensure_dirs
-from ainode.core.gpu import gpu_summary, detect_gpu
+from ainode.core.config import NodeConfig, ensure_dirs, AINODE_HOME, LOGS_DIR
 
 console = Console()
 
+PID_FILE = AINODE_HOME / "ainode.pid"
+VLLM_LOG = LOGS_DIR / "vllm.log"
 
-def _tail_log(path, lines=10):
-    """Print the last N lines of a log file."""
+
+# ---------------------------------------------------------------------------
+# Banner
+# ---------------------------------------------------------------------------
+
+def _banner():
+    """Return a Rich Panel banner for AINode."""
+    title_text = Text()
+    title_text.append("A", style="bold cyan")
+    title_text.append("I", style="bold cyan")
+    title_text.append("N", style="bold cyan")
+    title_text.append("ode", style="bold white")
+    title_text.append("  v" + __version__, style="dim")
+
+    body = Text.from_markup(
+        "[bold white]Turn any NVIDIA GPU into a local AI platform[/bold white]\n"
+        "[dim]Inference + fine-tuning in your browser. One command to start.[/dim]"
+    )
+
+    return Panel(
+        body,
+        title=title_text,
+        subtitle="[dim italic]Powered by argentos.ai[/dim italic]",
+        border_style="cyan",
+        padding=(1, 4),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_pid():
+    """Write current PID to the PID file."""
+    AINODE_HOME.mkdir(parents=True, exist_ok=True)
+    PID_FILE.write_text(str(os.getpid()))
+
+
+def _read_pid():
+    """Read PID from file, return int or None."""
     try:
-        with open(path) as f:
-            all_lines = f.readlines()
-        for line in all_lines[-lines:]:
-            console.print(f"    {line.rstrip()}")
+        return int(PID_FILE.read_text().strip())
+    except Exception:
+        return None
+
+
+def _remove_pid():
+    """Remove the PID file."""
+    try:
+        PID_FILE.unlink(missing_ok=True)
     except Exception:
         pass
 
 
-BANNER = """
-    ╔══════════════════════════════════════╗
-    ║            A I N o d e               ║
-    ║   Your local AI platform for NVIDIA  ║
-    ╚══════════════════════════════════════╝
-"""
+def _pid_alive(pid):
+    """Check if a PID is alive."""
+    if pid is None:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except (OSError, ProcessLookupError):
+        return False
 
+
+def _tail_log(path, lines=10):
+    """Return the last N lines of a log file."""
+    try:
+        with open(path) as f:
+            all_lines = f.readlines()
+        return all_lines[-lines:]
+    except Exception:
+        return []
+
+
+def _gpu_info_table(gpu):
+    """Build a Rich table for GPU info."""
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("key", style="bold cyan", no_wrap=True)
+    table.add_column("value")
+
+    mem_gb = gpu.memory_total_mb / 1024
+    um = " (unified memory)" if gpu.unified_memory else ""
+    table.add_row("GPU", f"{gpu.name} | {mem_gb:.0f} GB{um}")
+    table.add_row("CUDA", f"{gpu.cuda_version} | Driver {gpu.driver_version}")
+    table.add_row("Compute", f"SM {gpu.compute_capability}")
+    return table
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
 
 def cmd_start(args):
     """Start AINode."""
-    print(BANNER)
+    from ainode.core.gpu import gpu_summary, detect_gpu
+    console.print(_banner())
     ensure_dirs()
 
     config = NodeConfig.load()
+
+    # Override from CLI flags
+    if hasattr(args, "model") and args.model:
+        config.model = args.model
+        config.save()
+    if hasattr(args, "port") and args.port:
+        config.api_port = args.port
+        config.save()
 
     # First run — onboarding
     if not config.onboarded:
@@ -57,69 +144,139 @@ def cmd_start(args):
     # Detect GPU
     gpu = detect_gpu()
     if gpu:
-        mem_gb = gpu.memory_total_mb / 1024
-        um = " (unified memory)" if gpu.unified_memory else ""
-        print(f"  GPU:   {gpu.name} | {mem_gb:.0f} GB{um}")
-        print(f"  CUDA:  {gpu.cuda_version} | Driver {gpu.driver_version}")
+        console.print(_gpu_info_table(gpu))
     else:
-        print("  GPU:   No NVIDIA GPU detected (CPU mode)")
-    print()
-
-    # Start vLLM engine
-    console.print(f"  Model: {config.model}")
-    console.print(f"  API:   http://localhost:{config.api_port}/v1")
-    console.print(f"  Web:   http://localhost:{config.web_port}")
+        console.print("  [yellow]No NVIDIA GPU detected[/yellow] — running in CPU mode")
     console.print()
 
+    # Service info
+    info_table = Table(show_header=False, box=None, padding=(0, 2))
+    info_table.add_column("key", style="bold green", no_wrap=True)
+    info_table.add_column("value")
+    info_table.add_row("Model", config.model)
+    info_table.add_row("API", f"http://localhost:{config.api_port}/v1")
+    info_table.add_row("Web", f"http://localhost:{config.web_port}")
+    info_table.add_row("Node", config.node_id or "pending")
+    console.print(info_table)
+    console.print()
+
+    # Write PID file
+    _write_pid()
+
+    # Start vLLM engine
     from ainode.engine.vllm_engine import VLLMEngine
 
     engine = VLLMEngine(config)
     if not engine.start():
         console.print("  [red]Failed to start engine.[/red] Check logs in ~/.ainode/logs/")
+        _remove_pid()
         sys.exit(1)
 
-    # Wait for readiness with spinner and log tailing
+    # Wait for readiness with spinner
     with Live(Spinner("dots", text="Starting inference engine..."), console=console, transient=True):
         ready = engine.wait_ready(timeout=300)
 
     if not ready:
         console.print("  [red]Engine failed to become ready within 5 minutes.[/red]")
         if engine.log_path and engine.log_path.exists():
-            console.print(f"  Last log lines:")
-            _tail_log(engine.log_path, lines=10)
+            console.print("  [dim]Last log lines:[/dim]")
+            for line in _tail_log(engine.log_path, lines=10):
+                console.print(f"    [dim]{line.rstrip()}[/dim]")
         engine.stop()
+        _remove_pid()
         sys.exit(1)
 
-    console.print("  [green]Engine ready.[/green] Open your browser to get started.")
-    console.print()
-    console.print("  Powered by argentos.ai")
-    console.print()
+    console.print("  [bold green]Engine ready.[/bold green] Open your browser to get started.\n")
 
     # Keep running until interrupted
     try:
         engine.process.wait()
     except KeyboardInterrupt:
-        console.print("\n  Shutting down...")
+        console.print("\n  [yellow]Shutting down...[/yellow]")
         engine.stop()
+    finally:
+        _remove_pid()
 
 
 def cmd_stop(args):
-    """Stop AINode."""
-    print("Stopping AINode...")
-    # TODO: Signal running instance to stop
-    print("Done.")
+    """Stop a running AINode instance."""
+    console.print(_banner())
+
+    pid = _read_pid()
+
+    if pid and _pid_alive(pid):
+        console.print(f"  Stopping AINode (PID {pid})...")
+        try:
+            os.kill(pid, signal.SIGTERM)
+            # Wait up to 10 seconds for graceful shutdown
+            for _ in range(20):
+                if not _pid_alive(pid):
+                    break
+                time.sleep(0.5)
+            else:
+                # Force kill if still alive
+                console.print("  [yellow]Process did not exit gracefully, sending SIGKILL...[/yellow]")
+                os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        _remove_pid()
+        console.print("  [green]AINode stopped.[/green]\n")
+        return
+
+    # No PID file or stale PID — try to find the process
+    _remove_pid()
+
+    # Fallback: check for python processes running ainode
+    import subprocess
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", "ainode.cli.main|ainode start"],
+            capture_output=True, text=True
+        )
+        pids = [int(p) for p in result.stdout.strip().split("\n") if p.strip() and int(p) != os.getpid()]
+    except Exception:
+        pids = []
+
+    if pids:
+        for p in pids:
+            console.print(f"  Stopping AINode process (PID {p})...")
+            try:
+                os.kill(p, signal.SIGTERM)
+            except (OSError, ProcessLookupError):
+                pass
+        console.print("  [green]AINode stopped.[/green]\n")
+    else:
+        console.print("  [dim]No running AINode instance found.[/dim]\n")
 
 
 def cmd_status(args):
-    """Show cluster status."""
-    print(BANNER)
-    console.print(f"  GPU: {gpu_summary()}")
+    """Show cluster status with Rich formatting."""
+    from ainode.core.gpu import gpu_summary, detect_gpu
+    console.print(_banner())
 
     config = NodeConfig.load()
-    console.print(f"  Node ID: {config.node_id or 'not configured'}")
-    console.print(f"  Model: {config.model}")
-    console.print(f"  API: http://localhost:{config.api_port}/v1")
-    console.print(f"  Email: {config.email or 'not set'}")
+    gpu = detect_gpu()
+
+    # Node info table
+    table = Table(title="Node Info", border_style="cyan", show_lines=False)
+    table.add_column("Property", style="bold cyan", no_wrap=True)
+    table.add_column("Value")
+
+    table.add_row("Node ID", config.node_id or "[dim]not configured[/dim]")
+    table.add_row("Model", config.model)
+    table.add_row("API", f"http://localhost:{config.api_port}/v1")
+    table.add_row("Web", f"http://localhost:{config.web_port}")
+    table.add_row("Email", config.email or "[dim]not set[/dim]")
+
+    if gpu:
+        mem_gb = gpu.memory_total_mb / 1024
+        um = " (unified)" if gpu.unified_memory else ""
+        table.add_row("GPU", f"{gpu.name} | {mem_gb:.0f} GB{um}")
+        table.add_row("CUDA", f"{gpu.cuda_version} | Driver {gpu.driver_version}")
+    else:
+        table.add_row("GPU", "[yellow]No NVIDIA GPU detected[/yellow]")
+
+    console.print(table)
     console.print()
 
     # Engine health check
@@ -128,19 +285,29 @@ def cmd_status(args):
     health = engine.health_check()
 
     if health["api_responding"]:
-        console.print("  Engine: [green]running[/green]")
+        console.print("  Engine:  [bold green]running[/bold green]")
         if health["models_loaded"]:
-            console.print(f"  Models: {', '.join(health['models_loaded'])}")
+            console.print(f"  Models:  {', '.join(health['models_loaded'])}")
     elif health["process_alive"]:
-        console.print("  Engine: [yellow]starting[/yellow] (process alive, API not ready)")
+        console.print("  Engine:  [bold yellow]starting[/bold yellow] (process alive, API not ready)")
     else:
-        console.print("  Engine: [red]stopped[/red]")
+        console.print("  Engine:  [bold red]stopped[/bold red]")
+
+    # PID file status
+    pid = _read_pid()
+    if pid and _pid_alive(pid):
+        console.print(f"  PID:     {pid}")
     console.print()
 
 
 def cmd_models(args):
-    """List available models."""
-    print("Popular models for AINode:\n")
+    """List available models with Rich table and GPU-aware recommendations."""
+    from ainode.core.gpu import detect_gpu
+    console.print(_banner())
+
+    gpu = detect_gpu()
+    gpu_mem_gb = (gpu.memory_total_mb / 1024) if gpu else 0
+
     models = [
         ("llama-3.2-3b", "Llama 3.2 3B Instruct", "~6 GB", "Quick start"),
         ("llama-3.1-8b", "Llama 3.1 8B Instruct", "~16 GB", "Recommended"),
@@ -148,13 +315,121 @@ def cmd_models(args):
         ("qwen-2.5-72b", "Qwen 2.5 72B Instruct", "~40 GB", "Coding + multilingual"),
         ("deepseek-r1-7b", "DeepSeek R1 Distill 7B", "~14 GB", "Reasoning"),
     ]
-    for short, name, mem, note in models:
-        print(f"  {short:<25} {mem:<10} {note}")
-    print()
-    print("  Set model: ainode config --model <name>")
-    print("  Full list: https://ainode.dev/models")
-    print()
 
+    # Memory thresholds for recommendations
+    mem_thresholds = {
+        "~6 GB": 6,
+        "~14 GB": 14,
+        "~16 GB": 16,
+        "~35 GB": 35,
+        "~40 GB": 40,
+    }
+
+    table = Table(title="Available Models", border_style="cyan")
+    table.add_column("Name", style="bold white", no_wrap=True)
+    table.add_column("Size", justify="right")
+    table.add_column("Description")
+    table.add_column("Tag")
+
+    for short, name, mem, note in models:
+        threshold = mem_thresholds.get(mem, 999)
+        fits = gpu_mem_gb >= threshold
+
+        if note == "Recommended":
+            tag_style = "bold green" if fits else "dim green"
+        elif fits:
+            tag_style = "green"
+        else:
+            tag_style = "dim red"
+
+        tag = Text(note, style=tag_style)
+        if not fits and gpu_mem_gb > 0:
+            tag.append(" (needs more VRAM)", style="dim")
+
+        table.add_row(short, mem, name, tag)
+
+    console.print(table)
+    console.print()
+    console.print("  Set model:  [bold]ainode config --model <name>[/bold]")
+    console.print("  Full list:  [link=https://ainode.dev/models]https://ainode.dev/models[/link]")
+    console.print()
+
+
+def cmd_config(args):
+    """Show or update AINode configuration."""
+    config = NodeConfig.load()
+
+    if args.model:
+        config.model = args.model
+        config.save()
+        console.print(f"  [green]Model set to:[/green] {args.model}")
+        return
+
+    if args.port:
+        config.api_port = args.port
+        config.save()
+        console.print(f"  [green]API port set to:[/green] {args.port}")
+        return
+
+    # Default: --show
+    console.print(_banner())
+
+    from dataclasses import asdict
+    data = asdict(config)
+
+    table = Table(title="Configuration", border_style="cyan")
+    table.add_column("Key", style="bold cyan", no_wrap=True)
+    table.add_column("Value")
+
+    for key, value in data.items():
+        display = str(value) if value is not None else "[dim]not set[/dim]"
+        table.add_row(key, display)
+
+    console.print(table)
+    console.print()
+    console.print(f"  Config file: [dim]{AINODE_HOME / 'config.json'}[/dim]")
+    console.print()
+
+
+def cmd_logs(args):
+    """Show or tail vLLM logs."""
+    log_file = VLLM_LOG
+
+    if not log_file.exists():
+        console.print("  [dim]No log file found at[/dim] ~/.ainode/logs/vllm.log")
+        console.print("  [dim]Start AINode first: [bold]ainode start[/bold][/dim]")
+        return
+
+    if args.follow:
+        console.print(f"  [dim]Tailing {log_file} (Ctrl+C to stop)[/dim]\n")
+        try:
+            import subprocess
+            proc = subprocess.Popen(
+                ["tail", "-f", str(log_file)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            for line in proc.stdout:
+                console.print(line.rstrip())
+        except KeyboardInterrupt:
+            console.print("\n  [dim]Stopped tailing.[/dim]")
+            if proc:
+                proc.terminate()
+    else:
+        lines = _tail_log(log_file, lines=args.lines)
+        if not lines:
+            console.print("  [dim]Log file is empty.[/dim]")
+            return
+        console.print(f"  [dim]Last {len(lines)} lines of {log_file}:[/dim]\n")
+        for line in lines:
+            console.print(f"  {line.rstrip()}")
+        console.print()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
 
 def cmd_service(args):
     """Manage AINode systemd service."""
@@ -229,48 +504,10 @@ def cmd_service(args):
         console.print("  Usage: ainode service {install|uninstall|status|logs}")
 
 
-def cmd_auth(args):
-    """Manage API key authentication."""
-    from ainode.auth.middleware import AuthConfig
-
-    action = getattr(args, "auth_action", None)
-    auth_cfg = AuthConfig.load()
-
-    if action == "enable":
-        entry = auth_cfg.enable()
-        console.print("  [green]Auth enabled.[/green]")
-        console.print(f"  API key: {entry['key']}")
-        console.print(f"  Key ID:  {entry['id']}")
-        console.print()
-        console.print("  Use: Authorization: Bearer <key>")
-        console.print("  Powered by argentos.ai")
-
-    elif action == "disable":
-        auth_cfg.disable()
-        console.print("  [yellow]Auth disabled.[/yellow] All requests allowed.")
-        console.print("  Powered by argentos.ai")
-
-    elif action == "status":
-        state = "[green]enabled[/green]" if auth_cfg.enabled else "[dim]disabled[/dim]"
-        console.print(f"  Auth: {state}")
-        console.print(f"  Keys: {len(auth_cfg.api_keys)}")
-        console.print("  Powered by argentos.ai")
-
-    elif action == "new-key":
-        entry = auth_cfg.generate_key()
-        console.print("  [green]New API key generated.[/green]")
-        console.print(f"  API key: {entry['key']}")
-        console.print(f"  Key ID:  {entry['id']}")
-        console.print("  Powered by argentos.ai")
-
-    else:
-        console.print("  Usage: ainode auth {enable|disable|status|new-key}")
-
-
 def main():
     parser = argparse.ArgumentParser(
         prog="ainode",
-        description="AINode — Turn any NVIDIA GPU into a local AI platform.",
+        description="AINode -- Turn any NVIDIA GPU into a local AI platform.",
     )
     parser.add_argument("--version", action="version", version=f"ainode {__version__}")
 
@@ -294,6 +531,19 @@ def main():
     models_parser = subparsers.add_parser("models", help="List available models")
     models_parser.set_defaults(func=cmd_models)
 
+    # config
+    config_parser = subparsers.add_parser("config", help="Show or update configuration")
+    config_parser.add_argument("--show", action="store_true", default=True, help="Show current config")
+    config_parser.add_argument("--model", help="Set the model")
+    config_parser.add_argument("--port", type=int, help="Set the API port")
+    config_parser.set_defaults(func=cmd_config)
+
+    # logs
+    logs_parser = subparsers.add_parser("logs", help="Show vLLM logs")
+    logs_parser.add_argument("--follow", "-f", action="store_true", help="Tail logs in real-time")
+    logs_parser.add_argument("--lines", "-n", type=int, default=50, help="Number of lines to show (default: 50)")
+    logs_parser.set_defaults(func=cmd_logs)
+
     # service
     service_parser = subparsers.add_parser("service", help="Manage AINode systemd service")
     service_parser.add_argument(
@@ -303,18 +553,9 @@ def main():
     service_sub.add_parser("install", help="Install, enable, and start AINode service")
     service_sub.add_parser("uninstall", help="Stop, disable, and remove AINode service")
     service_sub.add_parser("status", help="Show AINode service status")
-    logs_parser = service_sub.add_parser("logs", help="Show AINode service logs")
-    logs_parser.add_argument("-n", "--lines", type=int, default=50, help="Number of log lines")
+    svc_logs_parser = service_sub.add_parser("logs", help="Show AINode service logs")
+    svc_logs_parser.add_argument("-n", "--lines", type=int, default=50, help="Number of log lines")
     service_parser.set_defaults(func=cmd_service)
-
-    # auth
-    auth_parser = subparsers.add_parser("auth", help="Manage API key authentication")
-    auth_sub = auth_parser.add_subparsers(dest="auth_action")
-    auth_sub.add_parser("enable", help="Enable API key auth")
-    auth_sub.add_parser("disable", help="Disable API key auth")
-    auth_sub.add_parser("status", help="Show auth status")
-    auth_sub.add_parser("new-key", help="Generate a new API key")
-    auth_parser.set_defaults(func=cmd_auth)
 
     args = parser.parse_args()
 

--- a/ainode/cli/main.py
+++ b/ainode/cli/main.py
@@ -504,6 +504,44 @@ def cmd_service(args):
         console.print("  Usage: ainode service {install|uninstall|status|logs}")
 
 
+def cmd_auth(args):
+    """Manage API key authentication."""
+    from ainode.auth.middleware import AuthConfig
+
+    action = getattr(args, "auth_action", None)
+    auth_cfg = AuthConfig.load()
+
+    if action == "enable":
+        entry = auth_cfg.enable()
+        console.print("  [green]Auth enabled.[/green]")
+        console.print(f"  API key: {entry['key']}")
+        console.print(f"  Key ID:  {entry['id']}")
+        console.print()
+        console.print("  Use: Authorization: Bearer <key>")
+        console.print("  Powered by argentos.ai")
+
+    elif action == "disable":
+        auth_cfg.disable()
+        console.print("  [yellow]Auth disabled.[/yellow] All requests allowed.")
+        console.print("  Powered by argentos.ai")
+
+    elif action == "status":
+        state = "[green]enabled[/green]" if auth_cfg.enabled else "[dim]disabled[/dim]"
+        console.print(f"  Auth: {state}")
+        console.print(f"  Keys: {len(auth_cfg.api_keys)}")
+        console.print("  Powered by argentos.ai")
+
+    elif action == "new-key":
+        entry = auth_cfg.generate_key()
+        console.print("  [green]New API key generated.[/green]")
+        console.print(f"  API key: {entry['key']}")
+        console.print(f"  Key ID:  {entry['id']}")
+        console.print("  Powered by argentos.ai")
+
+    else:
+        console.print("  Usage: ainode auth {enable|disable|status|new-key}")
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="ainode",
@@ -556,6 +594,15 @@ def main():
     svc_logs_parser = service_sub.add_parser("logs", help="Show AINode service logs")
     svc_logs_parser.add_argument("-n", "--lines", type=int, default=50, help="Number of log lines")
     service_parser.set_defaults(func=cmd_service)
+
+    # auth
+    auth_parser = subparsers.add_parser("auth", help="Manage API key authentication")
+    auth_sub = auth_parser.add_subparsers(dest="auth_action")
+    auth_sub.add_parser("enable", help="Enable API key auth")
+    auth_sub.add_parser("disable", help="Disable API key auth")
+    auth_sub.add_parser("status", help="Show auth status")
+    auth_sub.add_parser("new-key", help="Generate a new API key")
+    auth_parser.set_defaults(func=cmd_auth)
 
     args = parser.parse_args()
 

--- a/ainode/cli/main.py
+++ b/ainode/cli/main.py
@@ -1,48 +1,135 @@
-"""AINode CLI — main entry point."""
+"""AINode CLI — main entry point with Rich terminal output."""
 
 import argparse
+import os
+import signal
 import sys
-import uuid
 import time
-import threading
+import uuid
 
 from rich.console import Console
 from rich.live import Live
+from rich.panel import Panel
 from rich.spinner import Spinner
+from rich.table import Table
 from rich.text import Text
 
 from ainode import __version__
-from ainode.core.config import NodeConfig, ensure_dirs
-from ainode.core.gpu import gpu_summary, detect_gpu
+from ainode.core.config import NodeConfig, ensure_dirs, AINODE_HOME, LOGS_DIR
 
 console = Console()
 
+PID_FILE = AINODE_HOME / "ainode.pid"
+VLLM_LOG = LOGS_DIR / "vllm.log"
 
-def _tail_log(path, lines=10):
-    """Print the last N lines of a log file."""
+
+# ---------------------------------------------------------------------------
+# Banner
+# ---------------------------------------------------------------------------
+
+def _banner():
+    """Return a Rich Panel banner for AINode."""
+    title_text = Text()
+    title_text.append("A", style="bold cyan")
+    title_text.append("I", style="bold cyan")
+    title_text.append("N", style="bold cyan")
+    title_text.append("ode", style="bold white")
+    title_text.append("  v" + __version__, style="dim")
+
+    body = Text.from_markup(
+        "[bold white]Turn any NVIDIA GPU into a local AI platform[/bold white]\n"
+        "[dim]Inference + fine-tuning in your browser. One command to start.[/dim]"
+    )
+
+    return Panel(
+        body,
+        title=title_text,
+        subtitle="[dim italic]Powered by argentos.ai[/dim italic]",
+        border_style="cyan",
+        padding=(1, 4),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_pid():
+    """Write current PID to the PID file."""
+    AINODE_HOME.mkdir(parents=True, exist_ok=True)
+    PID_FILE.write_text(str(os.getpid()))
+
+
+def _read_pid():
+    """Read PID from file, return int or None."""
     try:
-        with open(path) as f:
-            all_lines = f.readlines()
-        for line in all_lines[-lines:]:
-            console.print(f"    {line.rstrip()}")
+        return int(PID_FILE.read_text().strip())
+    except Exception:
+        return None
+
+
+def _remove_pid():
+    """Remove the PID file."""
+    try:
+        PID_FILE.unlink(missing_ok=True)
     except Exception:
         pass
 
 
-BANNER = """
-    ╔══════════════════════════════════════╗
-    ║            A I N o d e               ║
-    ║   Your local AI platform for NVIDIA  ║
-    ╚══════════════════════════════════════╝
-"""
+def _pid_alive(pid):
+    """Check if a PID is alive."""
+    if pid is None:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except (OSError, ProcessLookupError):
+        return False
 
+
+def _tail_log(path, lines=10):
+    """Return the last N lines of a log file."""
+    try:
+        with open(path) as f:
+            all_lines = f.readlines()
+        return all_lines[-lines:]
+    except Exception:
+        return []
+
+
+def _gpu_info_table(gpu):
+    """Build a Rich table for GPU info."""
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("key", style="bold cyan", no_wrap=True)
+    table.add_column("value")
+
+    mem_gb = gpu.memory_total_mb / 1024
+    um = " (unified memory)" if gpu.unified_memory else ""
+    table.add_row("GPU", f"{gpu.name} | {mem_gb:.0f} GB{um}")
+    table.add_row("CUDA", f"{gpu.cuda_version} | Driver {gpu.driver_version}")
+    table.add_row("Compute", f"SM {gpu.compute_capability}")
+    return table
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
 
 def cmd_start(args):
     """Start AINode."""
-    print(BANNER)
+    from ainode.core.gpu import gpu_summary, detect_gpu
+    console.print(_banner())
     ensure_dirs()
 
     config = NodeConfig.load()
+
+    # Override from CLI flags
+    if hasattr(args, "model") and args.model:
+        config.model = args.model
+        config.save()
+    if hasattr(args, "port") and args.port:
+        config.api_port = args.port
+        config.save()
 
     # First run — onboarding
     if not config.onboarded:
@@ -57,69 +144,139 @@ def cmd_start(args):
     # Detect GPU
     gpu = detect_gpu()
     if gpu:
-        mem_gb = gpu.memory_total_mb / 1024
-        um = " (unified memory)" if gpu.unified_memory else ""
-        print(f"  GPU:   {gpu.name} | {mem_gb:.0f} GB{um}")
-        print(f"  CUDA:  {gpu.cuda_version} | Driver {gpu.driver_version}")
+        console.print(_gpu_info_table(gpu))
     else:
-        print("  GPU:   No NVIDIA GPU detected (CPU mode)")
-    print()
-
-    # Start vLLM engine
-    console.print(f"  Model: {config.model}")
-    console.print(f"  API:   http://localhost:{config.api_port}/v1")
-    console.print(f"  Web:   http://localhost:{config.web_port}")
+        console.print("  [yellow]No NVIDIA GPU detected[/yellow] — running in CPU mode")
     console.print()
 
+    # Service info
+    info_table = Table(show_header=False, box=None, padding=(0, 2))
+    info_table.add_column("key", style="bold green", no_wrap=True)
+    info_table.add_column("value")
+    info_table.add_row("Model", config.model)
+    info_table.add_row("API", f"http://localhost:{config.api_port}/v1")
+    info_table.add_row("Web", f"http://localhost:{config.web_port}")
+    info_table.add_row("Node", config.node_id or "pending")
+    console.print(info_table)
+    console.print()
+
+    # Write PID file
+    _write_pid()
+
+    # Start vLLM engine
     from ainode.engine.vllm_engine import VLLMEngine
 
     engine = VLLMEngine(config)
     if not engine.start():
         console.print("  [red]Failed to start engine.[/red] Check logs in ~/.ainode/logs/")
+        _remove_pid()
         sys.exit(1)
 
-    # Wait for readiness with spinner and log tailing
+    # Wait for readiness with spinner
     with Live(Spinner("dots", text="Starting inference engine..."), console=console, transient=True):
         ready = engine.wait_ready(timeout=300)
 
     if not ready:
         console.print("  [red]Engine failed to become ready within 5 minutes.[/red]")
         if engine.log_path and engine.log_path.exists():
-            console.print(f"  Last log lines:")
-            _tail_log(engine.log_path, lines=10)
+            console.print("  [dim]Last log lines:[/dim]")
+            for line in _tail_log(engine.log_path, lines=10):
+                console.print(f"    [dim]{line.rstrip()}[/dim]")
         engine.stop()
+        _remove_pid()
         sys.exit(1)
 
-    console.print("  [green]Engine ready.[/green] Open your browser to get started.")
-    console.print()
-    console.print("  Powered by argentos.ai")
-    console.print()
+    console.print("  [bold green]Engine ready.[/bold green] Open your browser to get started.\n")
 
     # Keep running until interrupted
     try:
         engine.process.wait()
     except KeyboardInterrupt:
-        console.print("\n  Shutting down...")
+        console.print("\n  [yellow]Shutting down...[/yellow]")
         engine.stop()
+    finally:
+        _remove_pid()
 
 
 def cmd_stop(args):
-    """Stop AINode."""
-    print("Stopping AINode...")
-    # TODO: Signal running instance to stop
-    print("Done.")
+    """Stop a running AINode instance."""
+    console.print(_banner())
+
+    pid = _read_pid()
+
+    if pid and _pid_alive(pid):
+        console.print(f"  Stopping AINode (PID {pid})...")
+        try:
+            os.kill(pid, signal.SIGTERM)
+            # Wait up to 10 seconds for graceful shutdown
+            for _ in range(20):
+                if not _pid_alive(pid):
+                    break
+                time.sleep(0.5)
+            else:
+                # Force kill if still alive
+                console.print("  [yellow]Process did not exit gracefully, sending SIGKILL...[/yellow]")
+                os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        _remove_pid()
+        console.print("  [green]AINode stopped.[/green]\n")
+        return
+
+    # No PID file or stale PID — try to find the process
+    _remove_pid()
+
+    # Fallback: check for python processes running ainode
+    import subprocess
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", "ainode.cli.main|ainode start"],
+            capture_output=True, text=True
+        )
+        pids = [int(p) for p in result.stdout.strip().split("\n") if p.strip() and int(p) != os.getpid()]
+    except Exception:
+        pids = []
+
+    if pids:
+        for p in pids:
+            console.print(f"  Stopping AINode process (PID {p})...")
+            try:
+                os.kill(p, signal.SIGTERM)
+            except (OSError, ProcessLookupError):
+                pass
+        console.print("  [green]AINode stopped.[/green]\n")
+    else:
+        console.print("  [dim]No running AINode instance found.[/dim]\n")
 
 
 def cmd_status(args):
-    """Show cluster status."""
-    print(BANNER)
-    console.print(f"  GPU: {gpu_summary()}")
+    """Show cluster status with Rich formatting."""
+    from ainode.core.gpu import gpu_summary, detect_gpu
+    console.print(_banner())
 
     config = NodeConfig.load()
-    console.print(f"  Node ID: {config.node_id or 'not configured'}")
-    console.print(f"  Model: {config.model}")
-    console.print(f"  API: http://localhost:{config.api_port}/v1")
-    console.print(f"  Email: {config.email or 'not set'}")
+    gpu = detect_gpu()
+
+    # Node info table
+    table = Table(title="Node Info", border_style="cyan", show_lines=False)
+    table.add_column("Property", style="bold cyan", no_wrap=True)
+    table.add_column("Value")
+
+    table.add_row("Node ID", config.node_id or "[dim]not configured[/dim]")
+    table.add_row("Model", config.model)
+    table.add_row("API", f"http://localhost:{config.api_port}/v1")
+    table.add_row("Web", f"http://localhost:{config.web_port}")
+    table.add_row("Email", config.email or "[dim]not set[/dim]")
+
+    if gpu:
+        mem_gb = gpu.memory_total_mb / 1024
+        um = " (unified)" if gpu.unified_memory else ""
+        table.add_row("GPU", f"{gpu.name} | {mem_gb:.0f} GB{um}")
+        table.add_row("CUDA", f"{gpu.cuda_version} | Driver {gpu.driver_version}")
+    else:
+        table.add_row("GPU", "[yellow]No NVIDIA GPU detected[/yellow]")
+
+    console.print(table)
     console.print()
 
     # Engine health check
@@ -128,19 +285,29 @@ def cmd_status(args):
     health = engine.health_check()
 
     if health["api_responding"]:
-        console.print("  Engine: [green]running[/green]")
+        console.print("  Engine:  [bold green]running[/bold green]")
         if health["models_loaded"]:
-            console.print(f"  Models: {', '.join(health['models_loaded'])}")
+            console.print(f"  Models:  {', '.join(health['models_loaded'])}")
     elif health["process_alive"]:
-        console.print("  Engine: [yellow]starting[/yellow] (process alive, API not ready)")
+        console.print("  Engine:  [bold yellow]starting[/bold yellow] (process alive, API not ready)")
     else:
-        console.print("  Engine: [red]stopped[/red]")
+        console.print("  Engine:  [bold red]stopped[/bold red]")
+
+    # PID file status
+    pid = _read_pid()
+    if pid and _pid_alive(pid):
+        console.print(f"  PID:     {pid}")
     console.print()
 
 
 def cmd_models(args):
-    """List available models."""
-    print("Popular models for AINode:\n")
+    """List available models with Rich table and GPU-aware recommendations."""
+    from ainode.core.gpu import detect_gpu
+    console.print(_banner())
+
+    gpu = detect_gpu()
+    gpu_mem_gb = (gpu.memory_total_mb / 1024) if gpu else 0
+
     models = [
         ("llama-3.2-3b", "Llama 3.2 3B Instruct", "~6 GB", "Quick start"),
         ("llama-3.1-8b", "Llama 3.1 8B Instruct", "~16 GB", "Recommended"),
@@ -148,13 +315,121 @@ def cmd_models(args):
         ("qwen-2.5-72b", "Qwen 2.5 72B Instruct", "~40 GB", "Coding + multilingual"),
         ("deepseek-r1-7b", "DeepSeek R1 Distill 7B", "~14 GB", "Reasoning"),
     ]
-    for short, name, mem, note in models:
-        print(f"  {short:<25} {mem:<10} {note}")
-    print()
-    print("  Set model: ainode config --model <name>")
-    print("  Full list: https://ainode.dev/models")
-    print()
 
+    # Memory thresholds for recommendations
+    mem_thresholds = {
+        "~6 GB": 6,
+        "~14 GB": 14,
+        "~16 GB": 16,
+        "~35 GB": 35,
+        "~40 GB": 40,
+    }
+
+    table = Table(title="Available Models", border_style="cyan")
+    table.add_column("Name", style="bold white", no_wrap=True)
+    table.add_column("Size", justify="right")
+    table.add_column("Description")
+    table.add_column("Tag")
+
+    for short, name, mem, note in models:
+        threshold = mem_thresholds.get(mem, 999)
+        fits = gpu_mem_gb >= threshold
+
+        if note == "Recommended":
+            tag_style = "bold green" if fits else "dim green"
+        elif fits:
+            tag_style = "green"
+        else:
+            tag_style = "dim red"
+
+        tag = Text(note, style=tag_style)
+        if not fits and gpu_mem_gb > 0:
+            tag.append(" (needs more VRAM)", style="dim")
+
+        table.add_row(short, mem, name, tag)
+
+    console.print(table)
+    console.print()
+    console.print("  Set model:  [bold]ainode config --model <name>[/bold]")
+    console.print("  Full list:  [link=https://ainode.dev/models]https://ainode.dev/models[/link]")
+    console.print()
+
+
+def cmd_config(args):
+    """Show or update AINode configuration."""
+    config = NodeConfig.load()
+
+    if args.model:
+        config.model = args.model
+        config.save()
+        console.print(f"  [green]Model set to:[/green] {args.model}")
+        return
+
+    if args.port:
+        config.api_port = args.port
+        config.save()
+        console.print(f"  [green]API port set to:[/green] {args.port}")
+        return
+
+    # Default: --show
+    console.print(_banner())
+
+    from dataclasses import asdict
+    data = asdict(config)
+
+    table = Table(title="Configuration", border_style="cyan")
+    table.add_column("Key", style="bold cyan", no_wrap=True)
+    table.add_column("Value")
+
+    for key, value in data.items():
+        display = str(value) if value is not None else "[dim]not set[/dim]"
+        table.add_row(key, display)
+
+    console.print(table)
+    console.print()
+    console.print(f"  Config file: [dim]{AINODE_HOME / 'config.json'}[/dim]")
+    console.print()
+
+
+def cmd_logs(args):
+    """Show or tail vLLM logs."""
+    log_file = VLLM_LOG
+
+    if not log_file.exists():
+        console.print("  [dim]No log file found at[/dim] ~/.ainode/logs/vllm.log")
+        console.print("  [dim]Start AINode first: [bold]ainode start[/bold][/dim]")
+        return
+
+    if args.follow:
+        console.print(f"  [dim]Tailing {log_file} (Ctrl+C to stop)[/dim]\n")
+        try:
+            import subprocess
+            proc = subprocess.Popen(
+                ["tail", "-f", str(log_file)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            for line in proc.stdout:
+                console.print(line.rstrip())
+        except KeyboardInterrupt:
+            console.print("\n  [dim]Stopped tailing.[/dim]")
+            if proc:
+                proc.terminate()
+    else:
+        lines = _tail_log(log_file, lines=args.lines)
+        if not lines:
+            console.print("  [dim]Log file is empty.[/dim]")
+            return
+        console.print(f"  [dim]Last {len(lines)} lines of {log_file}:[/dim]\n")
+        for line in lines:
+            console.print(f"  {line.rstrip()}")
+        console.print()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
 
 def cmd_service(args):
     """Manage AINode systemd service."""
@@ -232,7 +507,7 @@ def cmd_service(args):
 def main():
     parser = argparse.ArgumentParser(
         prog="ainode",
-        description="AINode — Turn any NVIDIA GPU into a local AI platform.",
+        description="AINode -- Turn any NVIDIA GPU into a local AI platform.",
     )
     parser.add_argument("--version", action="version", version=f"ainode {__version__}")
 
@@ -256,6 +531,19 @@ def main():
     models_parser = subparsers.add_parser("models", help="List available models")
     models_parser.set_defaults(func=cmd_models)
 
+    # config
+    config_parser = subparsers.add_parser("config", help="Show or update configuration")
+    config_parser.add_argument("--show", action="store_true", default=True, help="Show current config")
+    config_parser.add_argument("--model", help="Set the model")
+    config_parser.add_argument("--port", type=int, help="Set the API port")
+    config_parser.set_defaults(func=cmd_config)
+
+    # logs
+    logs_parser = subparsers.add_parser("logs", help="Show vLLM logs")
+    logs_parser.add_argument("--follow", "-f", action="store_true", help="Tail logs in real-time")
+    logs_parser.add_argument("--lines", "-n", type=int, default=50, help="Number of lines to show (default: 50)")
+    logs_parser.set_defaults(func=cmd_logs)
+
     # service
     service_parser = subparsers.add_parser("service", help="Manage AINode systemd service")
     service_parser.add_argument(
@@ -265,8 +553,8 @@ def main():
     service_sub.add_parser("install", help="Install, enable, and start AINode service")
     service_sub.add_parser("uninstall", help="Stop, disable, and remove AINode service")
     service_sub.add_parser("status", help="Show AINode service status")
-    logs_parser = service_sub.add_parser("logs", help="Show AINode service logs")
-    logs_parser.add_argument("-n", "--lines", type=int, default=50, help="Number of log lines")
+    svc_logs_parser = service_sub.add_parser("logs", help="Show AINode service logs")
+    svc_logs_parser.add_argument("-n", "--lines", type=int, default=50, help="Number of log lines")
     service_parser.set_defaults(func=cmd_service)
 
     args = parser.parse_args()

--- a/ainode/cli/main.py
+++ b/ainode/cli/main.py
@@ -229,6 +229,44 @@ def cmd_service(args):
         console.print("  Usage: ainode service {install|uninstall|status|logs}")
 
 
+def cmd_auth(args):
+    """Manage API key authentication."""
+    from ainode.auth.middleware import AuthConfig
+
+    action = getattr(args, "auth_action", None)
+    auth_cfg = AuthConfig.load()
+
+    if action == "enable":
+        entry = auth_cfg.enable()
+        console.print("  [green]Auth enabled.[/green]")
+        console.print(f"  API key: {entry['key']}")
+        console.print(f"  Key ID:  {entry['id']}")
+        console.print()
+        console.print("  Use: Authorization: Bearer <key>")
+        console.print("  Powered by argentos.ai")
+
+    elif action == "disable":
+        auth_cfg.disable()
+        console.print("  [yellow]Auth disabled.[/yellow] All requests allowed.")
+        console.print("  Powered by argentos.ai")
+
+    elif action == "status":
+        state = "[green]enabled[/green]" if auth_cfg.enabled else "[dim]disabled[/dim]"
+        console.print(f"  Auth: {state}")
+        console.print(f"  Keys: {len(auth_cfg.api_keys)}")
+        console.print("  Powered by argentos.ai")
+
+    elif action == "new-key":
+        entry = auth_cfg.generate_key()
+        console.print("  [green]New API key generated.[/green]")
+        console.print(f"  API key: {entry['key']}")
+        console.print(f"  Key ID:  {entry['id']}")
+        console.print("  Powered by argentos.ai")
+
+    else:
+        console.print("  Usage: ainode auth {enable|disable|status|new-key}")
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="ainode",
@@ -268,6 +306,15 @@ def main():
     logs_parser = service_sub.add_parser("logs", help="Show AINode service logs")
     logs_parser.add_argument("-n", "--lines", type=int, default=50, help="Number of log lines")
     service_parser.set_defaults(func=cmd_service)
+
+    # auth
+    auth_parser = subparsers.add_parser("auth", help="Manage API key authentication")
+    auth_sub = auth_parser.add_subparsers(dest="auth_action")
+    auth_sub.add_parser("enable", help="Enable API key auth")
+    auth_sub.add_parser("disable", help="Disable API key auth")
+    auth_sub.add_parser("status", help="Show auth status")
+    auth_sub.add_parser("new-key", help="Generate a new API key")
+    auth_parser.set_defaults(func=cmd_auth)
 
     args = parser.parse_args()
 

--- a/ainode/discovery/__init__.py
+++ b/ainode/discovery/__init__.py
@@ -1,0 +1,20 @@
+"""UDP broadcast discovery and cluster coordination for AINode."""
+
+from ainode.discovery.broadcast import (
+    NodeAnnouncement,
+    NodeStatus,
+    DiscoveredNode,
+    BroadcastSender,
+    BroadcastListener,
+)
+from ainode.discovery.cluster import ClusterState, ClusterNode
+
+__all__ = [
+    "NodeAnnouncement",
+    "NodeStatus",
+    "DiscoveredNode",
+    "BroadcastSender",
+    "BroadcastListener",
+    "ClusterState",
+    "ClusterNode",
+]

--- a/ainode/discovery/broadcast.py
+++ b/ainode/discovery/broadcast.py
@@ -3,111 +3,224 @@
 import json
 import socket
 import asyncio
-import uuid
-from dataclasses import dataclass, asdict
-from typing import Callable, Optional
+import time
+from dataclasses import dataclass, field, asdict
+from enum import Enum
+from typing import Callable, Dict, List, Optional
+
+
+class NodeStatus(str, Enum):
+    """Health status of a discovered node."""
+    ONLINE = "online"
+    STALE = "stale"
+    OFFLINE = "offline"
+
+
+# Thresholds in seconds
+ONLINE_THRESHOLD = 15.0
+STALE_THRESHOLD = 30.0
 
 
 @dataclass
 class NodeAnnouncement:
     """Broadcast message from a node."""
     node_id: str
-    host: str
-    api_port: int
+    node_name: str
     gpu_name: str
-    gpu_memory_mb: int
-    models_loaded: list
-    version: str
+    gpu_memory_gb: float
+    unified_memory: bool
+    model: str
+    status: str
+    api_port: int
+    web_port: int
+    timestamp: float = field(default_factory=time.time)
+
+    def to_json(self) -> str:
+        """Serialize to JSON string."""
+        return json.dumps(asdict(self))
+
+    @classmethod
+    def from_json(cls, data: str) -> "NodeAnnouncement":
+        """Deserialize from JSON string."""
+        return cls(**json.loads(data))
 
 
-class NodeDiscovery:
-    """Discovers other AINode instances on the local network via UDP broadcast."""
+@dataclass
+class DiscoveredNode:
+    """A node discovered on the network, with health tracking."""
+    announcement: NodeAnnouncement
+    last_seen: float = field(default_factory=time.time)
+
+    @property
+    def age(self) -> float:
+        """Seconds since last heartbeat."""
+        return time.time() - self.last_seen
+
+    @property
+    def health(self) -> NodeStatus:
+        """Determine node health based on heartbeat age."""
+        age = self.age
+        if age < ONLINE_THRESHOLD:
+            return NodeStatus.ONLINE
+        elif age < STALE_THRESHOLD:
+            return NodeStatus.STALE
+        return NodeStatus.OFFLINE
+
+
+class BroadcastSender:
+    """Sends UDP broadcast announcements on a regular interval."""
 
     def __init__(
         self,
-        node_id: str,
-        host: str,
-        api_port: int,
+        announcement: NodeAnnouncement,
         discovery_port: int = 5678,
         broadcast_interval: float = 5.0,
-        on_node_found: Optional[Callable] = None,
-        on_node_lost: Optional[Callable] = None,
     ):
-        self.node_id = node_id
-        self.host = host
-        self.api_port = api_port
+        self.announcement = announcement
         self.discovery_port = discovery_port
         self.broadcast_interval = broadcast_interval
-        self.on_node_found = on_node_found
-        self.on_node_lost = on_node_lost
-        self.known_nodes: dict[str, NodeAnnouncement] = {}
         self._running = False
+        self._task: Optional[asyncio.Task] = None
 
     async def start(self):
-        """Start broadcasting and listening."""
+        """Start the broadcast loop."""
         self._running = True
-        asyncio.create_task(self._broadcast_loop())
-        asyncio.create_task(self._listen_loop())
+        self._task = asyncio.create_task(self._broadcast_loop())
 
     async def stop(self):
-        """Stop discovery."""
+        """Stop broadcasting."""
         self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+    def update_announcement(self, **kwargs):
+        """Update fields on the announcement (e.g. model, status)."""
+        for key, value in kwargs.items():
+            if hasattr(self.announcement, key):
+                setattr(self.announcement, key, value)
 
     async def _broadcast_loop(self):
         """Periodically broadcast our presence."""
-        from ainode.core.gpu import detect_gpu
-        from ainode import __version__
-
-        gpu = detect_gpu()
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
         sock.setblocking(False)
 
-        announcement = NodeAnnouncement(
-            node_id=self.node_id,
-            host=self.host,
-            api_port=self.api_port,
-            gpu_name=gpu.name if gpu else "unknown",
-            gpu_memory_mb=gpu.memory_total_mb if gpu else 0,
-            models_loaded=[],
-            version=__version__,
+        try:
+            while self._running:
+                try:
+                    self.announcement.timestamp = time.time()
+                    data = self.announcement.to_json().encode()
+                    sock.sendto(data, ("<broadcast>", self.discovery_port))
+                except Exception:
+                    pass
+                await asyncio.sleep(self.broadcast_interval)
+        finally:
+            sock.close()
+
+
+class BroadcastListener:
+    """Listens for UDP broadcast announcements and maintains a node registry."""
+
+    def __init__(
+        self,
+        local_node_id: str,
+        discovery_port: int = 5678,
+        on_node_found: Optional[Callable[[NodeAnnouncement], None]] = None,
+        on_node_lost: Optional[Callable[[str], None]] = None,
+    ):
+        self.local_node_id = local_node_id
+        self.discovery_port = discovery_port
+        self.on_node_found = on_node_found
+        self.on_node_lost = on_node_lost
+        self._registry: Dict[str, DiscoveredNode] = {}
+        self._running = False
+        self._listen_task: Optional[asyncio.Task] = None
+        self._reaper_task: Optional[asyncio.Task] = None
+
+    @property
+    def registry(self) -> Dict[str, DiscoveredNode]:
+        return dict(self._registry)
+
+    def get_nodes(self, include_offline: bool = False) -> List[DiscoveredNode]:
+        """Return discovered nodes, optionally filtering out offline ones."""
+        nodes = list(self._registry.values())
+        if not include_offline:
+            nodes = [n for n in nodes if n.health != NodeStatus.OFFLINE]
+        return nodes
+
+    def get_node(self, node_id: str) -> Optional[DiscoveredNode]:
+        """Get a specific discovered node by ID."""
+        return self._registry.get(node_id)
+
+    def _process_announcement(self, announcement: NodeAnnouncement):
+        """Process a received announcement."""
+        if announcement.node_id == self.local_node_id:
+            return
+
+        is_new = announcement.node_id not in self._registry
+        self._registry[announcement.node_id] = DiscoveredNode(
+            announcement=announcement,
+            last_seen=time.time(),
         )
 
-        while self._running:
-            try:
-                data = json.dumps(asdict(announcement)).encode()
-                sock.sendto(data, ("<broadcast>", self.discovery_port))
-            except Exception:
-                pass
-            await asyncio.sleep(self.broadcast_interval)
+        if is_new and self.on_node_found:
+            self.on_node_found(announcement)
 
-        sock.close()
+    async def start(self):
+        """Start listening for broadcasts."""
+        self._running = True
+        self._listen_task = asyncio.create_task(self._listen_loop())
+        self._reaper_task = asyncio.create_task(self._reaper_loop())
+
+    async def stop(self):
+        """Stop listening."""
+        self._running = False
+        for task in [self._listen_task, self._reaper_task]:
+            if task:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
 
     async def _listen_loop(self):
-        """Listen for broadcasts from other nodes."""
+        """Listen for broadcast announcements."""
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+        except (AttributeError, OSError):
+            pass
         sock.bind(("", self.discovery_port))
         sock.setblocking(False)
 
         loop = asyncio.get_event_loop()
 
+        try:
+            while self._running:
+                try:
+                    data = await loop.run_in_executor(None, lambda: sock.recv(4096))
+                    announcement = NodeAnnouncement.from_json(data.decode())
+                    self._process_announcement(announcement)
+                except Exception:
+                    await asyncio.sleep(1)
+        finally:
+            sock.close()
+
+    async def _reaper_loop(self):
+        """Periodically check for offline nodes and fire on_node_lost."""
         while self._running:
-            try:
-                data = await loop.run_in_executor(None, lambda: sock.recv(4096))
-                announcement = NodeAnnouncement(**json.loads(data.decode()))
+            await asyncio.sleep(10)
+            to_remove = []
+            for node_id, node in self._registry.items():
+                if node.health == NodeStatus.OFFLINE:
+                    to_remove.append(node_id)
 
-                if announcement.node_id == self.node_id:
-                    continue  # Ignore our own broadcasts
-
-                if announcement.node_id not in self.known_nodes:
-                    self.known_nodes[announcement.node_id] = announcement
-                    if self.on_node_found:
-                        self.on_node_found(announcement)
-                else:
-                    self.known_nodes[announcement.node_id] = announcement
-
-            except Exception:
-                await asyncio.sleep(1)
-
-        sock.close()
+            for node_id in to_remove:
+                del self._registry[node_id]
+                if self.on_node_lost:
+                    self.on_node_lost(node_id)

--- a/ainode/discovery/cluster.py
+++ b/ainode/discovery/cluster.py
@@ -1,0 +1,143 @@
+"""Cluster coordinator -- tracks nodes, elects leader, routes model requests."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from ainode.discovery.broadcast import (
+    DiscoveredNode,
+    NodeAnnouncement,
+    NodeStatus,
+)
+
+
+@dataclass
+class ClusterNode:
+    """Enriched view of a node within the cluster."""
+    node_id: str
+    node_name: str
+    gpu_name: str
+    gpu_memory_gb: float
+    unified_memory: bool
+    model: str
+    status: NodeStatus
+    api_port: int
+    web_port: int
+    last_seen: float
+
+    @classmethod
+    def from_discovered(cls, discovered: DiscoveredNode) -> "ClusterNode":
+        a = discovered.announcement
+        return cls(
+            node_id=a.node_id,
+            node_name=a.node_name,
+            gpu_name=a.gpu_name,
+            gpu_memory_gb=a.gpu_memory_gb,
+            unified_memory=a.unified_memory,
+            model=a.model,
+            status=discovered.health,
+            api_port=a.api_port,
+            web_port=a.web_port,
+            last_seen=discovered.last_seen,
+        )
+
+    @classmethod
+    def from_announcement(cls, announcement: NodeAnnouncement, status: NodeStatus) -> "ClusterNode":
+        return cls(
+            node_id=announcement.node_id,
+            node_name=announcement.node_name,
+            gpu_name=announcement.gpu_name,
+            gpu_memory_gb=announcement.gpu_memory_gb,
+            unified_memory=announcement.unified_memory,
+            model=announcement.model,
+            status=status,
+            api_port=announcement.api_port,
+            web_port=announcement.web_port,
+            last_seen=time.time(),
+        )
+
+
+class ClusterState:
+    """Maintains cluster state: all nodes, their GPUs, loaded models, and leader election."""
+
+    def __init__(self, local_announcement: Optional[NodeAnnouncement] = None):
+        self._nodes: Dict[str, ClusterNode] = {}
+        self._local_announcement = local_announcement
+
+        # If we have a local announcement, add ourselves
+        if local_announcement:
+            self._nodes[local_announcement.node_id] = ClusterNode.from_announcement(
+                local_announcement, NodeStatus.ONLINE
+            )
+
+    def update_from_discovered(self, discovered_nodes: Dict[str, DiscoveredNode]):
+        """Sync cluster state from the listener registry."""
+        local_id = self._local_announcement.node_id if self._local_announcement else None
+
+        # Update remote nodes
+        for node_id, discovered in discovered_nodes.items():
+            self._nodes[node_id] = ClusterNode.from_discovered(discovered)
+
+        # Remove nodes no longer in the registry (except local)
+        remote_ids = set(discovered_nodes.keys())
+        to_remove = [
+            nid for nid in self._nodes
+            if nid != local_id and nid not in remote_ids
+        ]
+        for nid in to_remove:
+            del self._nodes[nid]
+
+        # Refresh local node timestamp
+        if local_id and self._local_announcement:
+            self._nodes[local_id] = ClusterNode.from_announcement(
+                self._local_announcement, NodeStatus.ONLINE
+            )
+
+    def add_node(self, node: ClusterNode):
+        """Add or update a node directly."""
+        self._nodes[node.node_id] = node
+
+    def remove_node(self, node_id: str):
+        """Remove a node from the cluster."""
+        self._nodes.pop(node_id, None)
+
+    def get_node(self, node_id: str) -> Optional[ClusterNode]:
+        """Get info for a specific node."""
+        return self._nodes.get(node_id)
+
+    def get_nodes(self, include_offline: bool = False) -> List[ClusterNode]:
+        """Get all nodes with their status."""
+        nodes = list(self._nodes.values())
+        if not include_offline:
+            nodes = [n for n in nodes if n.status != NodeStatus.OFFLINE]
+        return nodes
+
+    def get_leader(self) -> Optional[ClusterNode]:
+        """Return the current leader node. Leader = lowest node_id alphabetically among ONLINE nodes."""
+        online = [n for n in self._nodes.values() if n.status == NodeStatus.ONLINE]
+        if not online:
+            return None
+        return min(online, key=lambda n: n.node_id)
+
+    def find_model(self, model_name: str) -> List[ClusterNode]:
+        """Return which node(s) serve a given model. Only returns ONLINE or STALE nodes."""
+        return [
+            n for n in self._nodes.values()
+            if n.model == model_name and n.status in (NodeStatus.ONLINE, NodeStatus.STALE)
+        ]
+
+    def cluster_summary(self) -> dict:
+        """Return a summary dict of the cluster state."""
+        active_nodes = [n for n in self._nodes.values() if n.status != NodeStatus.OFFLINE]
+        models = set(n.model for n in active_nodes if n.model)
+        leader = self.get_leader()
+
+        return {
+            "total_nodes": len(active_nodes),
+            "total_gpus": len(active_nodes),
+            "total_memory_gb": sum(n.gpu_memory_gb for n in active_nodes),
+            "models_available": sorted(models),
+            "leader_id": leader.node_id if leader else None,
+        }

--- a/ainode/engine/vllm_engine.py
+++ b/ainode/engine/vllm_engine.py
@@ -1,29 +1,35 @@
-"""vLLM engine wrapper — manages the vLLM inference server."""
+"""vLLM engine wrapper — manages the vLLM inference server lifecycle."""
 
+import asyncio
 import subprocess
 import signal
 import os
-from typing import Optional
-from ainode.core.config import NodeConfig
+import sys
+import time
+import threading
+from pathlib import Path
+from typing import Optional, Callable
+from ainode.core.config import NodeConfig, LOGS_DIR
 from ainode.core.gpu import detect_gpu
 
 
 class VLLMEngine:
-    """Start, stop, and manage a vLLM inference server."""
+    """Start, stop, manage, and health-check a vLLM inference server."""
 
-    def __init__(self, config: NodeConfig):
+    def __init__(self, config: NodeConfig, on_ready: Optional[Callable] = None):
         self.config = config
         self.process: Optional[subprocess.Popen] = None
+        self.on_ready = on_ready
+        self._log_thread: Optional[threading.Thread] = None
+        self._ready = False
+        self._log_file: Optional[Path] = None
 
-    def start(self) -> bool:
-        """Start the vLLM server."""
-        if self.process and self.process.poll() is None:
-            return True  # Already running
-
+    def build_cmd(self) -> list[str]:
+        """Build the vLLM launch command."""
         gpu = detect_gpu()
 
         cmd = [
-            "python3", "-m", "vllm.entrypoints.openai.api_server",
+            sys.executable, "-m", "vllm.entrypoints.openai.api_server",
             "--model", self.config.model,
             "--host", self.config.host,
             "--port", str(self.config.api_port),
@@ -37,36 +43,121 @@ class VLLMEngine:
         if self.config.quantization:
             cmd.extend(["--quantization", self.config.quantization])
 
+        if self.config.models_dir:
+            cmd.extend(["--download-dir", self.config.models_dir])
+
         # DGX Spark / GB10 unified memory needs dtype override
         if gpu and gpu.unified_memory:
             cmd.extend(["--dtype", "bfloat16"])
 
+        return cmd
+
+    def start(self) -> bool:
+        """Start the vLLM server with log streaming and readiness detection."""
+        if self.process and self.process.poll() is None:
+            return True
+
+        cmd = self.build_cmd()
+
         env = os.environ.copy()
-        env["CUDA_VISIBLE_DEVICES"] = "0"
+        env["CUDA_VISIBLE_DEVICES"] = os.environ.get("CUDA_VISIBLE_DEVICES", "0")
+
+        # Log to file
+        LOGS_DIR.mkdir(parents=True, exist_ok=True)
+        self._log_file = LOGS_DIR / "vllm.log"
 
         self.process = subprocess.Popen(
             cmd,
             env=env,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
+            bufsize=1,
+            universal_newlines=True,
         )
+
+        # Start log streaming thread
+        self._log_thread = threading.Thread(target=self._stream_logs, daemon=True)
+        self._log_thread.start()
 
         return self.process.poll() is None
 
+    def _stream_logs(self):
+        """Read vLLM stdout, write to log file, detect readiness."""
+        if not self.process or not self.process.stdout:
+            return
+
+        with open(self._log_file, "w") as log_f:
+            for line in self.process.stdout:
+                log_f.write(line)
+                log_f.flush()
+
+                # Detect vLLM readiness
+                if not self._ready and ("Uvicorn running on" in line or "Application startup complete" in line):
+                    self._ready = True
+                    if self.on_ready:
+                        self.on_ready()
+
+    def wait_ready(self, timeout: int = 300) -> bool:
+        """Block until vLLM is ready to serve requests, or timeout."""
+        start = time.time()
+        while time.time() - start < timeout:
+            if self._ready:
+                return True
+            if self.process and self.process.poll() is not None:
+                return False  # Process died
+            time.sleep(1)
+        return False
+
+    def health_check(self) -> dict:
+        """Check if vLLM is healthy and responding.
+
+        Works both when this instance owns the process and when checking
+        an externally-running vLLM server (e.g. from `ainode status`).
+        """
+        import urllib.request
+        import json
+
+        result = {
+            "process_alive": self.is_running(),
+            "api_responding": False,
+            "models_loaded": [],
+        }
+
+        try:
+            req = urllib.request.Request(f"{self.api_url}/models")
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                data = json.loads(resp.read().decode())
+                result["api_responding"] = True
+                result["models_loaded"] = [m["id"] for m in data.get("data", [])]
+        except Exception:
+            pass
+
+        return result
+
     def stop(self):
-        """Stop the vLLM server."""
+        """Graceful shutdown of vLLM server."""
         if self.process and self.process.poll() is None:
             self.process.send_signal(signal.SIGTERM)
             try:
-                self.process.wait(timeout=10)
+                self.process.wait(timeout=15)
             except subprocess.TimeoutExpired:
                 self.process.kill()
+                self.process.wait(timeout=5)
             self.process = None
+            self._ready = False
 
     def is_running(self) -> bool:
-        """Check if the vLLM server is running."""
+        """Check if the vLLM process is alive."""
         return self.process is not None and self.process.poll() is None
+
+    @property
+    def ready(self) -> bool:
+        return self._ready
 
     @property
     def api_url(self) -> str:
         return f"http://localhost:{self.config.api_port}/v1"
+
+    @property
+    def log_path(self) -> Optional[Path]:
+        return self._log_file

--- a/ainode/engine/vllm_engine.py
+++ b/ainode/engine/vllm_engine.py
@@ -109,7 +109,11 @@ class VLLMEngine:
         return False
 
     def health_check(self) -> dict:
-        """Check if vLLM is healthy and responding."""
+        """Check if vLLM is healthy and responding.
+
+        Works both when this instance owns the process and when checking
+        an externally-running vLLM server (e.g. from `ainode status`).
+        """
         import urllib.request
         import json
 
@@ -118,9 +122,6 @@ class VLLMEngine:
             "api_responding": False,
             "models_loaded": [],
         }
-
-        if not result["process_alive"]:
-            return result
 
         try:
             req = urllib.request.Request(f"{self.api_url}/models")

--- a/ainode/metrics/__init__.py
+++ b/ainode/metrics/__init__.py
@@ -1,0 +1,5 @@
+"""AINode metrics collection and monitoring."""
+
+from ainode.metrics.collector import MetricsCollector
+
+__all__ = ["MetricsCollector"]

--- a/ainode/metrics/api_routes.py
+++ b/ainode/metrics/api_routes.py
@@ -1,0 +1,40 @@
+"""API route handlers for /api/metrics endpoints."""
+
+from aiohttp import web
+
+from ainode.metrics.collector import MetricsCollector
+
+
+def register_metrics_routes(app: web.Application, collector: MetricsCollector) -> None:
+    """Register metrics endpoints on the aiohttp application.
+
+    Parameters
+    ----------
+    app : web.Application
+        The aiohttp app to add routes to.
+    collector : MetricsCollector
+        Shared collector instance used by these handlers.
+    """
+    app["metrics_collector"] = collector
+
+    app.router.add_get("/api/metrics", handle_metrics)
+    app.router.add_get("/api/metrics/gpu", handle_metrics_gpu)
+    app.router.add_get("/api/metrics/requests", handle_metrics_requests)
+
+
+async def handle_metrics(request: web.Request) -> web.Response:
+    """GET /api/metrics — full metrics snapshot."""
+    collector: MetricsCollector = request.app["metrics_collector"]
+    return web.json_response(collector.get_snapshot())
+
+
+async def handle_metrics_gpu(request: web.Request) -> web.Response:
+    """GET /api/metrics/gpu — real-time GPU stats."""
+    collector: MetricsCollector = request.app["metrics_collector"]
+    return web.json_response(collector.get_gpu_metrics())
+
+
+async def handle_metrics_requests(request: web.Request) -> web.Response:
+    """GET /api/metrics/requests — request stats with latency percentiles."""
+    collector: MetricsCollector = request.app["metrics_collector"]
+    return web.json_response(collector.get_request_stats())

--- a/ainode/metrics/collector.py
+++ b/ainode/metrics/collector.py
@@ -1,0 +1,149 @@
+"""Metrics collector — GPU stats, request counters, latency tracking."""
+
+import threading
+import time
+from collections import defaultdict
+from typing import Any, Optional
+
+
+class MetricsCollector:
+    """Thread-safe metrics collector for AINode.
+
+    Tracks GPU utilization, request counts/latency, tokens per second, and uptime.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._start_time = time.time()
+
+        # Request counters
+        self._total_requests: int = 0
+        self._error_count: int = 0
+        self._requests_by_model: dict[str, int] = defaultdict(int)
+
+        # Latency tracking (store raw values for percentile computation)
+        self._latencies: list[float] = []
+
+        # Token tracking
+        self._total_tokens: int = 0
+
+    # ------------------------------------------------------------------
+    # Recording
+    # ------------------------------------------------------------------
+
+    def record_request(
+        self,
+        model: str,
+        latency_ms: float,
+        tokens_generated: int = 0,
+        error: bool = False,
+    ) -> None:
+        """Record a completed inference request.
+
+        Parameters
+        ----------
+        model : str
+            Model name that served the request.
+        latency_ms : float
+            End-to-end latency in milliseconds.
+        tokens_generated : int
+            Number of tokens produced (0 if unknown).
+        error : bool
+            Whether the request resulted in an error.
+        """
+        with self._lock:
+            self._total_requests += 1
+            self._requests_by_model[model] += 1
+            self._latencies.append(latency_ms)
+            self._total_tokens += tokens_generated
+            if error:
+                self._error_count += 1
+
+    # ------------------------------------------------------------------
+    # Snapshots
+    # ------------------------------------------------------------------
+
+    def get_snapshot(self) -> dict[str, Any]:
+        """Return a full metrics snapshot (requests, latency, GPU, uptime)."""
+        with self._lock:
+            request_stats = self._request_stats_locked()
+        gpu = self.get_gpu_metrics()
+        return {
+            "uptime_seconds": round(time.time() - self._start_time, 1),
+            "requests": request_stats,
+            "gpu": gpu,
+        }
+
+    def get_request_stats(self) -> dict[str, Any]:
+        """Return request-only stats (count, latency percentiles, errors)."""
+        with self._lock:
+            return self._request_stats_locked()
+
+    def get_gpu_metrics(self) -> dict[str, Any]:
+        """Query real-time GPU stats via pynvml.
+
+        Returns a dict with utilization_percent, memory_used_mb, memory_total_mb,
+        and temperature_c.  Returns an error dict if pynvml is unavailable.
+        """
+        try:
+            import pynvml
+
+            pynvml.nvmlInit()
+            handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+
+            util = pynvml.nvmlDeviceGetUtilizationRates(handle)
+            mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
+            temp = pynvml.nvmlDeviceGetTemperature(handle, pynvml.NVML_TEMPERATURE_GPU)
+
+            pynvml.nvmlShutdown()
+
+            return {
+                "utilization_percent": util.gpu,
+                "memory_used_mb": round(mem.used / (1024 * 1024)),
+                "memory_total_mb": round(mem.total / (1024 * 1024)),
+                "temperature_c": temp,
+            }
+        except Exception as exc:
+            return {"error": str(exc)}
+
+    # ------------------------------------------------------------------
+    # Internal helpers (caller must hold self._lock)
+    # ------------------------------------------------------------------
+
+    def _request_stats_locked(self) -> dict[str, Any]:
+        latencies = sorted(self._latencies) if self._latencies else []
+        uptime = time.time() - self._start_time
+
+        stats: dict[str, Any] = {
+            "total": self._total_requests,
+            "errors": self._error_count,
+            "by_model": dict(self._requests_by_model),
+            "tokens_generated": self._total_tokens,
+        }
+
+        if latencies:
+            stats["latency_ms"] = {
+                "p50": self._percentile(latencies, 50),
+                "p95": self._percentile(latencies, 95),
+                "p99": self._percentile(latencies, 99),
+            }
+        else:
+            stats["latency_ms"] = {"p50": 0, "p95": 0, "p99": 0}
+
+        if uptime > 0 and self._total_tokens > 0:
+            stats["tokens_per_second"] = round(self._total_tokens / uptime, 2)
+        else:
+            stats["tokens_per_second"] = 0
+
+        return stats
+
+    @staticmethod
+    def _percentile(sorted_data: list[float], pct: int) -> float:
+        """Compute the *pct*-th percentile from pre-sorted data."""
+        if not sorted_data:
+            return 0.0
+        k = (len(sorted_data) - 1) * (pct / 100)
+        f = int(k)
+        c = f + 1 if f + 1 < len(sorted_data) else f
+        d = k - f
+        return round(sorted_data[f] + d * (sorted_data[c] - sorted_data[f]), 2)

--- a/ainode/models/__init__.py
+++ b/ainode/models/__init__.py
@@ -1,0 +1,5 @@
+"""AINode model management — download, list, delete, and organize models."""
+
+from ainode.models.registry import ModelManager, MODEL_CATALOG
+
+__all__ = ["ModelManager", "MODEL_CATALOG"]

--- a/ainode/models/api_routes.py
+++ b/ainode/models/api_routes.py
@@ -1,0 +1,133 @@
+"""API route handlers for model management."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Optional
+
+from aiohttp import web
+
+from ainode.core.gpu import detect_gpu
+from ainode.models.registry import ModelManager, MODEL_CATALOG
+
+
+def register_model_routes(app: web.Application, manager: Optional[ModelManager] = None) -> None:
+    """Register model management routes on the aiohttp app."""
+    if manager is None:
+        manager = ModelManager()
+
+    app["model_manager"] = manager
+    app["download_jobs"] = {}
+
+    app.router.add_get("/api/models", handle_list_models)
+    app.router.add_get("/api/models/recommended", handle_recommended)
+    app.router.add_get("/api/models/{model_id}", handle_get_model)
+    app.router.add_post("/api/models/{model_id}/download", handle_download_model)
+    app.router.add_delete("/api/models/{model_id}", handle_delete_model)
+
+
+# -- Handlers ------------------------------------------------------------------
+
+async def handle_list_models(request: web.Request) -> web.Response:
+    """GET /api/models -- list all catalog models with download status."""
+    manager: ModelManager = request.app["model_manager"]
+    models = manager.list_available()
+    return web.json_response({"models": models})
+
+
+async def handle_get_model(request: web.Request) -> web.Response:
+    """GET /api/models/:model_id -- info for a specific model."""
+    model_id = request.match_info["model_id"]
+    manager: ModelManager = request.app["model_manager"]
+    info = manager.get_model_info(model_id)
+    if info is None:
+        return web.json_response(
+            {"error": f"Model '{model_id}' not found in catalog"},
+            status=404,
+        )
+    return web.json_response(info)
+
+
+async def handle_download_model(request: web.Request) -> web.Response:
+    """POST /api/models/:model_id/download -- start async download, return 202."""
+    model_id = request.match_info["model_id"]
+    manager: ModelManager = request.app["model_manager"]
+
+    if model_id not in MODEL_CATALOG:
+        return web.json_response(
+            {"error": f"Model '{model_id}' not found in catalog"},
+            status=404,
+        )
+
+    job_id = str(uuid.uuid4())
+    jobs: dict = request.app["download_jobs"]
+    jobs[job_id] = {"model_id": model_id, "status": "downloading", "error": None}
+
+    loop = asyncio.get_event_loop()
+    loop.create_task(_run_download(manager, model_id, job_id, jobs))
+
+    return web.json_response(
+        {"job_id": job_id, "model_id": model_id, "status": "downloading"},
+        status=202,
+    )
+
+
+async def handle_delete_model(request: web.Request) -> web.Response:
+    """DELETE /api/models/:model_id -- delete a downloaded model."""
+    model_id = request.match_info["model_id"]
+    manager: ModelManager = request.app["model_manager"]
+
+    if model_id not in MODEL_CATALOG:
+        return web.json_response(
+            {"error": f"Model '{model_id}' not found in catalog"},
+            status=404,
+        )
+
+    try:
+        deleted = manager.delete_model(model_id)
+    except Exception as exc:
+        return web.json_response({"error": str(exc)}, status=500)
+
+    if deleted:
+        return web.json_response({"status": "deleted", "model_id": model_id})
+    return web.json_response(
+        {"error": f"Model '{model_id}' is not downloaded"},
+        status=404,
+    )
+
+
+async def handle_recommended(request: web.Request) -> web.Response:
+    """GET /api/models/recommended -- models that fit this node's GPU."""
+    gpu = detect_gpu()
+    if gpu is None:
+        return web.json_response(
+            {"error": "No GPU detected", "models": []},
+            status=200,
+        )
+
+    gpu_memory_gb = gpu.memory_total_mb / 1024
+    manager: ModelManager = request.app["model_manager"]
+    models = manager.recommend_for_gpu(gpu_memory_gb)
+    return web.json_response({
+        "gpu_memory_gb": round(gpu_memory_gb, 1),
+        "models": models,
+    })
+
+
+# -- Background download task -------------------------------------------------
+
+async def _run_download(
+    manager: ModelManager,
+    model_id: str,
+    job_id: str,
+    jobs: dict,
+) -> None:
+    """Run model download in a thread so we don't block the event loop."""
+    loop = asyncio.get_event_loop()
+    try:
+        await loop.run_in_executor(None, manager.download_model, model_id)
+        jobs[job_id]["status"] = "complete"
+    except Exception as exc:
+        jobs[job_id]["status"] = "failed"
+        jobs[job_id]["error"] = str(exc)

--- a/ainode/models/registry.py
+++ b/ainode/models/registry.py
@@ -1,0 +1,268 @@
+"""Model registry and manager — catalog, download, delete, and recommend models."""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Callable, Optional
+
+from ainode.core.config import MODELS_DIR
+
+
+@dataclass
+class ModelInfo:
+    """Metadata for a model in the catalog."""
+
+    id: str
+    name: str
+    hf_repo: str
+    size_gb: float
+    description: str
+    quantization: Optional[str] = None
+    min_memory_gb: float = 0.0
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+# ---- Curated model catalog --------------------------------------------------
+
+MODEL_CATALOG: dict[str, ModelInfo] = {
+    "llama-3.2-3b": ModelInfo(
+        id="llama-3.2-3b",
+        name="Llama 3.2 3B Instruct",
+        hf_repo="meta-llama/Llama-3.2-3B-Instruct",
+        size_gb=6.0,
+        description="Compact, fast model for everyday tasks. Great starter model.",
+        min_memory_gb=8,
+    ),
+    "llama-3.1-8b": ModelInfo(
+        id="llama-3.1-8b",
+        name="Llama 3.1 8B Instruct",
+        hf_repo="meta-llama/Llama-3.1-8B-Instruct",
+        size_gb=16.0,
+        description="Strong general-purpose model. Good balance of quality and speed.",
+        min_memory_gb=16,
+    ),
+    "llama-3.1-70b-awq": ModelInfo(
+        id="llama-3.1-70b-awq",
+        name="Llama 3.1 70B Instruct AWQ",
+        hf_repo="hugging-quants/Meta-Llama-3.1-70B-Instruct-AWQ-INT4",
+        size_gb=38.0,
+        description="Quantized 70B for high-quality output on single-node hardware.",
+        quantization="awq",
+        min_memory_gb=48,
+    ),
+    "qwen-2.5-72b": ModelInfo(
+        id="qwen-2.5-72b",
+        name="Qwen 2.5 72B Instruct",
+        hf_repo="Qwen/Qwen2.5-72B-Instruct",
+        size_gb=145.0,
+        description="Flagship multilingual model. Excellent reasoning and code.",
+        min_memory_gb=160,
+    ),
+    "deepseek-r1-7b": ModelInfo(
+        id="deepseek-r1-7b",
+        name="DeepSeek R1 Distill Qwen 7B",
+        hf_repo="deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
+        size_gb=14.0,
+        description="Reasoning-focused model distilled from DeepSeek R1.",
+        min_memory_gb=16,
+    ),
+    "mistral-7b": ModelInfo(
+        id="mistral-7b",
+        name="Mistral 7B Instruct v0.3",
+        hf_repo="mistralai/Mistral-7B-Instruct-v0.3",
+        size_gb=14.0,
+        description="Fast, efficient 7B with strong instruction following.",
+        min_memory_gb=16,
+    ),
+    "phi-3-mini": ModelInfo(
+        id="phi-3-mini",
+        name="Phi-3 Mini 4K Instruct",
+        hf_repo="microsoft/Phi-3-mini-4k-instruct",
+        size_gb=7.5,
+        description="Microsoft's compact model. Strong reasoning for its size.",
+        min_memory_gb=8,
+    ),
+    "codellama-34b": ModelInfo(
+        id="codellama-34b",
+        name="CodeLlama 34B Instruct",
+        hf_repo="meta-llama/CodeLlama-34b-Instruct-hf",
+        size_gb=63.0,
+        description="Specialized code generation and understanding model.",
+        min_memory_gb=72,
+    ),
+}
+
+
+class ModelManager:
+    """Manage model downloads, listing, and deletion."""
+
+    def __init__(self, models_dir: Optional[str | Path] = None):
+        self.models_dir = Path(models_dir) if models_dir else MODELS_DIR
+        self.models_dir.mkdir(parents=True, exist_ok=True)
+        self._active_downloads: dict[str, dict] = {}
+
+    # -- Catalog queries -------------------------------------------------------
+
+    def list_available(self) -> list[dict]:
+        """Return catalog models annotated with download status."""
+        results = []
+        for model_id, info in MODEL_CATALOG.items():
+            entry = info.to_dict()
+            entry["downloaded"] = self._is_downloaded(model_id)
+            local_size = self._local_size_gb(model_id)
+            if local_size is not None:
+                entry["local_size_gb"] = round(local_size, 2)
+            results.append(entry)
+        return results
+
+    def list_downloaded(self) -> list[dict]:
+        """Scan models_dir and return info for every downloaded model."""
+        downloaded = []
+        if not self.models_dir.exists():
+            return downloaded
+
+        for child in sorted(self.models_dir.iterdir()):
+            if not child.is_dir():
+                continue
+            # Map directory name back to catalog entry
+            catalog_entry = self._find_catalog_by_dir(child.name)
+            if catalog_entry:
+                entry = catalog_entry.to_dict()
+                entry["downloaded"] = True
+                entry["local_size_gb"] = round(self._dir_size_gb(child), 2)
+                downloaded.append(entry)
+            else:
+                # Not in catalog — user-added model
+                downloaded.append({
+                    "id": child.name,
+                    "name": child.name,
+                    "hf_repo": child.name.replace("--", "/", 1),
+                    "size_gb": None,
+                    "description": "User-downloaded model (not in catalog)",
+                    "quantization": None,
+                    "min_memory_gb": 0,
+                    "downloaded": True,
+                    "local_size_gb": round(self._dir_size_gb(child), 2),
+                })
+        return downloaded
+
+    def get_model_info(self, model_id: str) -> Optional[dict]:
+        """Return catalog info for a model, plus local size if downloaded."""
+        info = MODEL_CATALOG.get(model_id)
+        if info is None:
+            return None
+        entry = info.to_dict()
+        entry["downloaded"] = self._is_downloaded(model_id)
+        local_size = self._local_size_gb(model_id)
+        if local_size is not None:
+            entry["local_size_gb"] = round(local_size, 2)
+        return entry
+
+    def recommend_for_gpu(self, gpu_memory_gb: float) -> list[dict]:
+        """Return models that fit within the given GPU memory."""
+        results = []
+        for model_id, info in MODEL_CATALOG.items():
+            if info.min_memory_gb <= gpu_memory_gb:
+                entry = info.to_dict()
+                entry["downloaded"] = self._is_downloaded(model_id)
+                results.append(entry)
+        # Sort by size descending so the most capable fitting model is first
+        results.sort(key=lambda m: m["size_gb"], reverse=True)
+        return results
+
+    # -- Download / Delete -----------------------------------------------------
+
+    def download_model(
+        self,
+        model_id: str,
+        progress_callback: Optional[Callable[[float], None]] = None,
+    ) -> Path:
+        """Download a model from HuggingFace Hub.
+
+        Parameters
+        ----------
+        model_id : str
+            Key from MODEL_CATALOG.
+        progress_callback : callable, optional
+            Called with progress fraction (0.0 to 1.0).
+
+        Returns
+        -------
+        Path
+            Local path where the model was downloaded.
+        """
+        info = MODEL_CATALOG.get(model_id)
+        if info is None:
+            raise ValueError(f"Unknown model: {model_id}. Use a key from MODEL_CATALOG.")
+
+        try:
+            from huggingface_hub import snapshot_download
+        except ImportError:
+            raise RuntimeError(
+                "huggingface_hub is required for model downloads. "
+                "Install it with: pip install huggingface_hub"
+            )
+
+        local_dir = self.models_dir / self._repo_to_dirname(info.hf_repo)
+
+        download_path = snapshot_download(
+            repo_id=info.hf_repo,
+            local_dir=str(local_dir),
+            local_dir_use_symlinks=False,
+        )
+
+        return Path(download_path)
+
+    def delete_model(self, model_id: str) -> bool:
+        """Delete a downloaded model from disk.
+
+        Returns True if deleted, False if not found.
+        """
+        info = MODEL_CATALOG.get(model_id)
+        if info is None:
+            raise ValueError(f"Unknown model: {model_id}")
+
+        model_dir = self.models_dir / self._repo_to_dirname(info.hf_repo)
+        if model_dir.exists():
+            shutil.rmtree(model_dir)
+            return True
+        return False
+
+    # -- Internal helpers ------------------------------------------------------
+
+    @staticmethod
+    def _repo_to_dirname(hf_repo: str) -> str:
+        """Convert 'org/model-name' to 'org--model-name' for filesystem safety."""
+        return hf_repo.replace("/", "--")
+
+    def _model_dir(self, model_id: str) -> Optional[Path]:
+        """Return the local directory for a catalog model, or None."""
+        info = MODEL_CATALOG.get(model_id)
+        if info is None:
+            return None
+        return self.models_dir / self._repo_to_dirname(info.hf_repo)
+
+    def _is_downloaded(self, model_id: str) -> bool:
+        d = self._model_dir(model_id)
+        return d is not None and d.exists() and any(d.iterdir())
+
+    def _local_size_gb(self, model_id: str) -> Optional[float]:
+        d = self._model_dir(model_id)
+        if d is None or not d.exists():
+            return None
+        return self._dir_size_gb(d)
+
+    @staticmethod
+    def _dir_size_gb(path: Path) -> float:
+        total = sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
+        return total / (1024**3)
+
+    def _find_catalog_by_dir(self, dirname: str) -> Optional[ModelInfo]:
+        for info in MODEL_CATALOG.values():
+            if ModelManager._repo_to_dirname(info.hf_repo) == dirname:
+                return info
+        return None

--- a/ainode/onboarding/api_routes.py
+++ b/ainode/onboarding/api_routes.py
@@ -1,0 +1,95 @@
+"""Onboarding API route handlers for browser-based setup wizard."""
+
+import socket
+from aiohttp import web
+
+from ainode.core.config import NodeConfig
+from ainode.core.gpu import detect_gpu
+from ainode.models.registry import MODEL_CATALOG
+
+
+def register_onboarding_routes(app: web.Application) -> None:
+    """Register all onboarding API routes on the given app."""
+    app.router.add_get("/api/onboarding/status", handle_onboarding_status)
+    app.router.add_get("/api/onboarding/suggestions", handle_onboarding_suggestions)
+    app.router.add_post("/api/onboarding/complete", handle_onboarding_complete)
+
+
+async def handle_onboarding_status(request: web.Request) -> web.Response:
+    """Return whether this node has completed onboarding."""
+    config: NodeConfig = request.app["config"]
+    return web.json_response({
+        "onboarded": config.onboarded,
+        "needs_setup": not config.onboarded,
+    })
+
+
+async def handle_onboarding_suggestions(request: web.Request) -> web.Response:
+    """Return hostname and recommended models for the detected GPU."""
+    hostname = socket.gethostname()
+    gpu = detect_gpu()
+
+    gpu_memory_gb = 0.0
+    gpu_info = None
+    if gpu:
+        gpu_memory_gb = gpu.memory_total_mb / 1024
+        gpu_info = {
+            "name": gpu.name,
+            "memory_gb": round(gpu_memory_gb, 1),
+            "unified_memory": gpu.unified_memory,
+        }
+
+    # Build model list with fit indicators
+    models = []
+    for model_id, info in MODEL_CATALOG.items():
+        entry = info.to_dict()
+        entry["fits_gpu"] = gpu_memory_gb >= info.min_memory_gb if gpu else False
+        models.append(entry)
+
+    # Sort: fitting models first (by size desc), then non-fitting (by size asc)
+    models.sort(key=lambda m: (-m["fits_gpu"], -m["size_gb"] if m["fits_gpu"] else m["size_gb"]))
+
+    return web.json_response({
+        "hostname": hostname,
+        "gpu": gpu_info,
+        "models": models,
+    })
+
+
+async def handle_onboarding_complete(request: web.Request) -> web.Response:
+    """Accept onboarding data and save config."""
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response(
+            {"error": "Invalid JSON body"}, status=400,
+        )
+
+    config: NodeConfig = request.app["config"]
+
+    node_name = body.get("node_name", "").strip()
+    if node_name:
+        config.node_name = node_name
+
+    model = body.get("model", "").strip()
+    if model:
+        config.model = model
+        # Set quantization for AWQ models
+        if "awq" in model.lower():
+            config.quantization = "awq"
+        else:
+            config.quantization = None
+
+    email = body.get("email", "").strip()
+    if email:
+        config.email = email
+
+    config.onboarded = True
+    config.save()
+
+    return web.json_response({
+        "status": "ok",
+        "node_name": config.node_name,
+        "model": config.model,
+        "onboarded": True,
+    })

--- a/ainode/service/__init__.py
+++ b/ainode/service/__init__.py
@@ -1,0 +1,1 @@
+"""AINode systemd service management."""

--- a/ainode/service/systemd.py
+++ b/ainode/service/systemd.py
@@ -1,0 +1,190 @@
+"""Systemd service management for AINode.
+
+Provides install, uninstall, enable, disable, start, stop, restart,
+status, and is_installed operations for running AINode as a systemd service.
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+
+SERVICE_NAME = "ainode.service"
+
+SYSTEM_UNIT_DIR = Path("/etc/systemd/system")
+USER_UNIT_DIR = Path.home() / ".config" / "systemd" / "user"
+
+UNIT_FILE_TEMPLATE = """\
+[Unit]
+Description=AINode — Local AI inference platform
+Documentation=https://ainode.dev
+After=network.target nvidia-persistenced.service nvidia-fabricmanager.service
+Wants=nvidia-persistenced.service
+
+[Service]
+Type=simple
+ExecStart={exec_start}
+Restart=on-failure
+RestartSec=10
+TimeoutStartSec=600
+TimeoutStopSec=30
+
+# GPU environment
+Environment=NVIDIA_VISIBLE_DEVICES=all
+Environment=CUDA_DEVICE_ORDER=PCI_BUS_ID
+Environment=AINODE_HOME={ainode_home}
+
+# Hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths={ainode_home}
+
+[Install]
+WantedBy={wanted_by}
+"""
+
+
+def _ainode_bin() -> str:
+    """Return the path to the ainode executable."""
+    return shutil.which("ainode") or "ainode"
+
+
+def _ainode_home() -> str:
+    """Return the AINODE_HOME directory."""
+    return os.environ.get("AINODE_HOME", str(Path.home() / ".ainode"))
+
+
+def _unit_dir(user_mode: bool) -> Path:
+    if user_mode:
+        return USER_UNIT_DIR
+    return SYSTEM_UNIT_DIR
+
+
+def _unit_path(user_mode: bool) -> Path:
+    return _unit_dir(user_mode) / SERVICE_NAME
+
+
+def _systemctl(args: list[str], user_mode: bool = False, capture: bool = False):
+    """Run a systemctl command."""
+    cmd = ["systemctl"]
+    if user_mode:
+        cmd.append("--user")
+    cmd.extend(args)
+    if capture:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        return result
+    subprocess.run(cmd, check=True, timeout=30)
+
+
+def generate_unit_file(user_mode: bool = False) -> str:
+    """Generate the systemd unit file content."""
+    wanted_by = "default.target" if user_mode else "multi-user.target"
+    return UNIT_FILE_TEMPLATE.format(
+        exec_start=f"{_ainode_bin()} start",
+        ainode_home=_ainode_home(),
+        wanted_by=wanted_by,
+    )
+
+
+def is_installed(user_mode: bool = False) -> bool:
+    """Check if the AINode service unit file exists."""
+    return _unit_path(user_mode).exists()
+
+
+def install_service(user_mode: bool = False) -> None:
+    """Write the unit file and reload the systemd daemon."""
+    unit_dir = _unit_dir(user_mode)
+    unit_dir.mkdir(parents=True, exist_ok=True)
+
+    unit_path = _unit_path(user_mode)
+    unit_content = generate_unit_file(user_mode=user_mode)
+    unit_path.write_text(unit_content)
+
+    _systemctl(["daemon-reload"], user_mode=user_mode)
+
+
+def uninstall_service(user_mode: bool = False) -> None:
+    """Stop, disable, and remove the unit file."""
+    if not is_installed(user_mode):
+        return
+
+    # Best-effort stop and disable before removal
+    try:
+        stop_service(user_mode=user_mode)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+    try:
+        disable_service(user_mode=user_mode)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+
+    _unit_path(user_mode).unlink(missing_ok=True)
+    _systemctl(["daemon-reload"], user_mode=user_mode)
+
+
+def enable_service(user_mode: bool = False) -> None:
+    """Enable AINode to start on boot."""
+    _systemctl(["enable", SERVICE_NAME], user_mode=user_mode)
+
+
+def disable_service(user_mode: bool = False) -> None:
+    """Disable AINode from starting on boot."""
+    _systemctl(["disable", SERVICE_NAME], user_mode=user_mode)
+
+
+def start_service(user_mode: bool = False) -> None:
+    """Start the AINode service."""
+    _systemctl(["start", SERVICE_NAME], user_mode=user_mode)
+
+
+def stop_service(user_mode: bool = False) -> None:
+    """Stop the AINode service."""
+    _systemctl(["stop", SERVICE_NAME], user_mode=user_mode)
+
+
+def restart_service(user_mode: bool = False) -> None:
+    """Restart the AINode service."""
+    _systemctl(["restart", SERVICE_NAME], user_mode=user_mode)
+
+
+def status_service(user_mode: bool = False) -> dict:
+    """Return service status and recent journal lines.
+
+    Returns dict with keys: state, enabled, journal_lines.
+    """
+    result = {"state": "unknown", "enabled": False, "journal_lines": []}
+
+    # Active state
+    r = _systemctl(["is-active", SERVICE_NAME], user_mode=user_mode, capture=True)
+    result["state"] = r.stdout.strip() or "unknown"
+
+    # Enabled state
+    r = _systemctl(["is-enabled", SERVICE_NAME], user_mode=user_mode, capture=True)
+    result["enabled"] = r.stdout.strip() == "enabled"
+
+    # Recent journal lines
+    result["journal_lines"] = get_journal_lines(user_mode=user_mode, lines=20)
+
+    return result
+
+
+def get_journal_lines(
+    user_mode: bool = False,
+    lines: int = 50,
+    follow: bool = False,
+) -> list[str]:
+    """Fetch recent journal lines for the AINode service."""
+    cmd = ["journalctl"]
+    if user_mode:
+        cmd.append("--user")
+    cmd.extend(["-u", SERVICE_NAME, "-n", str(lines), "--no-pager"])
+    if follow:
+        cmd.append("-f")
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        return r.stdout.strip().splitlines() if r.stdout else []
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return []

--- a/ainode/training/__init__.py
+++ b/ainode/training/__init__.py
@@ -1,0 +1,5 @@
+"""AINode training/fine-tuning engine."""
+
+from ainode.training.engine import TrainingConfig, TrainingJob, TrainingManager
+
+__all__ = ["TrainingConfig", "TrainingJob", "TrainingManager"]

--- a/ainode/training/_run_training.py
+++ b/ainode/training/_run_training.py
@@ -1,0 +1,184 @@
+"""Internal training script — launched as a subprocess by TrainingJob.
+
+Reads a config JSON and runs HuggingFace Transformers + PEFT training,
+emitting structured progress lines for the parent process to parse.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="AINode training runner")
+    parser.add_argument("--config", required=True, help="Path to training config JSON")
+    args = parser.parse_args()
+
+    config_path = Path(args.config)
+    if not config_path.exists():
+        print(f"Config file not found: {config_path}", file=sys.stderr)
+        sys.exit(1)
+
+    config = json.loads(config_path.read_text())
+
+    try:
+        import torch
+        from transformers import (
+            AutoModelForCausalLM,
+            AutoTokenizer,
+            TrainingArguments,
+            Trainer,
+            TrainerCallback,
+        )
+        from datasets import load_dataset
+    except ImportError as exc:
+        print(
+            f"Missing training dependency: {exc}. "
+            "Install with: pip install torch transformers datasets peft",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    base_model = config["base_model"]
+    dataset_path = config["dataset_path"]
+    output_dir = config.get("output_dir", "./output")
+    method = config.get("method", "lora")
+    num_epochs = config.get("num_epochs", 3)
+    batch_size = config.get("batch_size", 4)
+    learning_rate = config.get("learning_rate", 2e-4)
+    lora_rank = config.get("lora_rank", 16)
+    lora_alpha = config.get("lora_alpha", 32)
+    max_seq_length = config.get("max_seq_length", 2048)
+
+    print(f"Loading tokenizer: {base_model}")
+    tokenizer = AutoTokenizer.from_pretrained(base_model, trust_remote_code=True)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    print(f"Loading model: {base_model}")
+    model = AutoModelForCausalLM.from_pretrained(
+        base_model,
+        torch_dtype=torch.bfloat16,
+        device_map="auto",
+        trust_remote_code=True,
+    )
+
+    if method == "lora":
+        try:
+            from peft import LoraConfig, get_peft_model, TaskType
+        except ImportError:
+            print("PEFT is required for LoRA training: pip install peft", file=sys.stderr)
+            sys.exit(1)
+
+        peft_config = LoraConfig(
+            task_type=TaskType.CAUSAL_LM,
+            r=lora_rank,
+            lora_alpha=lora_alpha,
+            lora_dropout=0.05,
+            target_modules=["q_proj", "v_proj", "k_proj", "o_proj"],
+        )
+        model = get_peft_model(model, peft_config)
+        model.print_trainable_parameters()
+
+    # Load dataset (supports JSON, JSONL, CSV, or HF dataset name)
+    print(f"Loading dataset: {dataset_path}")
+    if Path(dataset_path).exists():
+        ext = Path(dataset_path).suffix.lower()
+        if ext in (".json", ".jsonl"):
+            dataset = load_dataset("json", data_files=dataset_path, split="train")
+        elif ext == ".csv":
+            dataset = load_dataset("csv", data_files=dataset_path, split="train")
+        else:
+            dataset = load_dataset("json", data_files=dataset_path, split="train")
+    else:
+        # Treat as HuggingFace dataset name
+        dataset = load_dataset(dataset_path, split="train")
+
+    # Tokenize
+    def tokenize_fn(examples):
+        # Support common dataset formats
+        if "text" in examples:
+            texts = examples["text"]
+        elif "instruction" in examples and "output" in examples:
+            texts = [
+                f"### Instruction:\n{inst}\n\n### Response:\n{out}"
+                for inst, out in zip(examples["instruction"], examples["output"])
+            ]
+        elif "prompt" in examples and "completion" in examples:
+            texts = [
+                f"{p}{c}" for p, c in zip(examples["prompt"], examples["completion"])
+            ]
+        else:
+            # Fallback: concatenate all string fields
+            keys = [k for k in examples.keys() if isinstance(examples[k][0], str)]
+            texts = [" ".join(examples[k][i] for k in keys) for i in range(len(examples[keys[0]]))]
+
+        return tokenizer(
+            texts,
+            truncation=True,
+            max_length=max_seq_length,
+            padding="max_length",
+        )
+
+    dataset = dataset.map(tokenize_fn, batched=True, remove_columns=dataset.column_names)
+    dataset = dataset.rename_column("input_ids", "input_ids")
+    # Set labels = input_ids for causal LM
+    dataset = dataset.map(lambda x: {"labels": x["input_ids"]})
+
+    # Progress callback
+    class ProgressCallback(TrainerCallback):
+        def __init__(self, total_epochs):
+            self.total_epochs = total_epochs
+
+        def on_log(self, _args, state, control, logs=None, **kwargs):
+            if logs and "loss" in logs:
+                epoch = state.epoch or 0
+                progress = (epoch / self.total_epochs) * 100 if self.total_epochs > 0 else 0
+                payload = {
+                    "epoch": int(epoch),
+                    "loss": round(logs["loss"], 4),
+                    "progress": round(progress, 1),
+                    "step": state.global_step,
+                }
+                print(f"AINODE_PROGRESS:{json.dumps(payload)}", flush=True)
+
+    training_args = TrainingArguments(
+        output_dir=output_dir,
+        num_train_epochs=num_epochs,
+        per_device_train_batch_size=batch_size,
+        learning_rate=learning_rate,
+        bf16=True,
+        logging_steps=10,
+        save_strategy="epoch",
+        save_total_limit=2,
+        report_to="none",
+        gradient_accumulation_steps=max(1, 8 // batch_size),
+        warmup_ratio=0.03,
+        lr_scheduler_type="cosine",
+        optim="adamw_torch",
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=dataset,
+        callbacks=[ProgressCallback(num_epochs)],
+    )
+
+    print("Starting training...")
+    trainer.train()
+
+    # Save final model
+    print(f"Saving model to {output_dir}")
+    trainer.save_model(output_dir)
+    tokenizer.save_pretrained(output_dir)
+
+    print(f"AINODE_PROGRESS:{json.dumps({'epoch': num_epochs, 'loss': 0, 'progress': 100.0})}")
+    print("Training complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/ainode/training/api_routes.py
+++ b/ainode/training/api_routes.py
@@ -1,0 +1,119 @@
+"""API routes for the training engine — mounted under /api/training/."""
+
+from __future__ import annotations
+
+from aiohttp import web
+
+from ainode.training.engine import TrainingConfig, TrainingManager
+
+
+def setup_training_routes(app: web.Application, manager: TrainingManager) -> None:
+    """Register training API routes on the aiohttp app."""
+    app["training_manager"] = manager
+
+    app.router.add_post("/api/training/jobs", handle_submit_job)
+    app.router.add_get("/api/training/jobs", handle_list_jobs)
+    app.router.add_get("/api/training/jobs/{job_id}", handle_get_job)
+    app.router.add_delete("/api/training/jobs/{job_id}", handle_cancel_job)
+    app.router.add_get("/api/training/jobs/{job_id}/logs", handle_get_logs)
+
+
+async def handle_submit_job(request: web.Request) -> web.Response:
+    """POST /api/training/jobs — submit a new training job."""
+    manager: TrainingManager = request.app["training_manager"]
+
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response(
+            {"error": "Invalid JSON body"}, status=400
+        )
+
+    try:
+        config = TrainingConfig.from_dict(body)
+    except Exception as exc:
+        return web.json_response(
+            {"error": f"Invalid config: {exc}"}, status=400
+        )
+
+    try:
+        job = manager.submit_job(config)
+    except ValueError as exc:
+        return web.json_response(
+            {"error": str(exc)}, status=400
+        )
+
+    # Attempt to start if nothing is running
+    await manager.start_next()
+
+    return web.json_response(job.get_status(), status=201)
+
+
+async def handle_list_jobs(request: web.Request) -> web.Response:
+    """GET /api/training/jobs — list all training jobs."""
+    manager: TrainingManager = request.app["training_manager"]
+    return web.json_response({"jobs": manager.list_jobs()})
+
+
+async def handle_get_job(request: web.Request) -> web.Response:
+    """GET /api/training/jobs/:job_id — get job status + progress."""
+    manager: TrainingManager = request.app["training_manager"]
+    job_id = request.match_info["job_id"]
+
+    job = manager.get_job(job_id)
+    if job is None:
+        return web.json_response(
+            {"error": f"Job not found: {job_id}"}, status=404
+        )
+
+    return web.json_response(job.get_status())
+
+
+async def handle_cancel_job(request: web.Request) -> web.Response:
+    """DELETE /api/training/jobs/:job_id — cancel a running or pending job."""
+    manager: TrainingManager = request.app["training_manager"]
+    job_id = request.match_info["job_id"]
+
+    job = manager.get_job(job_id)
+    if job is None:
+        return web.json_response(
+            {"error": f"Job not found: {job_id}"}, status=404
+        )
+
+    cancelled = await manager.cancel_job(job_id)
+    if not cancelled:
+        return web.json_response(
+            {"error": f"Job {job_id} cannot be cancelled (status: {job.status.value})"},
+            status=409,
+        )
+
+    return web.json_response({"status": "cancelled", "job_id": job_id})
+
+
+async def handle_get_logs(request: web.Request) -> web.Response:
+    """GET /api/training/jobs/:job_id/logs — return training logs."""
+    manager: TrainingManager = request.app["training_manager"]
+    job_id = request.match_info["job_id"]
+
+    job = manager.get_job(job_id)
+    if job is None:
+        return web.json_response(
+            {"error": f"Job not found: {job_id}"}, status=404
+        )
+
+    # Support ?tail=N to get only the last N log lines
+    tail = request.query.get("tail")
+    logs = job.logs
+    if tail is not None:
+        try:
+            n = int(tail)
+            logs = logs[-n:]
+        except ValueError:
+            pass
+
+    return web.json_response({
+        "job_id": job_id,
+        "status": job.status.value,
+        "logs": logs,
+        "total_lines": len(job.logs),
+    })

--- a/ainode/training/engine.py
+++ b/ainode/training/engine.py
@@ -1,0 +1,368 @@
+"""Training engine — run fine-tuning jobs on local GPUs using HuggingFace + PEFT."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import dataclass, field, asdict
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+from ainode.core.config import AINODE_HOME
+
+
+TRAINING_DIR = AINODE_HOME / "training"
+JOBS_DIR = TRAINING_DIR / "jobs"
+
+
+class TrainingMethod(str, Enum):
+    LORA = "lora"
+    FULL = "full"
+
+
+class JobStatus(str, Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+@dataclass
+class TrainingConfig:
+    """Configuration for a training/fine-tuning job."""
+
+    base_model: str
+    dataset_path: str
+    output_dir: Optional[str] = None
+    method: str = "lora"
+    num_epochs: int = 3
+    batch_size: int = 4
+    learning_rate: float = 2e-4
+    lora_rank: int = 16
+    lora_alpha: int = 32
+    max_seq_length: int = 2048
+
+    def validate(self) -> list[str]:
+        """Return a list of validation errors (empty means valid)."""
+        errors: list[str] = []
+
+        if not self.base_model or not self.base_model.strip():
+            errors.append("base_model is required")
+
+        if not self.dataset_path or not self.dataset_path.strip():
+            errors.append("dataset_path is required")
+
+        if self.method not in ("lora", "full"):
+            errors.append(f"method must be 'lora' or 'full', got '{self.method}'")
+
+        if self.num_epochs < 1:
+            errors.append("num_epochs must be >= 1")
+
+        if self.batch_size < 1:
+            errors.append("batch_size must be >= 1")
+
+        if self.learning_rate <= 0:
+            errors.append("learning_rate must be > 0")
+
+        if self.lora_rank < 1:
+            errors.append("lora_rank must be >= 1")
+
+        if self.lora_alpha < 1:
+            errors.append("lora_alpha must be >= 1")
+
+        if self.max_seq_length < 1:
+            errors.append("max_seq_length must be >= 1")
+
+        return errors
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "TrainingConfig":
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+
+class TrainingJob:
+    """Represents a single training job with lifecycle management."""
+
+    def __init__(self, config: TrainingConfig, job_id: Optional[str] = None):
+        self.job_id: str = job_id or uuid.uuid4().hex[:12]
+        self.config = config
+        self.status: JobStatus = JobStatus.PENDING
+        self.progress: float = 0.0
+        self.current_epoch: int = 0
+        self.current_loss: Optional[float] = None
+        self.start_time: Optional[float] = None
+        self.end_time: Optional[float] = None
+        self.logs: list[str] = []
+        self._process: Optional[subprocess.Popen] = None
+        self._monitor_task: Optional[asyncio.Task] = None
+
+        # Set output directory
+        if self.config.output_dir is None:
+            self.config.output_dir = str(JOBS_DIR / self.job_id / "output")
+
+        # Job working directory
+        self._job_dir = JOBS_DIR / self.job_id
+        self._job_dir.mkdir(parents=True, exist_ok=True)
+
+    async def start(self) -> None:
+        """Launch the training subprocess."""
+        if self.status != JobStatus.PENDING:
+            raise RuntimeError(f"Cannot start job in '{self.status.value}' state")
+
+        self.status = JobStatus.RUNNING
+        self.start_time = time.time()
+        self._log(f"Starting {self.config.method} training on {self.config.base_model}")
+
+        # Write config to job directory for the training script
+        config_path = self._job_dir / "config.json"
+        config_path.write_text(json.dumps(self.config.to_dict(), indent=2))
+
+        # Build the training command
+        cmd = self._build_command(config_path)
+        self._log(f"Command: {' '.join(cmd)}")
+
+        try:
+            # Ensure output dir exists
+            Path(self.config.output_dir).mkdir(parents=True, exist_ok=True)
+
+            self._process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                cwd=str(self._job_dir),
+                env={**os.environ, "PYTHONUNBUFFERED": "1"},
+            )
+            # Start monitoring in background
+            self._monitor_task = asyncio.create_task(self._monitor())
+        except Exception as exc:
+            self.status = JobStatus.FAILED
+            self.end_time = time.time()
+            self._log(f"Failed to start: {exc}")
+            raise
+
+    async def stop(self) -> None:
+        """Gracefully cancel a running job."""
+        if self.status == JobStatus.PENDING:
+            self.status = JobStatus.CANCELLED
+            self.end_time = time.time()
+            self._log("Job cancelled before start")
+            return
+
+        if self.status != JobStatus.RUNNING:
+            return
+
+        self._log("Cancelling job...")
+        if self._process and self._process.poll() is None:
+            # Send SIGTERM for graceful shutdown
+            self._process.send_signal(signal.SIGTERM)
+            try:
+                self._process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+                self._process.wait(timeout=5)
+
+        self.status = JobStatus.CANCELLED
+        self.end_time = time.time()
+        self._log("Job cancelled")
+
+        if self._monitor_task and not self._monitor_task.done():
+            self._monitor_task.cancel()
+
+    def get_status(self) -> dict:
+        """Return a summary of the current job state."""
+        elapsed = None
+        if self.start_time:
+            end = self.end_time or time.time()
+            elapsed = round(end - self.start_time, 1)
+
+        return {
+            "job_id": self.job_id,
+            "status": self.status.value,
+            "progress": round(self.progress, 1),
+            "current_epoch": self.current_epoch,
+            "current_loss": self.current_loss,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "elapsed_seconds": elapsed,
+            "config": self.config.to_dict(),
+        }
+
+    def _build_command(self, config_path: Path) -> list[str]:
+        """Build the CLI command to run training."""
+        c = self.config
+
+        if c.method == "lora":
+            # Use a Python training script via module invocation
+            return [
+                sys.executable, "-m", "ainode.training._run_training",
+                "--config", str(config_path),
+            ]
+        else:
+            # Full fine-tuning — use torchrun for potential multi-GPU
+            return [
+                sys.executable, "-m", "torch.distributed.run",
+                "--nproc_per_node=1",
+                "-m", "ainode.training._run_training",
+                "--config", str(config_path),
+            ]
+
+    async def _monitor(self) -> None:
+        """Read subprocess output and update progress."""
+        proc = self._process
+        if proc is None or proc.stdout is None:
+            return
+
+        loop = asyncio.get_event_loop()
+        try:
+            while True:
+                line = await loop.run_in_executor(None, proc.stdout.readline)
+                if not line and proc.poll() is not None:
+                    break
+                if line:
+                    line = line.rstrip()
+                    self._log(line)
+                    self._parse_progress(line)
+
+            rc = proc.wait()
+            if self.status == JobStatus.RUNNING:
+                if rc == 0:
+                    self.status = JobStatus.COMPLETED
+                    self.progress = 100.0
+                    self._log("Training completed successfully")
+                else:
+                    self.status = JobStatus.FAILED
+                    self._log(f"Training process exited with code {rc}")
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self.end_time = time.time()
+
+    def _parse_progress(self, line: str) -> None:
+        """Parse structured progress output from the training script.
+
+        Expected format: AINODE_PROGRESS:{"epoch":1,"loss":0.5,"progress":33.3}
+        """
+        marker = "AINODE_PROGRESS:"
+        if marker in line:
+            try:
+                payload = json.loads(line.split(marker, 1)[1])
+                if "epoch" in payload:
+                    self.current_epoch = payload["epoch"]
+                if "loss" in payload:
+                    self.current_loss = payload["loss"]
+                if "progress" in payload:
+                    self.progress = payload["progress"]
+            except (json.JSONDecodeError, IndexError):
+                pass
+
+    def _log(self, msg: str) -> None:
+        """Append a timestamped log entry."""
+        ts = time.strftime("%H:%M:%S")
+        self.logs.append(f"[{ts}] {msg}")
+
+
+class TrainingManager:
+    """Manage training jobs — one active at a time (GPU shared with inference)."""
+
+    def __init__(self):
+        self._jobs: dict[str, TrainingJob] = {}
+        self._queue: list[str] = []  # job_ids in queue order
+        self._active_job_id: Optional[str] = None
+
+    def submit_job(self, config: TrainingConfig) -> TrainingJob:
+        """Validate config and queue a new training job.
+
+        Returns the created TrainingJob.
+        Raises ValueError if config is invalid.
+        """
+        errors = config.validate()
+        if errors:
+            raise ValueError(f"Invalid training config: {'; '.join(errors)}")
+
+        job = TrainingJob(config)
+        self._jobs[job.job_id] = job
+        self._queue.append(job.job_id)
+        return job
+
+    def list_jobs(self) -> list[dict]:
+        """Return all jobs with their current status."""
+        return [job.get_status() for job in self._jobs.values()]
+
+    def get_job(self, job_id: str) -> Optional[TrainingJob]:
+        """Get a specific job by ID."""
+        return self._jobs.get(job_id)
+
+    async def cancel_job(self, job_id: str) -> bool:
+        """Cancel a running or pending job. Returns True if cancelled."""
+        job = self._jobs.get(job_id)
+        if job is None:
+            return False
+
+        if job.status in (JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED):
+            return False
+
+        await job.stop()
+
+        # Remove from queue if pending
+        if job_id in self._queue:
+            self._queue.remove(job_id)
+
+        # Clear active if this was the running job
+        if self._active_job_id == job_id:
+            self._active_job_id = None
+
+        return True
+
+    async def start_next(self) -> Optional[TrainingJob]:
+        """Start the next pending job if no job is currently running.
+
+        Returns the started job, or None if nothing to start.
+        """
+        if self._active_job_id is not None:
+            active = self._jobs.get(self._active_job_id)
+            if active and active.status == JobStatus.RUNNING:
+                return None  # Something is already running
+            # Active job finished — clear it
+            self._active_job_id = None
+
+        # Find next pending job in queue
+        while self._queue:
+            job_id = self._queue[0]
+            job = self._jobs.get(job_id)
+            if job and job.status == JobStatus.PENDING:
+                self._queue.pop(0)
+                self._active_job_id = job_id
+                await job.start()
+                return job
+            else:
+                self._queue.pop(0)  # Skip cancelled/missing jobs
+
+        return None
+
+    @property
+    def active_job(self) -> Optional[TrainingJob]:
+        """Return the currently running job, if any."""
+        if self._active_job_id:
+            return self._jobs.get(self._active_job_id)
+        return None
+
+    @property
+    def queue_size(self) -> int:
+        """Number of pending jobs in the queue."""
+        return len([
+            jid for jid in self._queue
+            if jid in self._jobs and self._jobs[jid].status == JobStatus.PENDING
+        ])

--- a/ainode/web/__init__.py
+++ b/ainode/web/__init__.py
@@ -1,0 +1,1 @@
+"""AINode Web UI — embedded dashboard served by the API server."""

--- a/ainode/web/serve.py
+++ b/ainode/web/serve.py
@@ -13,6 +13,12 @@ def get_index_html() -> str:
     return index.read_text()
 
 
+def get_onboarding_html() -> str:
+    """Return the onboarding wizard HTML."""
+    onboarding = TEMPLATES_DIR / "onboarding.html"
+    return onboarding.read_text()
+
+
 def get_static_path() -> Path:
     """Return the path to static assets directory."""
     return STATIC_DIR

--- a/ainode/web/serve.py
+++ b/ainode/web/serve.py
@@ -1,0 +1,18 @@
+"""Web UI file serving — serves the embedded dashboard."""
+
+from pathlib import Path
+
+WEB_DIR = Path(__file__).parent
+STATIC_DIR = WEB_DIR / "static"
+TEMPLATES_DIR = WEB_DIR / "templates"
+
+
+def get_index_html() -> str:
+    """Return the main dashboard HTML."""
+    index = TEMPLATES_DIR / "index.html"
+    return index.read_text()
+
+
+def get_static_path() -> Path:
+    """Return the path to static assets directory."""
+    return STATIC_DIR

--- a/ainode/web/static/css/style.css
+++ b/ainode/web/static/css/style.css
@@ -520,24 +520,521 @@ body {
   border: 1px solid var(--accent);
 }
 
-/* Training section */
-.training-placeholder {
+/* --- Training Section --- */
+
+.training-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 24px;
+  gap: 16px;
+}
+
+.training-stat-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  flex: 1;
+}
+
+.training-stat-card {
+  padding: 16px;
+}
+
+.training-stat-card .stat-value {
+  font-size: 24px;
+}
+
+.training-empty {
   text-align: center;
   padding: 80px 20px;
   color: var(--text-muted);
 }
 
-.training-placeholder svg {
-  width: 64px;
-  height: 64px;
+.training-empty svg {
   margin-bottom: 16px;
   opacity: 0.3;
 }
 
-.training-placeholder h3 {
+.training-empty h3 {
   font-size: 18px;
   margin-bottom: 8px;
   color: var(--text-secondary);
+}
+
+/* Buttons */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 20px;
+  border-radius: var(--radius-sm);
+  font-size: 14px;
+  font-weight: 600;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+
+.btn-primary:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+}
+
+.btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--text-secondary);
+  border-color: var(--border);
+}
+
+.btn-ghost:hover {
+  background: var(--bg-card);
+  color: var(--text-primary);
+}
+
+.btn-danger {
+  background: var(--red);
+  color: white;
+  border-color: var(--red);
+}
+
+.btn-danger:hover {
+  background: #dc2626;
+}
+
+.btn-lg {
+  padding: 12px 28px;
+  font-size: 15px;
+}
+
+/* Job Cards */
+.training-jobs-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.training-job-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.training-job-card:hover {
+  border-color: var(--border-active);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow);
+}
+
+.job-card-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 8px;
+}
+
+.job-card-model {
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.job-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.job-method-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  background: rgba(139, 92, 246, 0.15);
+  color: var(--purple);
+  border: 1px solid rgba(139, 92, 246, 0.3);
+}
+
+.job-card-id {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+/* Status badges */
+.job-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: 20px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.job-status-badge::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.job-status-badge.status-pending {
+  background: rgba(100, 116, 139, 0.15);
+  color: var(--text-secondary);
+}
+.job-status-badge.status-pending::before { background: var(--text-muted); }
+
+.job-status-badge.status-running {
+  background: var(--green-glow);
+  color: var(--green);
+}
+.job-status-badge.status-running::before {
+  background: var(--green);
+  animation: pulse 1.5s infinite;
+}
+
+.job-status-badge.status-completed {
+  background: rgba(74, 144, 217, 0.15);
+  color: var(--accent);
+}
+.job-status-badge.status-completed::before { background: var(--accent); }
+
+.job-status-badge.status-failed {
+  background: var(--red-glow);
+  color: var(--red);
+}
+.job-status-badge.status-failed::before { background: var(--red); }
+
+.job-status-badge.status-cancelled {
+  background: var(--yellow-glow);
+  color: var(--yellow);
+}
+.job-status-badge.status-cancelled::before { background: var(--yellow); }
+
+/* Job card progress */
+.job-card-progress { margin: 8px 0; }
+.training-progress-bar { height: 8px; }
+.training-progress-bar-lg { height: 12px; }
+.progress-fill.accent { background: var(--accent); }
+
+.training-progress-animated {
+  background: linear-gradient(90deg, var(--accent) 0%, var(--accent-hover) 50%, var(--accent) 100%);
+  background-size: 200% 100%;
+  animation: progress-shimmer 2s infinite linear;
+}
+
+@keyframes progress-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.job-progress-text {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 6px;
+}
+
+.job-card-footer {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+/* Training Form */
+.training-form-wrapper { max-width: 720px; }
+
+.training-form-header { margin-bottom: 24px; }
+
+.training-form-header h2,
+.training-form-title {
+  font-size: 20px;
+  font-weight: 700;
+  margin-top: 12px;
+}
+
+.training-form {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.form-section { margin-bottom: 8px; }
+
+.form-section-title {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.form-section-title.collapsible {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  user-select: none;
+}
+
+.form-section-title.collapsible .chevron {
+  transition: transform 0.2s ease;
+}
+
+.form-section-title.collapsible.open .chevron {
+  transform: rotate(180deg);
+}
+
+.advanced-settings {
+  overflow: hidden;
+  transition: max-height 0.3s ease, opacity 0.2s ease;
+  max-height: 600px;
+  opacity: 1;
+}
+
+.advanced-settings.collapsed {
+  max-height: 0;
+  opacity: 0;
+}
+
+.form-group { margin-bottom: 16px; }
+
+.form-label {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 6px;
+}
+
+.form-input,
+.form-select {
+  width: 100%;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px 14px;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-family: var(--font-sans);
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.form-input:focus,
+.form-select:focus {
+  border-color: var(--accent);
+}
+
+.form-input::placeholder {
+  color: var(--text-muted);
+}
+
+.form-select {
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 36px;
+}
+
+.form-select option {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.form-hint {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px 16px;
+}
+
+/* Method toggle */
+.method-toggle {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.method-btn {
+  background: var(--bg-card);
+  border: 2px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.15s ease;
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+}
+
+.method-btn:hover {
+  border-color: var(--border-active);
+}
+
+.method-btn.active {
+  border-color: var(--accent);
+  background: rgba(74, 144, 217, 0.08);
+}
+
+.method-btn-title {
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.method-btn-desc {
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 16px;
+  padding-top: 20px;
+  border-top: 1px solid var(--border);
+}
+
+/* Training Detail View */
+.training-detail-title {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.training-detail-title h2 {
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.training-detail-progress { margin-bottom: 24px; }
+
+.progress-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 10px;
+}
+
+.progress-pct {
+  font-size: 28px;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  color: var(--accent);
+}
+
+.progress-epoch {
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+.progress-stats {
+  display: flex;
+  gap: 24px;
+  margin-top: 10px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.training-detail-grid {
+  display: grid;
+  grid-template-columns: 340px 1fr;
+  gap: 20px;
+  align-items: start;
+}
+
+.training-config-card {
+  position: sticky;
+  top: 24px;
+}
+
+.training-right-col {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+/* Loss chart */
+.training-chart-card { min-height: 240px; }
+
+.loss-chart-container {
+  width: 100%;
+  height: 200px;
+}
+
+.loss-chart-container canvas {
+  width: 100%;
+  height: 100%;
+}
+
+/* Log viewer */
+.training-log-card { min-height: 300px; }
+
+.training-log-viewer {
+  max-height: 400px;
+  overflow-y: auto;
+  background: var(--bg-primary);
+  border-radius: var(--radius-sm);
+  padding: 12px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.log-line {
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.log-empty {
+  color: var(--text-muted);
+  text-align: center;
+  padding: 40px 0;
+}
+
+.log-line-count {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
 }
 
 /* Table */
@@ -589,12 +1086,18 @@ body {
 @media (max-width: 1024px) {
   .grid-4 { grid-template-columns: repeat(2, 1fr); }
   .grid-3 { grid-template-columns: repeat(2, 1fr); }
+  .training-detail-grid { grid-template-columns: 1fr; }
+  .training-config-card { position: static; }
+  .training-stat-row { grid-template-columns: repeat(2, 1fr); }
 }
 
 @media (max-width: 768px) {
   .sidebar { display: none; }
   .main { margin-left: 0; }
   .grid-4, .grid-3, .grid-2 { grid-template-columns: 1fr; }
+  .training-header { flex-direction: column; }
+  .training-stat-row { grid-template-columns: repeat(2, 1fr); }
+  .form-grid, .method-toggle { grid-template-columns: 1fr; }
 }
 
 /* Loading skeleton */

--- a/ainode/web/static/css/style.css
+++ b/ainode/web/static/css/style.css
@@ -1,0 +1,611 @@
+/* AINode Dashboard — Core Styles */
+
+:root {
+  --bg-primary: #0a0e17;
+  --bg-secondary: #111827;
+  --bg-card: #1a2332;
+  --bg-card-hover: #1e2a3d;
+  --border: #2d3748;
+  --border-active: #4a90d9;
+  --text-primary: #e2e8f0;
+  --text-secondary: #94a3b8;
+  --text-muted: #64748b;
+  --accent: #4a90d9;
+  --accent-hover: #5ba0e9;
+  --green: #10b981;
+  --green-glow: rgba(16, 185, 129, 0.2);
+  --yellow: #f59e0b;
+  --yellow-glow: rgba(245, 158, 11, 0.2);
+  --red: #ef4444;
+  --red-glow: rgba(239, 68, 68, 0.2);
+  --purple: #8b5cf6;
+  --font-mono: 'JetBrains Mono', 'Fira Code', 'SF Mono', monospace;
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  --radius: 12px;
+  --radius-sm: 8px;
+  --shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--font-sans);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+/* Layout */
+.app {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 240px;
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  z-index: 100;
+}
+
+.sidebar-header {
+  padding: 24px 20px;
+  border-bottom: 1px solid var(--border);
+}
+
+.sidebar-logo {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.5px;
+  color: var(--text-primary);
+}
+
+.sidebar-logo span {
+  color: var(--accent);
+}
+
+.sidebar-subtitle {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 4px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.sidebar-nav {
+  flex: 1;
+  padding: 12px 8px;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 2px;
+}
+
+.nav-item:hover {
+  background: var(--bg-card);
+  color: var(--text-primary);
+}
+
+.nav-item.active {
+  background: var(--accent);
+  color: white;
+}
+
+.nav-item svg {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
+.sidebar-footer {
+  padding: 16px 20px;
+  border-top: 1px solid var(--border);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.sidebar-footer a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.main {
+  flex: 1;
+  margin-left: 240px;
+  padding: 24px 32px;
+  min-height: 100vh;
+}
+
+/* Page Header */
+.page-header {
+  margin-bottom: 24px;
+}
+
+.page-title {
+  font-size: 24px;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.page-desc {
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+/* Cards */
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+  transition: border-color 0.15s ease;
+}
+
+.card:hover {
+  border-color: var(--border-active);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.card-title {
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+}
+
+/* Grid layouts */
+.grid-2 {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+}
+
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+.grid-4 {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+
+/* Stat cards */
+.stat-value {
+  font-size: 32px;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  line-height: 1;
+  margin-bottom: 4px;
+}
+
+.stat-label {
+  font-size: 12px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* Status indicators */
+.status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.status-online .status-dot {
+  background: var(--green);
+  box-shadow: 0 0 8px var(--green-glow);
+}
+
+.status-online { color: var(--green); }
+
+.status-starting .status-dot {
+  background: var(--yellow);
+  box-shadow: 0 0 8px var(--yellow-glow);
+  animation: pulse 1.5s infinite;
+}
+
+.status-starting { color: var(--yellow); }
+
+.status-offline .status-dot {
+  background: var(--red);
+  box-shadow: 0 0 8px var(--red-glow);
+}
+
+.status-offline { color: var(--red); }
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+/* Node cards */
+.node-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+  transition: all 0.2s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.node-card:hover {
+  border-color: var(--border-active);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow);
+}
+
+.node-card.is-leader {
+  border-color: var(--accent);
+}
+
+.node-card.is-leader::before {
+  content: 'LEADER';
+  position: absolute;
+  top: 12px;
+  right: -28px;
+  background: var(--accent);
+  color: white;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  padding: 2px 32px;
+  transform: rotate(45deg);
+}
+
+.node-name {
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.node-id {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  margin-bottom: 12px;
+}
+
+.node-gpu {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+}
+
+.node-model {
+  font-size: 13px;
+  color: var(--accent);
+  font-family: var(--font-mono);
+}
+
+/* Progress bars */
+.progress-bar {
+  width: 100%;
+  height: 6px;
+  background: var(--bg-primary);
+  border-radius: 3px;
+  overflow: hidden;
+  margin-top: 8px;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.5s ease;
+}
+
+.progress-fill.green { background: var(--green); }
+.progress-fill.yellow { background: var(--yellow); }
+.progress-fill.red { background: var(--red); }
+
+/* Chat */
+.chat-container {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 120px);
+}
+
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 0;
+}
+
+.chat-message {
+  padding: 12px 16px;
+  margin-bottom: 8px;
+  border-radius: var(--radius-sm);
+  max-width: 80%;
+  line-height: 1.6;
+  font-size: 14px;
+}
+
+.chat-message.user {
+  background: var(--accent);
+  color: white;
+  margin-left: auto;
+  border-bottom-right-radius: 2px;
+}
+
+.chat-message.assistant {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-bottom-left-radius: 2px;
+}
+
+.chat-message pre {
+  background: var(--bg-primary);
+  border-radius: var(--radius-sm);
+  padding: 12px;
+  margin: 8px 0;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+
+.chat-message code {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  background: var(--bg-primary);
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.chat-input-area {
+  border-top: 1px solid var(--border);
+  padding: 16px 0;
+}
+
+.chat-input-wrapper {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+}
+
+.chat-input {
+  flex: 1;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 12px 16px;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-family: var(--font-sans);
+  resize: none;
+  min-height: 48px;
+  max-height: 200px;
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.chat-input:focus {
+  border-color: var(--accent);
+}
+
+.chat-input::placeholder {
+  color: var(--text-muted);
+}
+
+.chat-send {
+  background: var(--accent);
+  color: white;
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 12px 20px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease;
+  white-space: nowrap;
+}
+
+.chat-send:hover {
+  background: var(--accent-hover);
+}
+
+.chat-send:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.chat-model-select {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 12px;
+  color: var(--text-primary);
+  font-size: 13px;
+  outline: none;
+  margin-bottom: 12px;
+}
+
+/* Models list */
+.model-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  transition: border-color 0.15s ease;
+  margin-bottom: 8px;
+}
+
+.model-card:hover {
+  border-color: var(--border-active);
+}
+
+.model-info {
+  flex: 1;
+}
+
+.model-name {
+  font-size: 15px;
+  font-weight: 600;
+  font-family: var(--font-mono);
+  margin-bottom: 4px;
+}
+
+.model-meta {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.model-status {
+  text-align: right;
+}
+
+.model-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 20px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.model-badge.loaded {
+  background: var(--green-glow);
+  color: var(--green);
+  border: 1px solid var(--green);
+}
+
+.model-badge.available {
+  background: rgba(74, 144, 217, 0.1);
+  color: var(--accent);
+  border: 1px solid var(--accent);
+}
+
+/* Training section */
+.training-placeholder {
+  text-align: center;
+  padding: 80px 20px;
+  color: var(--text-muted);
+}
+
+.training-placeholder svg {
+  width: 64px;
+  height: 64px;
+  margin-bottom: 16px;
+  opacity: 0.3;
+}
+
+.training-placeholder h3 {
+  font-size: 18px;
+  margin-bottom: 8px;
+  color: var(--text-secondary);
+}
+
+/* Table */
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th {
+  text-align: left;
+  padding: 10px 16px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border);
+}
+
+.table td {
+  padding: 12px 16px;
+  font-size: 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.table tr:hover td {
+  background: var(--bg-card-hover);
+}
+
+/* Scrollbar */
+::-webkit-scrollbar {
+  width: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
+}
+
+/* Responsive */
+@media (max-width: 1024px) {
+  .grid-4 { grid-template-columns: repeat(2, 1fr); }
+  .grid-3 { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (max-width: 768px) {
+  .sidebar { display: none; }
+  .main { margin-left: 0; }
+  .grid-4, .grid-3, .grid-2 { grid-template-columns: 1fr; }
+}
+
+/* Loading skeleton */
+.skeleton {
+  background: linear-gradient(90deg, var(--bg-card) 25%, var(--bg-card-hover) 50%, var(--bg-card) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+  border-radius: var(--radius-sm);
+}
+
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}

--- a/ainode/web/static/js/app.js
+++ b/ainode/web/static/js/app.js
@@ -8,9 +8,13 @@ const AINode = {
     messages: [],
     streaming: false,
     pollInterval: null,
+    trainingJobs: [],
+    trainingView: 'list',
+    trainingDetailId: null,
+    trainingLossData: [],
   },
 
-  // ─── Initialization ────────────────────────────────
+  // --- Initialization ---
   init() {
     this.bindNav();
     this.bindChat();
@@ -18,7 +22,7 @@ const AINode = {
     this.startPolling();
   },
 
-  // ─── Navigation ────────────────────────────────────
+  // --- Navigation ---
   bindNav() {
     document.querySelectorAll('.nav-item').forEach(el => {
       el.addEventListener('click', () => {
@@ -31,22 +35,16 @@ const AINode = {
   navigate(view) {
     this.state.currentView = view;
     window.location.hash = view;
-
-    // Update nav active state
     document.querySelectorAll('.nav-item').forEach(el => {
       el.classList.toggle('active', el.dataset.view === view);
     });
-
-    // Show/hide views
     document.querySelectorAll('.view').forEach(el => {
       el.style.display = el.id === `view-${view}` ? 'block' : 'none';
     });
-
-    // Refresh data for the view
     this.refresh();
   },
 
-  // ─── Data Fetching ─────────────────────────────────
+  // --- Data Fetching ---
   async fetchJSON(url) {
     try {
       const resp = await fetch(url);
@@ -62,10 +60,8 @@ const AINode = {
       this.fetchJSON('/api/status'),
       this.fetchJSON('/api/nodes'),
     ]);
-
     this.state.status = status;
     this.state.nodes = nodes?.nodes || [];
-
     switch (this.state.currentView) {
       case 'dashboard': this.renderDashboard(); break;
       case 'chat': this.renderChatHeader(); break;
@@ -78,53 +74,31 @@ const AINode = {
     this.state.pollInterval = setInterval(() => this.refresh(), 5000);
   },
 
-  // ─── Dashboard View ────────────────────────────────
+  // --- Dashboard View ---
   renderDashboard() {
     const s = this.state.status;
     const nodes = this.state.nodes;
-
     if (!s) {
       document.getElementById('dashboard-stats').innerHTML = this.skeletonCards(4);
       return;
     }
-
-    // Stats row
     const totalGPUs = nodes.reduce((sum, n) => sum + (n.gpu_count || 1), 0);
     const totalMem = nodes.reduce((sum, n) => sum + (n.gpu_memory_gb || 0), 0);
     const onlineNodes = nodes.filter(n => n.status === 'online').length;
     const modelsLoaded = s.models_loaded?.length || 0;
-
     document.getElementById('dashboard-stats').innerHTML = `
-      <div class="card">
-        <div class="stat-value">${onlineNodes || 1}</div>
-        <div class="stat-label">Nodes Online</div>
-      </div>
-      <div class="card">
-        <div class="stat-value">${totalGPUs || 1}</div>
-        <div class="stat-label">GPUs</div>
-      </div>
-      <div class="card">
-        <div class="stat-value">${totalMem || (s.gpu?.memory_gb || 0)} GB</div>
-        <div class="stat-label">Total Memory</div>
-      </div>
-      <div class="card">
-        <div class="stat-value">${modelsLoaded}</div>
-        <div class="stat-label">Models Loaded</div>
-      </div>
+      <div class="card"><div class="stat-value">${onlineNodes || 1}</div><div class="stat-label">Nodes Online</div></div>
+      <div class="card"><div class="stat-value">${totalGPUs || 1}</div><div class="stat-label">GPUs</div></div>
+      <div class="card"><div class="stat-value">${totalMem || (s.gpu?.memory_gb || 0)} GB</div><div class="stat-label">Total Memory</div></div>
+      <div class="card"><div class="stat-value">${modelsLoaded}</div><div class="stat-label">Models Loaded</div></div>
     `;
-
-    // Node cards
     this.renderNodes(nodes, s);
-
-    // Cluster health
     this.renderClusterHealth(s);
   },
 
   renderNodes(nodes, status) {
     const container = document.getElementById('dashboard-nodes');
     if (!container) return;
-
-    // If no cluster nodes, show this node
     if (nodes.length === 0 && status) {
       nodes = [{
         node_id: status.node_id || 'local',
@@ -137,15 +111,12 @@ const AINode = {
         is_leader: true,
       }];
     }
-
     container.innerHTML = nodes.map(node => {
-      const statusClass = node.status === 'online' ? 'status-online' :
-                          node.status === 'starting' ? 'status-starting' : 'status-offline';
+      const statusClass = node.status === 'online' ? 'status-online' : node.status === 'starting' ? 'status-starting' : 'status-offline';
       const leaderClass = node.is_leader ? 'is-leader' : '';
       const memLabel = node.unified_memory ? 'unified' : 'VRAM';
       const memPct = node.gpu_memory_used_pct || 0;
       const barClass = memPct > 90 ? 'red' : memPct > 70 ? 'yellow' : 'green';
-
       return `
         <div class="node-card ${leaderClass}">
           <div style="display:flex; justify-content:space-between; align-items:start; margin-bottom:12px">
@@ -153,19 +124,12 @@ const AINode = {
               <div class="node-name">${this.esc(node.node_name || node.node_id)}</div>
               <div class="node-id">${this.esc(node.node_id)}</div>
             </div>
-            <div class="status ${statusClass}">
-              <span class="status-dot"></span>
-              ${node.status || 'unknown'}
-            </div>
+            <div class="status ${statusClass}"><span class="status-dot"></span>${node.status || 'unknown'}</div>
           </div>
           <div class="node-gpu">${this.esc(node.gpu_name || 'Unknown')} &middot; ${node.gpu_memory_gb || '?'} GB ${memLabel}</div>
           <div class="node-model">${this.esc(node.model || 'no model')}</div>
-          <div class="progress-bar">
-            <div class="progress-fill ${barClass}" style="width:${memPct}%"></div>
-          </div>
-          <div style="font-size:11px; color:var(--text-muted); margin-top:4px">
-            Memory: ${memPct}% used
-          </div>
+          <div class="progress-bar"><div class="progress-fill ${barClass}" style="width:${memPct}%"></div></div>
+          <div style="font-size:11px; color:var(--text-muted); margin-top:4px">Memory: ${memPct}% used</div>
         </div>
       `;
     }).join('');
@@ -174,57 +138,30 @@ const AINode = {
   renderClusterHealth(status) {
     const container = document.getElementById('dashboard-health');
     if (!container) return;
-
     const uptime = status.uptime_seconds ? this.formatUptime(status.uptime_seconds) : 'N/A';
-
     container.innerHTML = `
       <div class="card">
-        <div class="card-header">
-          <div class="card-title">Engine Status</div>
-        </div>
+        <div class="card-header"><div class="card-title">Engine Status</div></div>
         <table class="table">
-          <tr>
-            <td>Engine</td>
-            <td>${status.engine_ready ?
-              '<span class="status status-online"><span class="status-dot"></span>Ready</span>' :
-              '<span class="status status-starting"><span class="status-dot"></span>Starting</span>'}</td>
-          </tr>
-          <tr>
-            <td>Model</td>
-            <td style="font-family:var(--font-mono)">${this.esc(status.model || 'none')}</td>
-          </tr>
-          <tr>
-            <td>API Port</td>
-            <td style="font-family:var(--font-mono)">${status.api_port || 8000}</td>
-          </tr>
-          <tr>
-            <td>Uptime</td>
-            <td>${uptime}</td>
-          </tr>
-          <tr>
-            <td>Version</td>
-            <td>${this.esc(status.version || 'unknown')}</td>
-          </tr>
+          <tr><td>Engine</td><td>${status.engine_ready ? '<span class="status status-online"><span class="status-dot"></span>Ready</span>' : '<span class="status status-starting"><span class="status-dot"></span>Starting</span>'}</td></tr>
+          <tr><td>Model</td><td style="font-family:var(--font-mono)">${this.esc(status.model || 'none')}</td></tr>
+          <tr><td>API Port</td><td style="font-family:var(--font-mono)">${status.api_port || 8000}</td></tr>
+          <tr><td>Uptime</td><td>${uptime}</td></tr>
+          <tr><td>Version</td><td>${this.esc(status.version || 'unknown')}</td></tr>
         </table>
       </div>
     `;
   },
 
-  // ─── Chat View ─────────────────────────────────────
+  // --- Chat View ---
   bindChat() {
     const input = document.getElementById('chat-input');
     const send = document.getElementById('chat-send');
     if (!input || !send) return;
-
     send.addEventListener('click', () => this.sendMessage());
     input.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault();
-        this.sendMessage();
-      }
+      if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); this.sendMessage(); }
     });
-
-    // Auto-resize textarea
     input.addEventListener('input', () => {
       input.style.height = 'auto';
       input.style.height = Math.min(input.scrollHeight, 200) + 'px';
@@ -235,84 +172,47 @@ const AINode = {
     const s = this.state.status;
     const select = document.getElementById('chat-model');
     if (!select || !s) return;
-
     const models = s.models_loaded || [];
-    if (models.length === 0) {
-      select.innerHTML = '<option>No models loaded</option>';
-    } else {
-      select.innerHTML = models.map(m =>
-        `<option value="${this.esc(m)}">${this.esc(m)}</option>`
-      ).join('');
-    }
+    if (models.length === 0) { select.innerHTML = '<option>No models loaded</option>'; }
+    else { select.innerHTML = models.map(m => `<option value="${this.esc(m)}">${this.esc(m)}</option>`).join(''); }
   },
 
   async sendMessage() {
     const input = document.getElementById('chat-input');
     const content = input.value.trim();
     if (!content || this.state.streaming) return;
-
-    input.value = '';
-    input.style.height = 'auto';
-
-    // Add user message
+    input.value = ''; input.style.height = 'auto';
     this.state.messages.push({ role: 'user', content });
     this.renderMessages();
-
-    // Get model
     const select = document.getElementById('chat-model');
     const model = select?.value || '';
-
-    // Stream response
     this.state.streaming = true;
     document.getElementById('chat-send').disabled = true;
-
     const assistantMsg = { role: 'assistant', content: '' };
     this.state.messages.push(assistantMsg);
-
     try {
       const resp = await fetch('/v1/chat/completions', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          model,
-          messages: this.state.messages.slice(0, -1).map(m => ({
-            role: m.role, content: m.content
-          })),
-          stream: true,
-        }),
+        body: JSON.stringify({ model, messages: this.state.messages.slice(0, -1).map(m => ({ role: m.role, content: m.content })), stream: true }),
       });
-
       const reader = resp.body.getReader();
       const decoder = new TextDecoder();
       let buffer = '';
-
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
-
         buffer += decoder.decode(value, { stream: true });
         const lines = buffer.split('\n');
         buffer = lines.pop();
-
         for (const line of lines) {
           if (!line.startsWith('data: ')) continue;
           const data = line.slice(6);
           if (data === '[DONE]') break;
-
-          try {
-            const json = JSON.parse(data);
-            const delta = json.choices?.[0]?.delta?.content;
-            if (delta) {
-              assistantMsg.content += delta;
-              this.renderMessages();
-            }
-          } catch { /* skip malformed chunks */ }
+          try { const json = JSON.parse(data); const delta = json.choices?.[0]?.delta?.content; if (delta) { assistantMsg.content += delta; this.renderMessages(); } } catch { }
         }
       }
-    } catch (err) {
-      assistantMsg.content = `Error: ${err.message}. Is the engine running?`;
-    }
-
+    } catch (err) { assistantMsg.content = 'Error: ' + err.message + '. Is the engine running?'; }
     this.state.streaming = false;
     document.getElementById('chat-send').disabled = false;
     this.renderMessages();
@@ -321,24 +221,16 @@ const AINode = {
   renderMessages() {
     const container = document.getElementById('chat-messages');
     if (!container) return;
-
-    container.innerHTML = this.state.messages.map(msg => `
-      <div class="chat-message ${msg.role}">
-        ${this.formatMarkdown(msg.content)}
-      </div>
-    `).join('');
-
+    container.innerHTML = this.state.messages.map(msg => `<div class="chat-message ${msg.role}">${this.formatMarkdown(msg.content)}</div>`).join('');
     container.scrollTop = container.scrollHeight;
   },
 
-  // ─── Models View ───────────────────────────────────
+  // --- Models View ---
   renderModels() {
     const container = document.getElementById('models-list');
     if (!container) return;
-
     const s = this.state.status;
     const loaded = s?.models_loaded || [];
-
     const recommended = [
       { id: 'meta-llama/Llama-3.2-3B-Instruct', size: '~6 GB', desc: 'Quick start, fast inference' },
       { id: 'meta-llama/Llama-3.1-8B-Instruct', size: '~16 GB', desc: 'Recommended for most tasks' },
@@ -347,7 +239,6 @@ const AINode = {
       { id: 'deepseek-ai/DeepSeek-R1-Distill-Qwen-7B', size: '~14 GB', desc: 'Reasoning specialist' },
       { id: 'mistralai/Mistral-7B-Instruct-v0.3', size: '~14 GB', desc: 'Fast, general purpose' },
     ];
-
     container.innerHTML = recommended.map(model => {
       const isLoaded = loaded.includes(model.id);
       return `
@@ -357,63 +248,287 @@ const AINode = {
             <div class="model-meta">${model.size} &middot; ${model.desc}</div>
           </div>
           <div class="model-status">
-            ${isLoaded ?
-              '<span class="model-badge loaded">Loaded</span>' :
-              '<span class="model-badge available">Available</span>'}
+            ${isLoaded ? '<span class="model-badge loaded">Loaded</span>' : '<span class="model-badge available">Available</span>'}
           </div>
         </div>
       `;
     }).join('');
   },
 
-  // ─── Training View ─────────────────────────────────
-  renderTraining() {
+  // --- Training View ---
+  trainingModels: [
+    { id: 'meta-llama/Llama-3.2-3B-Instruct', name: 'Llama 3.2 3B Instruct', size: '~6 GB' },
+    { id: 'meta-llama/Llama-3.1-8B-Instruct', name: 'Llama 3.1 8B Instruct', size: '~16 GB' },
+    { id: 'meta-llama/Llama-3.1-70B-Instruct-AWQ', name: 'Llama 3.1 70B AWQ', size: '~38 GB' },
+    { id: 'Qwen/Qwen2.5-72B-Instruct', name: 'Qwen 2.5 72B Instruct', size: '~145 GB' },
+    { id: 'deepseek-ai/DeepSeek-R1-Distill-Qwen-7B', name: 'DeepSeek R1 7B', size: '~14 GB' },
+    { id: 'mistralai/Mistral-7B-Instruct-v0.3', name: 'Mistral 7B v0.3', size: '~14 GB' },
+    { id: 'microsoft/Phi-3-mini-4k-instruct', name: 'Phi-3 Mini 4K', size: '~7.5 GB' },
+    { id: 'meta-llama/CodeLlama-34b-Instruct-hf', name: 'CodeLlama 34B', size: '~63 GB' },
+  ],
+
+  async renderTraining() {
     const container = document.getElementById('training-content');
     if (!container) return;
-
-    container.innerHTML = `
-      <div class="training-placeholder">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-          <path d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
-        </svg>
-        <h3>Fine-Tuning Studio</h3>
-        <p>Upload datasets, configure LoRA adapters, and train models — all from your browser.</p>
-        <p style="margin-top:16px; font-size:13px">Coming in AINode v0.2</p>
-      </div>
-    `;
+    const data = await this.fetchJSON('/api/training/jobs');
+    this.state.trainingJobs = data?.jobs || [];
+    switch (this.state.trainingView) {
+      case 'list': this.renderTrainingList(container); break;
+      case 'new': this.renderTrainingForm(container); break;
+      case 'detail': await this.renderTrainingDetail(container); break;
+    }
   },
 
-  // ─── Utilities ─────────────────────────────────────
-  esc(str) {
-    const div = document.createElement('div');
-    div.textContent = str || '';
-    return div.innerHTML;
+  renderTrainingList(container) {
+    const jobs = this.state.trainingJobs;
+    const hasJobs = jobs.length > 0;
+    container.innerHTML = '<div class="training-header">' +
+      '<div class="training-stat-row">' +
+        '<div class="card training-stat-card"><div class="stat-value">' + jobs.length + '</div><div class="stat-label">Total Jobs</div></div>' +
+        '<div class="card training-stat-card"><div class="stat-value">' + jobs.filter(j => j.status === 'running').length + '</div><div class="stat-label">Running</div></div>' +
+        '<div class="card training-stat-card"><div class="stat-value">' + jobs.filter(j => j.status === 'completed').length + '</div><div class="stat-label">Completed</div></div>' +
+        '<div class="card training-stat-card"><div class="stat-value">' + jobs.filter(j => j.status === 'pending').length + '</div><div class="stat-label">Queued</div></div>' +
+      '</div>' +
+      '<button class="btn btn-primary" id="training-new-btn">' +
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>' +
+        'New Training Job</button>' +
+    '</div>' +
+    (hasJobs ?
+      '<div class="training-jobs-list">' + jobs.sort((a, b) => (b.start_time || 0) - (a.start_time || 0)).map(job => this.renderJobCard(job)).join('') + '</div>'
+      :
+      '<div class="training-empty">' +
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" width="56" height="56"><path d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/></svg>' +
+        '<h3>No training jobs yet</h3><p>Create your first fine-tuning job to get started.</p>' +
+      '</div>'
+    );
+    document.getElementById('training-new-btn')?.addEventListener('click', () => { this.state.trainingView = 'new'; this.renderTraining(); });
+    container.querySelectorAll('.training-job-card').forEach(card => {
+      card.addEventListener('click', () => { this.state.trainingView = 'detail'; this.state.trainingDetailId = card.dataset.jobId; this.state.trainingLossData = []; this.renderTraining(); });
+    });
   },
 
-  formatUptime(seconds) {
-    if (seconds < 60) return `${seconds}s`;
-    if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
-    const h = Math.floor(seconds / 3600);
-    const m = Math.floor((seconds % 3600) / 60);
-    return `${h}h ${m}m`;
+  renderJobCard(job) {
+    const statusMap = { pending: { cls: 'status-pending', label: 'Pending' }, running: { cls: 'status-running', label: 'Running' }, completed: { cls: 'status-completed', label: 'Completed' }, failed: { cls: 'status-failed', label: 'Failed' }, cancelled: { cls: 'status-cancelled', label: 'Cancelled' } };
+    const s = statusMap[job.status] || { cls: '', label: job.status };
+    const modelShort = job.config?.base_model?.split('/').pop() || 'Unknown';
+    const methodLabel = (job.config?.method || 'lora').toUpperCase();
+    const started = job.start_time ? new Date(job.start_time * 1000).toLocaleString() : 'Not started';
+    const elapsed = job.elapsed_seconds ? this.formatUptime(Math.round(job.elapsed_seconds)) : '--';
+    let html = '<div class="training-job-card" data-job-id="' + this.esc(job.job_id) + '">' +
+      '<div class="job-card-top"><div class="job-card-left">' +
+        '<div class="job-card-model">' + this.esc(modelShort) + '</div>' +
+        '<div class="job-card-meta"><span class="job-method-badge">' + methodLabel + '</span><span class="job-card-id">' + this.esc(job.job_id) + '</span></div>' +
+      '</div><div class="job-card-right"><span class="job-status-badge ' + s.cls + '">' + s.label + '</span></div></div>';
+    if (job.status === 'running') {
+      html += '<div class="job-card-progress">' +
+        '<div class="progress-bar training-progress-bar"><div class="progress-fill accent training-progress-animated" style="width:' + (job.progress || 0) + '%"></div></div>' +
+        '<div class="job-progress-text">' + (job.progress || 0).toFixed(1) + '% &middot; Epoch ' + (job.current_epoch || 0) + '/' + (job.config?.num_epochs || '?') + (job.current_loss != null ? ' &middot; Loss: ' + job.current_loss.toFixed(4) : '') + '</div></div>';
+    }
+    html += '<div class="job-card-footer"><span>Started: ' + started + '</span><span>Duration: ' + elapsed + '</span></div></div>';
+    return html;
   },
 
-  formatMarkdown(text) {
-    if (!text) return '';
-    // Basic markdown: code blocks, inline code, bold, newlines
-    return text
-      .replace(/```(\w*)\n([\s\S]*?)```/g, '<pre><code>$2</code></pre>')
-      .replace(/`([^`]+)`/g, '<code>$1</code>')
-      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-      .replace(/\n/g, '<br>');
+  renderTrainingForm(container) {
+    const models = this.trainingModels;
+    const optionsHtml = models.map(m => '<option value="' + this.esc(m.id) + '">' + this.esc(m.name) + ' (' + m.size + ')</option>').join('');
+    container.innerHTML = '<div class="training-form-wrapper">' +
+      '<div class="training-form-header">' +
+        '<button class="btn btn-ghost" id="training-back-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><polyline points="15 18 9 12 15 6"/></svg>Back to Jobs</button>' +
+        '<h2 class="training-form-title">New Training Job</h2>' +
+      '</div>' +
+      '<form id="training-form" class="training-form">' +
+        '<div class="form-section"><div class="form-section-title">Model</div>' +
+          '<div class="form-group"><label class="form-label" for="train-model">Base Model</label><select id="train-model" class="form-select" required>' + optionsHtml + '</select><div class="form-hint">Or enter a custom HuggingFace model ID below</div></div>' +
+          '<div class="form-group"><label class="form-label" for="train-model-custom">Custom Model ID (optional)</label><input type="text" id="train-model-custom" class="form-input" placeholder="e.g. org/my-model"></div>' +
+        '</div>' +
+        '<div class="form-section"><div class="form-section-title">Dataset</div>' +
+          '<div class="form-group"><label class="form-label" for="train-dataset">Dataset Path</label><input type="text" id="train-dataset" class="form-input" placeholder="/path/to/dataset.jsonl" required><div class="form-hint">Path to a JSONL file on this machine. Each line should have &quot;instruction&quot; and &quot;output&quot; fields.</div></div>' +
+        '</div>' +
+        '<div class="form-section"><div class="form-section-title">Training Method</div>' +
+          '<div class="form-group"><div class="method-toggle">' +
+            '<button type="button" class="method-btn active" data-method="lora"><div class="method-btn-title">LoRA</div><div class="method-btn-desc">Recommended. Trains adapter weights only. Fast, memory-efficient.</div></button>' +
+            '<button type="button" class="method-btn" data-method="full"><div class="method-btn-title">Full Fine-Tune</div><div class="method-btn-desc">Updates all model weights. Requires more VRAM and time.</div></button>' +
+          '</div><input type="hidden" id="train-method" value="lora"></div>' +
+        '</div>' +
+        '<div class="form-section"><div class="form-section-title collapsible" id="advanced-toggle"><span>Advanced Settings</span><svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><polyline points="6 9 12 15 18 9"/></svg></div>' +
+          '<div class="advanced-settings collapsed" id="advanced-settings">' +
+            '<div class="form-grid">' +
+              '<div class="form-group"><label class="form-label" for="train-epochs">Epochs</label><input type="number" id="train-epochs" class="form-input" value="3" min="1" max="100"></div>' +
+              '<div class="form-group"><label class="form-label" for="train-batch">Batch Size</label><input type="number" id="train-batch" class="form-input" value="4" min="1" max="128"></div>' +
+              '<div class="form-group"><label class="form-label" for="train-lr">Learning Rate</label><input type="text" id="train-lr" class="form-input" value="2e-4"></div>' +
+              '<div class="form-group"><label class="form-label" for="train-seq-len">Max Sequence Length</label><input type="number" id="train-seq-len" class="form-input" value="2048" min="128" max="32768" step="128"></div>' +
+            '</div>' +
+            '<div class="form-grid lora-settings" id="lora-settings">' +
+              '<div class="form-group"><label class="form-label" for="train-lora-rank">LoRA Rank</label><input type="number" id="train-lora-rank" class="form-input" value="16" min="1" max="256"><div class="form-hint">Higher = more capacity, more memory</div></div>' +
+              '<div class="form-group"><label class="form-label" for="train-lora-alpha">LoRA Alpha</label><input type="number" id="train-lora-alpha" class="form-input" value="32" min="1" max="512"><div class="form-hint">Typically 2x the rank</div></div>' +
+            '</div>' +
+          '</div>' +
+        '</div>' +
+        '<div class="form-actions"><button type="button" class="btn btn-ghost" id="training-cancel-btn">Cancel</button><button type="submit" class="btn btn-primary btn-lg" id="training-submit-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><polygon points="5 3 19 12 5 21 5 3"/></svg>Start Training</button></div>' +
+      '</form></div>';
+    this.bindTrainingForm();
   },
 
-  skeletonCards(n) {
-    return Array(n).fill(
-      '<div class="card"><div class="skeleton" style="height:48px;margin-bottom:8px"></div><div class="skeleton" style="height:14px;width:60%"></div></div>'
-    ).join('');
+  bindTrainingForm() {
+    const goBack = () => { this.state.trainingView = 'list'; this.renderTraining(); };
+    document.getElementById('training-back-btn')?.addEventListener('click', goBack);
+    document.getElementById('training-cancel-btn')?.addEventListener('click', goBack);
+    document.querySelectorAll('.method-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.method-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        document.getElementById('train-method').value = btn.dataset.method;
+        const ls = document.getElementById('lora-settings');
+        if (ls) ls.style.display = btn.dataset.method === 'lora' ? '' : 'none';
+      });
+    });
+    document.getElementById('advanced-toggle')?.addEventListener('click', () => {
+      const s = document.getElementById('advanced-settings');
+      const t = document.getElementById('advanced-toggle');
+      if (s) { s.classList.toggle('collapsed'); t.classList.toggle('open'); }
+    });
+    document.getElementById('training-form')?.addEventListener('submit', async (e) => { e.preventDefault(); await this.submitTrainingJob(); });
   },
+
+  async submitTrainingJob() {
+    const submitBtn = document.getElementById('training-submit-btn');
+    if (submitBtn) { submitBtn.disabled = true; submitBtn.textContent = 'Submitting...'; }
+    const customModel = document.getElementById('train-model-custom')?.value?.trim();
+    const baseModel = customModel || document.getElementById('train-model')?.value;
+    const method = document.getElementById('train-method')?.value || 'lora';
+    const payload = {
+      base_model: baseModel,
+      dataset_path: document.getElementById('train-dataset')?.value?.trim(),
+      method: method,
+      num_epochs: parseInt(document.getElementById('train-epochs')?.value) || 3,
+      batch_size: parseInt(document.getElementById('train-batch')?.value) || 4,
+      learning_rate: parseFloat(document.getElementById('train-lr')?.value) || 2e-4,
+      max_seq_length: parseInt(document.getElementById('train-seq-len')?.value) || 2048,
+    };
+    if (method === 'lora') {
+      payload.lora_rank = parseInt(document.getElementById('train-lora-rank')?.value) || 16;
+      payload.lora_alpha = parseInt(document.getElementById('train-lora-alpha')?.value) || 32;
+    }
+    try {
+      const resp = await fetch('/api/training/jobs', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+      const result = await resp.json();
+      if (!resp.ok) { alert('Error: ' + (result.error || 'Failed to create job')); if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = 'Start Training'; } return; }
+      this.state.trainingView = 'detail'; this.state.trainingDetailId = result.job_id; this.state.trainingLossData = []; this.renderTraining();
+    } catch (err) { alert('Network error: ' + err.message); if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = 'Start Training'; } }
+  },
+
+  async renderTrainingDetail(container) {
+    const jobId = this.state.trainingDetailId;
+    if (!jobId) { this.state.trainingView = 'list'; this.renderTraining(); return; }
+    const jobData = await this.fetchJSON('/api/training/jobs/' + jobId);
+    if (!jobData) { container.innerHTML = '<div class="training-empty"><h3>Job not found</h3></div>'; return; }
+    const logsData = await this.fetchJSON('/api/training/jobs/' + jobId + '/logs?tail=200');
+    const logs = logsData?.logs || [];
+    if (jobData.current_loss != null && jobData.progress > 0) {
+      const lastPoint = this.state.trainingLossData[this.state.trainingLossData.length - 1];
+      if (!lastPoint || lastPoint.progress !== jobData.progress) {
+        this.state.trainingLossData.push({ progress: jobData.progress, loss: jobData.current_loss, epoch: jobData.current_epoch });
+      }
+    }
+    if (this.state.trainingLossData.length === 0) {
+      for (const line of logs) {
+        const marker = 'AINODE_PROGRESS:'; const idx = line.indexOf(marker);
+        if (idx !== -1) { try { const p = JSON.parse(line.slice(idx + marker.length)); if (p.loss != null && p.progress != null) { this.state.trainingLossData.push({ progress: p.progress, loss: p.loss, epoch: p.epoch || 0 }); } } catch { } }
+      }
+    }
+    const statusMap = { pending: { cls: 'status-pending', label: 'Pending' }, running: { cls: 'status-running', label: 'Running' }, completed: { cls: 'status-completed', label: 'Completed' }, failed: { cls: 'status-failed', label: 'Failed' }, cancelled: { cls: 'status-cancelled', label: 'Cancelled' } };
+    const s = statusMap[jobData.status] || { cls: '', label: jobData.status };
+    const cfg = jobData.config || {};
+    const modelShort = cfg.base_model?.split('/').pop() || 'Unknown';
+    const started = jobData.start_time ? new Date(jobData.start_time * 1000).toLocaleString() : 'Not started';
+    const ended = jobData.end_time ? new Date(jobData.end_time * 1000).toLocaleString() : '--';
+    const elapsed = jobData.elapsed_seconds ? this.formatUptime(Math.round(jobData.elapsed_seconds)) : '--';
+    const isActive = jobData.status === 'running' || jobData.status === 'pending';
+    let html = '<div class="training-detail">' +
+      '<div class="training-form-header">' +
+        '<button class="btn btn-ghost" id="training-back-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><polyline points="15 18 9 12 15 6"/></svg>Back to Jobs</button>' +
+        '<div class="training-detail-title"><h2>' + this.esc(modelShort) + '</h2><span class="job-status-badge ' + s.cls + '">' + s.label + '</span></div>' +
+      '</div>';
+    if (jobData.status === 'running') {
+      html += '<div class="training-detail-progress card">' +
+        '<div class="progress-header"><span class="progress-pct">' + (jobData.progress || 0).toFixed(1) + '%</span><span class="progress-epoch">Epoch ' + (jobData.current_epoch || 0) + ' / ' + (cfg.num_epochs || '?') + '</span></div>' +
+        '<div class="progress-bar training-progress-bar-lg"><div class="progress-fill accent training-progress-animated" style="width:' + (jobData.progress || 0) + '%"></div></div>' +
+        '<div class="progress-stats">' + (jobData.current_loss != null ? '<span>Loss: <strong>' + jobData.current_loss.toFixed(4) + '</strong></span>' : '') + '<span>Elapsed: <strong>' + elapsed + '</strong></span></div></div>';
+    }
+    html += '<div class="training-detail-grid">' +
+      '<div class="card training-config-card"><div class="card-header"><div class="card-title">Configuration</div></div><table class="table">' +
+        '<tr><td>Model</td><td style="font-family:var(--font-mono)">' + this.esc(cfg.base_model || '') + '</td></tr>' +
+        '<tr><td>Method</td><td>' + (cfg.method || 'lora').toUpperCase() + '</td></tr>' +
+        '<tr><td>Dataset</td><td style="font-family:var(--font-mono);word-break:break-all">' + this.esc(cfg.dataset_path || '') + '</td></tr>' +
+        '<tr><td>Epochs</td><td>' + (cfg.num_epochs || '?') + '</td></tr>' +
+        '<tr><td>Batch Size</td><td>' + (cfg.batch_size || '?') + '</td></tr>' +
+        '<tr><td>Learning Rate</td><td>' + (cfg.learning_rate || '?') + '</td></tr>' +
+        '<tr><td>Max Seq Length</td><td>' + (cfg.max_seq_length || '?') + '</td></tr>' +
+        (cfg.method === 'lora' ? '<tr><td>LoRA Rank</td><td>' + (cfg.lora_rank || '?') + '</td></tr><tr><td>LoRA Alpha</td><td>' + (cfg.lora_alpha || '?') + '</td></tr>' : '') +
+        '<tr><td>Job ID</td><td style="font-family:var(--font-mono)">' + this.esc(jobData.job_id) + '</td></tr>' +
+        '<tr><td>Started</td><td>' + started + '</td></tr><tr><td>Ended</td><td>' + ended + '</td></tr><tr><td>Duration</td><td>' + elapsed + '</td></tr>' +
+      '</table>' + (isActive ? '<div style="margin-top:16px"><button class="btn btn-danger" id="training-cancel-job-btn">Cancel Job</button></div>' : '') + '</div>' +
+      '<div class="training-right-col">' +
+        (this.state.trainingLossData.length > 1 ? '<div class="card training-chart-card"><div class="card-header"><div class="card-title">Training Loss</div></div><div class="loss-chart-container"><canvas id="loss-chart" width="460" height="200"></canvas></div></div>' : '') +
+        '<div class="card training-log-card"><div class="card-header"><div class="card-title">Logs</div><span class="log-line-count">' + (logsData?.total_lines || 0) + ' lines</span></div>' +
+        '<div class="training-log-viewer" id="training-log-viewer">' + (logs.length > 0 ? logs.map(l => '<div class="log-line">' + this.esc(l) + '</div>').join('') : '<div class="log-empty">No logs yet</div>') + '</div></div>' +
+      '</div></div></div>';
+    container.innerHTML = html;
+    document.getElementById('training-back-btn')?.addEventListener('click', () => { this.state.trainingView = 'list'; this.state.trainingDetailId = null; this.state.trainingLossData = []; this.renderTraining(); });
+    document.getElementById('training-cancel-job-btn')?.addEventListener('click', async () => {
+      if (!confirm('Cancel this training job?')) return;
+      const resp = await fetch('/api/training/jobs/' + jobId, { method: 'DELETE' });
+      if (resp.ok) { this.renderTraining(); } else { const err = await resp.json().catch(() => ({})); alert(err.error || 'Failed to cancel job'); }
+    });
+    const logViewer = document.getElementById('training-log-viewer');
+    if (logViewer) logViewer.scrollTop = logViewer.scrollHeight;
+    if (this.state.trainingLossData.length > 1) this.drawLossChart();
+  },
+
+  drawLossChart() {
+    const canvas = document.getElementById('loss-chart');
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    const dpr = window.devicePixelRatio || 1;
+    const rect = canvas.getBoundingClientRect();
+    canvas.width = rect.width * dpr; canvas.height = rect.height * dpr; ctx.scale(dpr, dpr);
+    const w = rect.width, h = rect.height;
+    const pad = { top: 12, right: 16, bottom: 28, left: 48 };
+    const plotW = w - pad.left - pad.right, plotH = h - pad.top - pad.bottom;
+    const data = this.state.trainingLossData;
+    if (data.length < 2) return;
+    const losses = data.map(d => d.loss);
+    const maxLoss = Math.max(...losses) * 1.05, minLoss = Math.min(...losses) * 0.95;
+    const maxProg = Math.max(...data.map(d => d.progress), 1);
+    const toX = (prog) => pad.left + (prog / maxProg) * plotW;
+    const toY = (loss) => pad.top + ((maxLoss - loss) / (maxLoss - minLoss || 1)) * plotH;
+    ctx.clearRect(0, 0, w, h);
+    ctx.strokeStyle = 'rgba(45, 55, 72, 0.5)'; ctx.lineWidth = 1;
+    for (let i = 0; i <= 4; i++) {
+      const y = pad.top + (plotH / 4) * i;
+      ctx.beginPath(); ctx.moveTo(pad.left, y); ctx.lineTo(w - pad.right, y); ctx.stroke();
+      const val = maxLoss - ((maxLoss - minLoss) / 4) * i;
+      ctx.fillStyle = '#64748b'; ctx.font = '10px Inter, sans-serif'; ctx.textAlign = 'right'; ctx.fillText(val.toFixed(3), pad.left - 6, y + 3);
+    }
+    ctx.fillStyle = '#64748b'; ctx.font = '10px Inter, sans-serif'; ctx.textAlign = 'center';
+    ctx.fillText('0%', pad.left, h - 6); ctx.fillText(maxProg.toFixed(0) + '%', w - pad.right, h - 6);
+    ctx.strokeStyle = '#4a90d9'; ctx.lineWidth = 2; ctx.lineJoin = 'round'; ctx.lineCap = 'round'; ctx.beginPath();
+    data.forEach((d, i) => { const x = toX(d.progress), y = toY(d.loss); if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y); }); ctx.stroke();
+    const gradient = ctx.createLinearGradient(0, pad.top, 0, h - pad.bottom);
+    gradient.addColorStop(0, 'rgba(74, 144, 217, 0.15)'); gradient.addColorStop(1, 'rgba(74, 144, 217, 0)');
+    ctx.fillStyle = gradient; ctx.beginPath();
+    data.forEach((d, i) => { const x = toX(d.progress), y = toY(d.loss); if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y); });
+    ctx.lineTo(toX(data[data.length - 1].progress), h - pad.bottom); ctx.lineTo(toX(data[0].progress), h - pad.bottom); ctx.closePath(); ctx.fill();
+    const last = data[data.length - 1];
+    ctx.fillStyle = '#4a90d9'; ctx.beginPath(); ctx.arc(toX(last.progress), toY(last.loss), 4, 0, Math.PI * 2); ctx.fill();
+    ctx.strokeStyle = '#0a0e17'; ctx.lineWidth = 2; ctx.stroke();
+  },
+
+  // --- Utilities ---
+  esc(str) { const div = document.createElement('div'); div.textContent = str || ''; return div.innerHTML; },
+  formatUptime(seconds) { if (seconds < 60) return seconds + 's'; if (seconds < 3600) return Math.floor(seconds / 60) + 'm'; return Math.floor(seconds / 3600) + 'h ' + Math.floor((seconds % 3600) / 60) + 'm'; },
+  formatMarkdown(text) { if (!text) return ''; return text.replace(/```(\w*)\n([\s\S]*?)```/g, '<pre><code>$2</code></pre>').replace(/`([^`]+)`/g, '<code>$1</code>').replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>').replace(/\n/g, '<br>'); },
+  skeletonCards(n) { return Array(n).fill('<div class="card"><div class="skeleton" style="height:48px;margin-bottom:8px"></div><div class="skeleton" style="height:14px;width:60%"></div></div>').join(''); },
 };
 
-// Boot
 document.addEventListener('DOMContentLoaded', () => AINode.init());

--- a/ainode/web/static/js/app.js
+++ b/ainode/web/static/js/app.js
@@ -1,0 +1,419 @@
+/* AINode Dashboard — Single Page Application */
+
+const AINode = {
+  state: {
+    currentView: 'dashboard',
+    status: null,
+    nodes: [],
+    messages: [],
+    streaming: false,
+    pollInterval: null,
+  },
+
+  // ─── Initialization ────────────────────────────────
+  init() {
+    this.bindNav();
+    this.bindChat();
+    this.navigate(window.location.hash.slice(1) || 'dashboard');
+    this.startPolling();
+  },
+
+  // ─── Navigation ────────────────────────────────────
+  bindNav() {
+    document.querySelectorAll('.nav-item').forEach(el => {
+      el.addEventListener('click', () => {
+        const view = el.dataset.view;
+        if (view) this.navigate(view);
+      });
+    });
+  },
+
+  navigate(view) {
+    this.state.currentView = view;
+    window.location.hash = view;
+
+    // Update nav active state
+    document.querySelectorAll('.nav-item').forEach(el => {
+      el.classList.toggle('active', el.dataset.view === view);
+    });
+
+    // Show/hide views
+    document.querySelectorAll('.view').forEach(el => {
+      el.style.display = el.id === `view-${view}` ? 'block' : 'none';
+    });
+
+    // Refresh data for the view
+    this.refresh();
+  },
+
+  // ─── Data Fetching ─────────────────────────────────
+  async fetchJSON(url) {
+    try {
+      const resp = await fetch(url);
+      if (!resp.ok) return null;
+      return await resp.json();
+    } catch {
+      return null;
+    }
+  },
+
+  async refresh() {
+    const [status, nodes] = await Promise.all([
+      this.fetchJSON('/api/status'),
+      this.fetchJSON('/api/nodes'),
+    ]);
+
+    this.state.status = status;
+    this.state.nodes = nodes?.nodes || [];
+
+    switch (this.state.currentView) {
+      case 'dashboard': this.renderDashboard(); break;
+      case 'chat': this.renderChatHeader(); break;
+      case 'models': this.renderModels(); break;
+      case 'training': this.renderTraining(); break;
+    }
+  },
+
+  startPolling() {
+    this.state.pollInterval = setInterval(() => this.refresh(), 5000);
+  },
+
+  // ─── Dashboard View ────────────────────────────────
+  renderDashboard() {
+    const s = this.state.status;
+    const nodes = this.state.nodes;
+
+    if (!s) {
+      document.getElementById('dashboard-stats').innerHTML = this.skeletonCards(4);
+      return;
+    }
+
+    // Stats row
+    const totalGPUs = nodes.reduce((sum, n) => sum + (n.gpu_count || 1), 0);
+    const totalMem = nodes.reduce((sum, n) => sum + (n.gpu_memory_gb || 0), 0);
+    const onlineNodes = nodes.filter(n => n.status === 'online').length;
+    const modelsLoaded = s.models_loaded?.length || 0;
+
+    document.getElementById('dashboard-stats').innerHTML = `
+      <div class="card">
+        <div class="stat-value">${onlineNodes || 1}</div>
+        <div class="stat-label">Nodes Online</div>
+      </div>
+      <div class="card">
+        <div class="stat-value">${totalGPUs || 1}</div>
+        <div class="stat-label">GPUs</div>
+      </div>
+      <div class="card">
+        <div class="stat-value">${totalMem || (s.gpu?.memory_gb || 0)} GB</div>
+        <div class="stat-label">Total Memory</div>
+      </div>
+      <div class="card">
+        <div class="stat-value">${modelsLoaded}</div>
+        <div class="stat-label">Models Loaded</div>
+      </div>
+    `;
+
+    // Node cards
+    this.renderNodes(nodes, s);
+
+    // Cluster health
+    this.renderClusterHealth(s);
+  },
+
+  renderNodes(nodes, status) {
+    const container = document.getElementById('dashboard-nodes');
+    if (!container) return;
+
+    // If no cluster nodes, show this node
+    if (nodes.length === 0 && status) {
+      nodes = [{
+        node_id: status.node_id || 'local',
+        node_name: status.node_name || 'This Node',
+        gpu_name: status.gpu?.name || 'Unknown GPU',
+        gpu_memory_gb: status.gpu?.memory_gb || 0,
+        unified_memory: status.gpu?.unified_memory || false,
+        model: status.model || 'none',
+        status: status.engine_ready ? 'online' : 'starting',
+        is_leader: true,
+      }];
+    }
+
+    container.innerHTML = nodes.map(node => {
+      const statusClass = node.status === 'online' ? 'status-online' :
+                          node.status === 'starting' ? 'status-starting' : 'status-offline';
+      const leaderClass = node.is_leader ? 'is-leader' : '';
+      const memLabel = node.unified_memory ? 'unified' : 'VRAM';
+      const memPct = node.gpu_memory_used_pct || 0;
+      const barClass = memPct > 90 ? 'red' : memPct > 70 ? 'yellow' : 'green';
+
+      return `
+        <div class="node-card ${leaderClass}">
+          <div style="display:flex; justify-content:space-between; align-items:start; margin-bottom:12px">
+            <div>
+              <div class="node-name">${this.esc(node.node_name || node.node_id)}</div>
+              <div class="node-id">${this.esc(node.node_id)}</div>
+            </div>
+            <div class="status ${statusClass}">
+              <span class="status-dot"></span>
+              ${node.status || 'unknown'}
+            </div>
+          </div>
+          <div class="node-gpu">${this.esc(node.gpu_name || 'Unknown')} &middot; ${node.gpu_memory_gb || '?'} GB ${memLabel}</div>
+          <div class="node-model">${this.esc(node.model || 'no model')}</div>
+          <div class="progress-bar">
+            <div class="progress-fill ${barClass}" style="width:${memPct}%"></div>
+          </div>
+          <div style="font-size:11px; color:var(--text-muted); margin-top:4px">
+            Memory: ${memPct}% used
+          </div>
+        </div>
+      `;
+    }).join('');
+  },
+
+  renderClusterHealth(status) {
+    const container = document.getElementById('dashboard-health');
+    if (!container) return;
+
+    const uptime = status.uptime_seconds ? this.formatUptime(status.uptime_seconds) : 'N/A';
+
+    container.innerHTML = `
+      <div class="card">
+        <div class="card-header">
+          <div class="card-title">Engine Status</div>
+        </div>
+        <table class="table">
+          <tr>
+            <td>Engine</td>
+            <td>${status.engine_ready ?
+              '<span class="status status-online"><span class="status-dot"></span>Ready</span>' :
+              '<span class="status status-starting"><span class="status-dot"></span>Starting</span>'}</td>
+          </tr>
+          <tr>
+            <td>Model</td>
+            <td style="font-family:var(--font-mono)">${this.esc(status.model || 'none')}</td>
+          </tr>
+          <tr>
+            <td>API Port</td>
+            <td style="font-family:var(--font-mono)">${status.api_port || 8000}</td>
+          </tr>
+          <tr>
+            <td>Uptime</td>
+            <td>${uptime}</td>
+          </tr>
+          <tr>
+            <td>Version</td>
+            <td>${this.esc(status.version || 'unknown')}</td>
+          </tr>
+        </table>
+      </div>
+    `;
+  },
+
+  // ─── Chat View ─────────────────────────────────────
+  bindChat() {
+    const input = document.getElementById('chat-input');
+    const send = document.getElementById('chat-send');
+    if (!input || !send) return;
+
+    send.addEventListener('click', () => this.sendMessage());
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        this.sendMessage();
+      }
+    });
+
+    // Auto-resize textarea
+    input.addEventListener('input', () => {
+      input.style.height = 'auto';
+      input.style.height = Math.min(input.scrollHeight, 200) + 'px';
+    });
+  },
+
+  renderChatHeader() {
+    const s = this.state.status;
+    const select = document.getElementById('chat-model');
+    if (!select || !s) return;
+
+    const models = s.models_loaded || [];
+    if (models.length === 0) {
+      select.innerHTML = '<option>No models loaded</option>';
+    } else {
+      select.innerHTML = models.map(m =>
+        `<option value="${this.esc(m)}">${this.esc(m)}</option>`
+      ).join('');
+    }
+  },
+
+  async sendMessage() {
+    const input = document.getElementById('chat-input');
+    const content = input.value.trim();
+    if (!content || this.state.streaming) return;
+
+    input.value = '';
+    input.style.height = 'auto';
+
+    // Add user message
+    this.state.messages.push({ role: 'user', content });
+    this.renderMessages();
+
+    // Get model
+    const select = document.getElementById('chat-model');
+    const model = select?.value || '';
+
+    // Stream response
+    this.state.streaming = true;
+    document.getElementById('chat-send').disabled = true;
+
+    const assistantMsg = { role: 'assistant', content: '' };
+    this.state.messages.push(assistantMsg);
+
+    try {
+      const resp = await fetch('/v1/chat/completions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model,
+          messages: this.state.messages.slice(0, -1).map(m => ({
+            role: m.role, content: m.content
+          })),
+          stream: true,
+        }),
+      });
+
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop();
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          const data = line.slice(6);
+          if (data === '[DONE]') break;
+
+          try {
+            const json = JSON.parse(data);
+            const delta = json.choices?.[0]?.delta?.content;
+            if (delta) {
+              assistantMsg.content += delta;
+              this.renderMessages();
+            }
+          } catch { /* skip malformed chunks */ }
+        }
+      }
+    } catch (err) {
+      assistantMsg.content = `Error: ${err.message}. Is the engine running?`;
+    }
+
+    this.state.streaming = false;
+    document.getElementById('chat-send').disabled = false;
+    this.renderMessages();
+  },
+
+  renderMessages() {
+    const container = document.getElementById('chat-messages');
+    if (!container) return;
+
+    container.innerHTML = this.state.messages.map(msg => `
+      <div class="chat-message ${msg.role}">
+        ${this.formatMarkdown(msg.content)}
+      </div>
+    `).join('');
+
+    container.scrollTop = container.scrollHeight;
+  },
+
+  // ─── Models View ───────────────────────────────────
+  renderModels() {
+    const container = document.getElementById('models-list');
+    if (!container) return;
+
+    const s = this.state.status;
+    const loaded = s?.models_loaded || [];
+
+    const recommended = [
+      { id: 'meta-llama/Llama-3.2-3B-Instruct', size: '~6 GB', desc: 'Quick start, fast inference' },
+      { id: 'meta-llama/Llama-3.1-8B-Instruct', size: '~16 GB', desc: 'Recommended for most tasks' },
+      { id: 'meta-llama/Llama-3.1-70B-Instruct-AWQ', size: '~35 GB', desc: 'High quality, needs 40+ GB' },
+      { id: 'Qwen/Qwen2.5-72B-Instruct', size: '~40 GB', desc: 'Great for coding + multilingual' },
+      { id: 'deepseek-ai/DeepSeek-R1-Distill-Qwen-7B', size: '~14 GB', desc: 'Reasoning specialist' },
+      { id: 'mistralai/Mistral-7B-Instruct-v0.3', size: '~14 GB', desc: 'Fast, general purpose' },
+    ];
+
+    container.innerHTML = recommended.map(model => {
+      const isLoaded = loaded.includes(model.id);
+      return `
+        <div class="model-card">
+          <div class="model-info">
+            <div class="model-name">${this.esc(model.id)}</div>
+            <div class="model-meta">${model.size} &middot; ${model.desc}</div>
+          </div>
+          <div class="model-status">
+            ${isLoaded ?
+              '<span class="model-badge loaded">Loaded</span>' :
+              '<span class="model-badge available">Available</span>'}
+          </div>
+        </div>
+      `;
+    }).join('');
+  },
+
+  // ─── Training View ─────────────────────────────────
+  renderTraining() {
+    const container = document.getElementById('training-content');
+    if (!container) return;
+
+    container.innerHTML = `
+      <div class="training-placeholder">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+          <path d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
+        </svg>
+        <h3>Fine-Tuning Studio</h3>
+        <p>Upload datasets, configure LoRA adapters, and train models — all from your browser.</p>
+        <p style="margin-top:16px; font-size:13px">Coming in AINode v0.2</p>
+      </div>
+    `;
+  },
+
+  // ─── Utilities ─────────────────────────────────────
+  esc(str) {
+    const div = document.createElement('div');
+    div.textContent = str || '';
+    return div.innerHTML;
+  },
+
+  formatUptime(seconds) {
+    if (seconds < 60) return `${seconds}s`;
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    return `${h}h ${m}m`;
+  },
+
+  formatMarkdown(text) {
+    if (!text) return '';
+    // Basic markdown: code blocks, inline code, bold, newlines
+    return text
+      .replace(/```(\w*)\n([\s\S]*?)```/g, '<pre><code>$2</code></pre>')
+      .replace(/`([^`]+)`/g, '<code>$1</code>')
+      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+      .replace(/\n/g, '<br>');
+  },
+
+  skeletonCards(n) {
+    return Array(n).fill(
+      '<div class="card"><div class="skeleton" style="height:48px;margin-bottom:8px"></div><div class="skeleton" style="height:14px;width:60%"></div></div>'
+    ).join('');
+  },
+};
+
+// Boot
+document.addEventListener('DOMContentLoaded', () => AINode.init());

--- a/ainode/web/templates/index.html
+++ b/ainode/web/templates/index.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AINode — Local AI Platform</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/css/style.css">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚡</text></svg>">
+</head>
+<body>
+  <div class="app">
+    <!-- Sidebar -->
+    <aside class="sidebar">
+      <div class="sidebar-header">
+        <div class="sidebar-logo"><span>AI</span>Node</div>
+        <div class="sidebar-subtitle">Local AI Platform</div>
+      </div>
+
+      <nav class="sidebar-nav">
+        <div class="nav-item active" data-view="dashboard">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <rect x="3" y="3" width="7" height="7" rx="1"/>
+            <rect x="14" y="3" width="7" height="7" rx="1"/>
+            <rect x="3" y="14" width="7" height="7" rx="1"/>
+            <rect x="14" y="14" width="7" height="7" rx="1"/>
+          </svg>
+          Dashboard
+        </div>
+        <div class="nav-item" data-view="chat">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/>
+          </svg>
+          Chat
+        </div>
+        <div class="nav-item" data-view="models">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/>
+            <polyline points="3.27 6.96 12 12.01 20.73 6.96"/>
+            <line x1="12" y1="22.08" x2="12" y2="12"/>
+          </svg>
+          Models
+        </div>
+        <div class="nav-item" data-view="training">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
+          </svg>
+          Training
+        </div>
+      </nav>
+
+      <div class="sidebar-footer">
+        Powered by <a href="https://argentos.ai" target="_blank">argentos.ai</a>
+      </div>
+    </aside>
+
+    <!-- Main Content -->
+    <main class="main">
+
+      <!-- Dashboard View -->
+      <div id="view-dashboard" class="view">
+        <div class="page-header">
+          <div class="page-title">Dashboard</div>
+          <div class="page-desc">Cluster overview and node status</div>
+        </div>
+
+        <div id="dashboard-stats" class="grid-4" style="margin-bottom:24px">
+          <!-- Filled by JS -->
+        </div>
+
+        <div class="card-header" style="margin-bottom:12px">
+          <div class="card-title">Nodes</div>
+        </div>
+        <div id="dashboard-nodes" class="grid-3" style="margin-bottom:24px">
+          <!-- Filled by JS -->
+        </div>
+
+        <div id="dashboard-health">
+          <!-- Filled by JS -->
+        </div>
+      </div>
+
+      <!-- Chat View -->
+      <div id="view-chat" class="view" style="display:none">
+        <div class="page-header">
+          <div class="page-title">Chat</div>
+          <div class="page-desc">Talk to your local models</div>
+        </div>
+
+        <div class="chat-container">
+          <select id="chat-model" class="chat-model-select">
+            <option>Loading models...</option>
+          </select>
+
+          <div id="chat-messages" class="chat-messages">
+            <div style="text-align:center; color:var(--text-muted); padding:60px 0">
+              Send a message to get started
+            </div>
+          </div>
+
+          <div class="chat-input-area">
+            <div class="chat-input-wrapper">
+              <textarea id="chat-input" class="chat-input" placeholder="Type a message..." rows="1"></textarea>
+              <button id="chat-send" class="chat-send">Send</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Models View -->
+      <div id="view-models" class="view" style="display:none">
+        <div class="page-header">
+          <div class="page-title">Models</div>
+          <div class="page-desc">Browse and manage available models</div>
+        </div>
+
+        <div id="models-list">
+          <!-- Filled by JS -->
+        </div>
+      </div>
+
+      <!-- Training View -->
+      <div id="view-training" class="view" style="display:none">
+        <div class="page-header">
+          <div class="page-title">Training</div>
+          <div class="page-desc">Fine-tune models on your hardware</div>
+        </div>
+
+        <div id="training-content">
+          <!-- Filled by JS -->
+        </div>
+      </div>
+
+    </main>
+  </div>
+
+  <script src="/static/js/app.js"></script>
+</body>
+</html>

--- a/ainode/web/templates/onboarding.html
+++ b/ainode/web/templates/onboarding.html
@@ -1,0 +1,660 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AINode — Setup</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/css/style.css">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚡</text></svg>">
+  <style>
+    /* Onboarding-specific styles */
+    .onboarding-shell {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      padding: 24px;
+    }
+
+    .wizard {
+      width: 100%;
+      max-width: 640px;
+      position: relative;
+    }
+
+    /* Progress bar */
+    .progress-track {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 32px;
+    }
+
+    .progress-segment {
+      flex: 1;
+      height: 4px;
+      background: var(--border);
+      border-radius: 2px;
+      transition: background 0.4s ease;
+    }
+
+    .progress-segment.done {
+      background: var(--accent);
+    }
+
+    .progress-segment.active {
+      background: var(--accent);
+      animation: pulse 1.5s infinite;
+    }
+
+    /* Step container */
+    .step {
+      display: none;
+      animation: fadeSlideIn 0.35s ease;
+    }
+
+    .step.active {
+      display: block;
+    }
+
+    @keyframes fadeSlideIn {
+      from { opacity: 0; transform: translateY(12px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+
+    .step-label {
+      font-size: 12px;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      margin-bottom: 8px;
+    }
+
+    .step-title {
+      font-size: 28px;
+      font-weight: 700;
+      margin-bottom: 8px;
+    }
+
+    .step-desc {
+      color: var(--text-secondary);
+      font-size: 15px;
+      line-height: 1.6;
+      margin-bottom: 32px;
+    }
+
+    /* Logo */
+    .brand {
+      text-align: center;
+      margin-bottom: 40px;
+    }
+
+    .brand-logo {
+      font-size: 48px;
+      font-weight: 700;
+      letter-spacing: -1px;
+      margin-bottom: 4px;
+    }
+
+    .brand-logo span { color: var(--accent); }
+
+    .brand-tagline {
+      font-size: 14px;
+      color: var(--text-muted);
+    }
+
+    /* Form elements */
+    .field {
+      margin-bottom: 20px;
+    }
+
+    .field label {
+      display: block;
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text-secondary);
+      margin-bottom: 6px;
+    }
+
+    .field input[type="text"],
+    .field input[type="email"] {
+      width: 100%;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      padding: 12px 16px;
+      color: var(--text-primary);
+      font-size: 15px;
+      font-family: var(--font-sans);
+      outline: none;
+      transition: border-color 0.15s ease;
+    }
+
+    .field input:focus {
+      border-color: var(--accent);
+    }
+
+    .field input::placeholder {
+      color: var(--text-muted);
+    }
+
+    .field .hint {
+      font-size: 12px;
+      color: var(--text-muted);
+      margin-top: 4px;
+    }
+
+    /* Model cards */
+    .model-pick {
+      background: var(--bg-card);
+      border: 2px solid var(--border);
+      border-radius: var(--radius);
+      padding: 16px 20px;
+      cursor: pointer;
+      transition: all 0.15s ease;
+      margin-bottom: 10px;
+      display: flex;
+      align-items: center;
+      gap: 16px;
+    }
+
+    .model-pick:hover {
+      border-color: var(--border-active);
+    }
+
+    .model-pick.selected {
+      border-color: var(--accent);
+      background: rgba(74, 144, 217, 0.08);
+    }
+
+    .model-pick.disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+
+    .model-pick .radio {
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      border: 2px solid var(--border);
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: all 0.15s ease;
+    }
+
+    .model-pick.selected .radio {
+      border-color: var(--accent);
+    }
+
+    .model-pick.selected .radio::after {
+      content: '';
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: var(--accent);
+    }
+
+    .model-pick .model-details {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .model-pick .model-pick-name {
+      font-size: 15px;
+      font-weight: 600;
+      margin-bottom: 2px;
+    }
+
+    .model-pick .model-pick-desc {
+      font-size: 13px;
+      color: var(--text-secondary);
+      margin-bottom: 4px;
+    }
+
+    .model-pick .model-pick-meta {
+      font-size: 12px;
+      color: var(--text-muted);
+      font-family: var(--font-mono);
+    }
+
+    .model-pick .fit-badge {
+      font-size: 10px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      padding: 3px 8px;
+      border-radius: 12px;
+      flex-shrink: 0;
+    }
+
+    .fit-badge.fits {
+      background: var(--green-glow);
+      color: var(--green);
+      border: 1px solid var(--green);
+    }
+
+    .fit-badge.no-fit {
+      background: var(--red-glow);
+      color: var(--red);
+      border: 1px solid var(--red);
+    }
+
+    /* GPU info bar */
+    .gpu-bar {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      padding: 12px 16px;
+      margin-bottom: 20px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 13px;
+    }
+
+    .gpu-bar .gpu-icon {
+      color: var(--green);
+      font-size: 18px;
+    }
+
+    .gpu-bar .gpu-label {
+      color: var(--text-secondary);
+    }
+
+    .gpu-bar .gpu-value {
+      color: var(--text-primary);
+      font-weight: 600;
+      font-family: var(--font-mono);
+    }
+
+    /* Summary */
+    .summary-table {
+      width: 100%;
+      margin-bottom: 32px;
+    }
+
+    .summary-row {
+      display: flex;
+      justify-content: space-between;
+      padding: 14px 0;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .summary-row:last-child {
+      border-bottom: none;
+    }
+
+    .summary-key {
+      font-size: 14px;
+      color: var(--text-secondary);
+    }
+
+    .summary-val {
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--text-primary);
+      font-family: var(--font-mono);
+    }
+
+    /* Buttons */
+    .btn-row {
+      display: flex;
+      gap: 12px;
+      margin-top: 32px;
+    }
+
+    .btn {
+      padding: 12px 28px;
+      border-radius: var(--radius-sm);
+      font-size: 15px;
+      font-weight: 600;
+      font-family: var(--font-sans);
+      cursor: pointer;
+      border: none;
+      transition: all 0.15s ease;
+    }
+
+    .btn-primary {
+      background: var(--accent);
+      color: white;
+      flex: 1;
+    }
+
+    .btn-primary:hover { background: var(--accent-hover); }
+
+    .btn-primary:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .btn-secondary {
+      background: transparent;
+      color: var(--text-secondary);
+      border: 1px solid var(--border);
+    }
+
+    .btn-secondary:hover {
+      background: var(--bg-card);
+      color: var(--text-primary);
+    }
+
+    .btn-link {
+      background: none;
+      border: none;
+      color: var(--text-muted);
+      font-size: 13px;
+      cursor: pointer;
+      padding: 8px 0;
+      text-decoration: underline;
+      font-family: var(--font-sans);
+    }
+
+    .btn-link:hover { color: var(--text-secondary); }
+
+    /* Launch animation */
+    .launch-spinner {
+      display: none;
+      text-align: center;
+      padding: 40px 0;
+    }
+
+    .launch-spinner.visible { display: block; }
+
+    .spinner {
+      width: 48px;
+      height: 48px;
+      border: 3px solid var(--border);
+      border-top-color: var(--accent);
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+      margin: 0 auto 16px;
+    }
+
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+
+    .launch-text {
+      color: var(--text-secondary);
+      font-size: 15px;
+    }
+
+    .footer {
+      text-align: center;
+      margin-top: 40px;
+      font-size: 11px;
+      color: var(--text-muted);
+    }
+
+    .footer a {
+      color: var(--accent);
+      text-decoration: none;
+    }
+  </style>
+</head>
+<body>
+  <div class="onboarding-shell">
+    <div class="wizard">
+      <!-- Progress -->
+      <div class="progress-track">
+        <div class="progress-segment active" data-step="1"></div>
+        <div class="progress-segment" data-step="2"></div>
+        <div class="progress-segment" data-step="3"></div>
+        <div class="progress-segment" data-step="4"></div>
+        <div class="progress-segment" data-step="5"></div>
+      </div>
+
+      <!-- Step 1: Welcome -->
+      <div class="step active" data-step="1">
+        <div class="brand">
+          <div class="brand-logo"><span>AI</span>Node</div>
+          <div class="brand-tagline">Local AI Platform</div>
+        </div>
+        <div class="step-title" style="text-align:center">Let's get you set up</div>
+        <div class="step-desc" style="text-align:center">
+          Turn your NVIDIA GPU into a local AI powerhouse. Inference and fine-tuning in your browser, one command to start.
+        </div>
+        <div class="btn-row" style="justify-content:center">
+          <button class="btn btn-primary" onclick="goStep(2)" style="max-width:280px">Get Started</button>
+        </div>
+      </div>
+
+      <!-- Step 2: Name your node -->
+      <div class="step" data-step="2">
+        <div class="step-label">Step 1 of 4</div>
+        <div class="step-title">Name your node</div>
+        <div class="step-desc">Give this AINode a name so you can identify it in the cluster.</div>
+        <div class="field">
+          <label for="node-name">Node Name</label>
+          <input type="text" id="node-name" placeholder="my-ainode" autocomplete="off" spellcheck="false">
+          <div class="hint">Auto-suggested from your hostname. You can change this later.</div>
+        </div>
+        <div class="btn-row">
+          <button class="btn btn-secondary" onclick="goStep(1)">Back</button>
+          <button class="btn btn-primary" onclick="goStep(3)">Continue</button>
+        </div>
+      </div>
+
+      <!-- Step 3: Select a model -->
+      <div class="step" data-step="3">
+        <div class="step-label">Step 2 of 4</div>
+        <div class="step-title">Choose a model</div>
+        <div class="step-desc">Pick a model to run. Recommended models are highlighted based on your hardware.</div>
+        <div id="gpu-info-bar" class="gpu-bar" style="display:none">
+          <span class="gpu-icon">&#9889;</span>
+          <span class="gpu-label">Detected:</span>
+          <span class="gpu-value" id="gpu-name">—</span>
+          <span class="gpu-label" style="margin-left:auto">Memory:</span>
+          <span class="gpu-value" id="gpu-mem">—</span>
+        </div>
+        <div id="model-list">
+          <div style="text-align:center; color:var(--text-muted); padding:40px 0">Loading models...</div>
+        </div>
+        <div class="btn-row">
+          <button class="btn btn-secondary" onclick="goStep(2)">Back</button>
+          <button class="btn btn-primary" id="btn-model-next" onclick="goStep(4)" disabled>Continue</button>
+        </div>
+      </div>
+
+      <!-- Step 4: Email -->
+      <div class="step" data-step="4">
+        <div class="step-label">Step 3 of 4</div>
+        <div class="step-title">Stay in the loop</div>
+        <div class="step-desc">Optionally enter your email for product updates and support. We won't spam you.</div>
+        <div class="field">
+          <label for="email">Email Address</label>
+          <input type="email" id="email" placeholder="you@example.com" autocomplete="email">
+        </div>
+        <button class="btn-link" onclick="goStep(5)">Skip this step</button>
+        <div class="btn-row">
+          <button class="btn btn-secondary" onclick="goStep(3)">Back</button>
+          <button class="btn btn-primary" onclick="goStep(5)">Continue</button>
+        </div>
+      </div>
+
+      <!-- Step 5: Summary -->
+      <div class="step" data-step="5">
+        <div class="step-label">Step 4 of 4</div>
+        <div class="step-title">Ready to launch</div>
+        <div class="step-desc">Here's a summary of your setup. Hit the button to start AINode.</div>
+        <div class="summary-table">
+          <div class="summary-row">
+            <span class="summary-key">Node Name</span>
+            <span class="summary-val" id="sum-name">—</span>
+          </div>
+          <div class="summary-row">
+            <span class="summary-key">Model</span>
+            <span class="summary-val" id="sum-model">—</span>
+          </div>
+          <div class="summary-row">
+            <span class="summary-key">Email</span>
+            <span class="summary-val" id="sum-email">—</span>
+          </div>
+        </div>
+        <div id="launch-area">
+          <div class="btn-row">
+            <button class="btn btn-secondary" onclick="goStep(4)">Back</button>
+            <button class="btn btn-primary" id="btn-launch" onclick="launch()">Launch AINode</button>
+          </div>
+        </div>
+        <div class="launch-spinner" id="launch-spinner">
+          <div class="spinner"></div>
+          <div class="launch-text">Saving configuration...</div>
+        </div>
+      </div>
+
+      <div class="footer">
+        Powered by <a href="https://argentos.ai" target="_blank">argentos.ai</a>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    // State
+    let currentStep = 1;
+    let selectedModel = '';
+    let suggestions = {};
+
+    // Fetch suggestions on load
+    async function init() {
+      try {
+        const resp = await fetch('/api/onboarding/suggestions');
+        suggestions = await resp.json();
+
+        // Pre-fill node name
+        const nameInput = document.getElementById('node-name');
+        if (suggestions.hostname) {
+          nameInput.value = suggestions.hostname;
+        }
+
+        // GPU info
+        if (suggestions.gpu) {
+          document.getElementById('gpu-info-bar').style.display = 'flex';
+          document.getElementById('gpu-name').textContent = suggestions.gpu.name;
+          document.getElementById('gpu-mem').textContent = suggestions.gpu.memory_gb + ' GB';
+        }
+
+        // Render models
+        renderModels(suggestions.models || []);
+      } catch (err) {
+        console.error('Failed to load suggestions:', err);
+      }
+    }
+
+    function renderModels(models) {
+      const container = document.getElementById('model-list');
+      if (!models.length) {
+        container.innerHTML = '<div style="color:var(--text-muted)">No models available</div>';
+        return;
+      }
+
+      container.innerHTML = '';
+      models.forEach(m => {
+        const card = document.createElement('div');
+        card.className = 'model-pick' + (m.fits_gpu ? '' : ' disabled');
+        card.dataset.repo = m.hf_repo;
+        card.innerHTML = `
+          <div class="radio"></div>
+          <div class="model-details">
+            <div class="model-pick-name">${esc(m.name)}</div>
+            <div class="model-pick-desc">${esc(m.description)}</div>
+            <div class="model-pick-meta">${m.size_gb} GB &middot; min ${m.min_memory_gb} GB VRAM</div>
+          </div>
+          <span class="fit-badge ${m.fits_gpu ? 'fits' : 'no-fit'}">${m.fits_gpu ? 'Fits' : 'Too large'}</span>
+        `;
+        card.addEventListener('click', () => selectModel(card, m));
+        container.appendChild(card);
+      });
+
+      // Auto-select first fitting model
+      const firstFit = models.find(m => m.fits_gpu);
+      if (firstFit) {
+        const el = container.querySelector(`[data-repo="${firstFit.hf_repo}"]`);
+        if (el) selectModel(el, firstFit);
+      }
+    }
+
+    function selectModel(card, model) {
+      if (!model.fits_gpu && suggestions.gpu) return; // block selection if too large and GPU detected
+      document.querySelectorAll('.model-pick').forEach(c => c.classList.remove('selected'));
+      card.classList.add('selected');
+      selectedModel = model.hf_repo;
+      document.getElementById('btn-model-next').disabled = false;
+    }
+
+    function goStep(n) {
+      // Update summary when entering step 5
+      if (n === 5) {
+        const name = document.getElementById('node-name').value.trim() || 'my-ainode';
+        const email = document.getElementById('email').value.trim();
+        document.getElementById('sum-name').textContent = name;
+        document.getElementById('sum-model').textContent = selectedModel.split('/').pop() || '—';
+        document.getElementById('sum-email').textContent = email || '(skipped)';
+      }
+
+      // Hide current, show target
+      document.querySelectorAll('.step').forEach(s => s.classList.remove('active'));
+      const target = document.querySelector(`.step[data-step="${n}"]`);
+      if (target) target.classList.add('active');
+
+      // Update progress
+      document.querySelectorAll('.progress-segment').forEach(seg => {
+        const s = parseInt(seg.dataset.step);
+        seg.classList.remove('done', 'active');
+        if (s < n) seg.classList.add('done');
+        else if (s === n) seg.classList.add('active');
+      });
+
+      currentStep = n;
+    }
+
+    async function launch() {
+      const btn = document.getElementById('btn-launch');
+      btn.disabled = true;
+      document.getElementById('launch-area').style.display = 'none';
+      document.getElementById('launch-spinner').classList.add('visible');
+
+      const payload = {
+        node_name: document.getElementById('node-name').value.trim() || 'my-ainode',
+        model: selectedModel,
+        email: document.getElementById('email').value.trim(),
+      };
+
+      try {
+        const resp = await fetch('/api/onboarding/complete', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+
+        if (resp.ok) {
+          document.querySelector('.launch-text').textContent = 'Setup complete! Redirecting to dashboard...';
+          setTimeout(() => { window.location.href = '/'; }, 1500);
+        } else {
+          const data = await resp.json();
+          document.querySelector('.launch-text').textContent = 'Error: ' + (data.error || 'Unknown error');
+          btn.disabled = false;
+          document.getElementById('launch-area').style.display = '';
+          document.getElementById('launch-spinner').classList.remove('visible');
+        }
+      } catch (err) {
+        document.querySelector('.launch-text').textContent = 'Network error. Please try again.';
+        btn.disabled = false;
+        document.getElementById('launch-area').style.display = '';
+        document.getElementById('launch-spinner').classList.remove('visible');
+      }
+    }
+
+    function esc(s) {
+      const d = document.createElement('div');
+      d.textContent = s;
+      return d.innerHTML;
+    }
+
+    init();
+  </script>
+</body>
+</html>

--- a/ops/log/handoff-2026-04-12.md
+++ b/ops/log/handoff-2026-04-12.md
@@ -1,0 +1,76 @@
+HANDOFF — AINode Product Threadmaster Session 1
+
+Repo: getainode/ainode
+Date: 2026-04-12
+Author: Claude Opus 4.6 (Threadmaster, session 1)
+
+## Session Summary
+
+Built the AINode project from zero to scaffolded product with ops framework.
+
+## What Was Done
+
+### Decisions Made (with Operator)
+- Forked EXO, then **deleted the fork** — building from scratch to avoid GPL v3 lock-in
+- Chose **Apache 2.0** license — full commercial freedom
+- Name: **AINode** (ainode.dev, ainode.app — operator owns both domains)
+- Backend engine: **vLLM** (not tinygrad) — production-grade, NVIDIA-supported
+- Target hardware: NVIDIA GB10 (DGX Spark, ASUS, Dell, HP variants)
+- Branding: "Powered by argentos.ai" in all output
+- GitHub org: **getainode** (github.com/getainode)
+
+### Repos Created
+- `getainode/ainode` — Product code (public, Apache 2.0)
+- `getainode/ainode.dev` — Marketing site (private, Next.js + shadcn + Tailwind)
+
+### Code Written
+- `ainode/core/config.py` — Config management with JSON persistence
+- `ainode/core/gpu.py` — GPU detection with DGX Spark unified memory fallback
+- `ainode/engine/vllm_engine.py` — vLLM wrapper with health checks, readiness wait, log streaming, graceful shutdown
+- `ainode/discovery/broadcast.py` — UDP broadcast node discovery
+- `ainode/cli/main.py` — CLI: start, stop, status, models commands
+- `ainode/onboarding/setup.py` — First-run onboarding with email capture
+- `scripts/install.sh` — One-line curl installer
+- `pyproject.toml` — Package config, entry points
+- Full ops/ structure: rules, runbooks, slices, agents
+
+### Current Branch State
+- `main` — Ops structure + initial scaffold (pushed)
+- `dev` — Clean integration lane (created, pushed)
+- `codex/engine-vllm` — **ACTIVE** — Enhanced VLLMEngine (pushed, WIP)
+
+## What's In Progress
+
+### Active Slice: `codex/engine-vllm`
+Branch: `codex/engine-vllm` (commit cea10c2)
+Status: WIP — engine enhanced, CLI not yet updated to use new features
+
+Remaining work on this slice:
+1. Update CLI `cmd_start` to use `wait_ready()` with a progress indicator
+2. Wire in `health_check()` to `cmd_status`
+3. Add log tailing to `cmd_start` (show vLLM output as it starts)
+
+## What's Next (P0 Slices)
+
+| Priority | Slice | Description |
+|----------|-------|-------------|
+| **Current** | `engine-vllm` | Finish engine lifecycle, update CLI |
+| **Next** | `api-proxy` | aiohttp server in front of vLLM: /status, /nodes, model catalog |
+| **Next** | `web-ui` | Embedded chat UI served by ainode, no external deps |
+
+## Context the Next Session Needs
+
+- Operator is Jason Brashear (@JasonBrashearTX), MSP owner, 30+ years IT
+- Target audience: MSP owners who bought NVIDIA Sparks, not deeply technical
+- The marketing site Threadmaster is running in a separate session (`ainode-tm`)
+- There is also the DGX Spark cluster guide repo at `ArgentAIOS/dgx-spark-cluster`
+- vLLM has official DGX Spark support: https://build.nvidia.com/spark/vllm
+- The install experience is the product — `curl | bash → browser opens → AI running`
+- Read CLAUDE.md and ops/ for full project config and workflow rules
+
+## Risks / Assumptions
+
+- vLLM ARM64/aarch64 install on DGX Spark may require building from source (not just pip)
+- Unified memory GPU detection patch is implemented but untested on real hardware in this codebase
+- No tests written yet — need pytest suite before first PR to dev
+- Email capture endpoint at argentos.ai not yet built (placeholder in onboarding)

--- a/ops/slices/REGISTRY.md
+++ b/ops/slices/REGISTRY.md
@@ -4,7 +4,10 @@
 
 | Slice | Owner | Branch | Status | Linear |
 |-------|-------|--------|--------|--------|
-| engine-vllm | Threadmaster | codex/engine-vllm | IN PROGRESS | — |
+| engine-vllm | Threadmaster | codex/engine-vllm | MERGED TO DEV | — |
+| api-proxy | Agent (pane 1) | codex/api-proxy | IN PROGRESS | — |
+| cli-polish | Agent (pane 2) | codex/cli-polish | IN PROGRESS | — |
+| discovery-cluster | Agent (pane 3) | codex/discovery-cluster | IN PROGRESS | — |
 
 ## Completed Slices
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "psutil>=5.9.0",
     "aiohttp>=3.9.0",
     "rich>=13.0.0",
+    "huggingface_hub>=0.20.0",
 ]
 
 [project.optional-dependencies]
@@ -39,6 +40,8 @@ engine = [
 ]
 dev = [
     "pytest>=7.0",
+    "pytest-asyncio>=0.23.0",
+    "pytest-aiohttp>=1.0.0",
     "ruff>=0.1.0",
 ]
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -102,14 +102,43 @@ fi
 echo ""
 echo "    ────────────────────────────────────"
 echo ""
-echo "    To start AINode:"
-echo ""
-echo "      source ${SHELL_RC}"
-echo "      ainode start"
-echo ""
-echo "    Or run directly:"
-echo ""
-echo "      $AINODE_BIN/ainode start"
+
+# Optionally install systemd service
+INSTALL_SERVICE="${AINODE_SERVICE:-}"
+if [ -z "$INSTALL_SERVICE" ]; then
+    echo -n "    Install AINode as a systemd service (auto-start on boot)? [y/N] "
+    read -r INSTALL_SERVICE
+fi
+
+if [[ "$INSTALL_SERVICE" =~ ^[Yy]$ ]]; then
+    echo ""
+    echo "    Installing systemd service..."
+    if [ "$(id -u)" -eq 0 ]; then
+        "$AINODE_BIN/ainode" service install
+    else
+        "$AINODE_BIN/ainode" service install --user
+    fi
+    echo -e "    ${GREEN}✓${NC} AINode service installed and enabled"
+    echo ""
+    echo "    Manage with:"
+    echo "      ainode service status"
+    echo "      ainode service logs"
+    echo "      ainode service uninstall"
+else
+    echo ""
+    echo "    To start AINode:"
+    echo ""
+    echo "      source ${SHELL_RC}"
+    echo "      ainode start"
+    echo ""
+    echo "    Or run directly:"
+    echo ""
+    echo "      $AINODE_BIN/ainode start"
+    echo ""
+    echo "    To install as a service later:"
+    echo "      ainode service install"
+fi
+
 echo ""
 echo -e "    Powered by ${BLUE}argentos.ai${NC}"
 echo ""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,106 @@
+"""Tests for ainode.api.server — AINode-specific endpoints."""
+
+import pytest
+import pytest_asyncio
+from aiohttp.test_utils import TestClient, TestServer
+
+from ainode.api.server import create_app
+from ainode.core.config import NodeConfig
+
+
+@pytest.fixture
+def config():
+    return NodeConfig(node_id="test-node-1", node_name="TestNode", model="test-model")
+
+
+@pytest.fixture
+def app(config):
+    return create_app(config=config, engine=None)
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    async with TestClient(TestServer(app)) as c:
+        yield c
+
+
+# ---- /api/health -----------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_health(client):
+    resp = await client.get("/api/health")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data == {"status": "ok"}
+
+
+# ---- /api/status -----------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_status_fields(client):
+    resp = await client.get("/api/status")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["node_id"] == "test-node-1"
+    assert data["node_name"] == "TestNode"
+    assert data["model"] == "test-model"
+    assert data["version"] == "0.1.0"
+    assert data["powered_by"] == "argentos.ai"
+    assert data["engine_ready"] is False
+    assert isinstance(data["uptime"], (int, float))
+    assert isinstance(data["models_loaded"], list)
+    assert "api_port" in data
+
+
+# ---- /api/nodes ------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_nodes(client):
+    resp = await client.get("/api/nodes")
+    assert resp.status == 200
+    data = await resp.json()
+    assert "nodes" in data
+    nodes = data["nodes"]
+    assert len(nodes) == 1
+    node = nodes[0]
+    assert node["node_id"] == "test-node-1"
+    assert node["node_name"] == "TestNode"
+    assert node["model"] == "test-model"
+    assert node["engine_ready"] is False
+
+
+# ---- / (index) -------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_index_serves_html(client):
+    resp = await client.get("/")
+    assert resp.status == 200
+    assert "text/html" in resp.headers.get("Content-Type", "")
+    body = await resp.text()
+    assert "<html" in body.lower() or "<!doctype" in body.lower()
+
+
+# ---- CORS ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_cors_headers(client):
+    resp = await client.get("/api/health")
+    assert resp.headers.get("Access-Control-Allow-Origin") == "*"
+
+
+@pytest.mark.asyncio
+async def test_cors_preflight(client):
+    resp = await client.options("/api/health")
+    assert resp.status == 204
+    assert resp.headers.get("Access-Control-Allow-Origin") == "*"
+    assert "POST" in resp.headers.get("Access-Control-Allow-Methods", "")
+
+
+# ---- vLLM proxy returns 502 when engine is down ----------------------------
+
+@pytest.mark.asyncio
+async def test_vllm_proxy_returns_502_when_down(client):
+    resp = await client.get("/v1/models")
+    assert resp.status == 502
+    data = await resp.json()
+    assert "error" in data

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,305 @@
+"""Tests for ainode.auth — middleware, key management, enable/disable."""
+
+import json
+import pytest
+import pytest_asyncio
+from pathlib import Path
+from unittest.mock import patch
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from ainode.auth.middleware import AuthConfig, auth_middleware, AUTH_FILE
+from ainode.auth.api_routes import register_auth_routes
+from ainode.core.config import NodeConfig
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+@pytest.fixture
+def tmp_auth_file(tmp_path, monkeypatch):
+    """Redirect AUTH_FILE to a temp directory."""
+    auth_file = tmp_path / "auth.json"
+    monkeypatch.setattr("ainode.auth.middleware.AUTH_FILE", auth_file)
+    monkeypatch.setattr("ainode.auth.middleware.AINODE_HOME", tmp_path)
+    return auth_file
+
+
+@pytest.fixture
+def auth_config(tmp_auth_file):
+    """Fresh AuthConfig with temp storage."""
+    return AuthConfig()
+
+
+def _make_app(auth_config):
+    """Create a minimal aiohttp app with auth middleware and test routes."""
+
+    @web.middleware
+    async def cors_middleware(request, handler):
+        return await handler(request)
+
+    app = web.Application(middlewares=[cors_middleware, auth_middleware])
+    app["config"] = NodeConfig(node_id="test", node_name="Test", onboarded=True)
+    app["auth_config"] = auth_config
+
+    # Test routes
+    app.router.add_get("/", _handle_index)
+    app.router.add_get("/api/health", _handle_health)
+    app.router.add_get("/api/status", _handle_status)
+    app.router.add_get("/api/onboarding/config", _handle_onboarding)
+    app.router.add_get("/v1/models", _handle_protected)
+    app.router.add_post("/v1/chat/completions", _handle_protected)
+    app.router.add_static("/static", Path(__file__).parent, name="static")
+
+    # Auth management routes
+    register_auth_routes(app)
+
+    return app
+
+
+async def _handle_index(_req):
+    return web.Response(text="<html>dashboard</html>", content_type="text/html")
+
+async def _handle_health(_req):
+    return web.json_response({"status": "ok"})
+
+async def _handle_status(_req):
+    return web.json_response({"node_id": "test"})
+
+async def _handle_onboarding(_req):
+    return web.json_response({"step": 1})
+
+async def _handle_protected(_req):
+    return web.json_response({"data": "secret"})
+
+
+# =============================================================================
+# AuthConfig unit tests
+# =============================================================================
+
+class TestAuthConfig:
+    def test_default_disabled(self, auth_config):
+        assert auth_config.enabled is False
+        assert auth_config.api_keys == []
+
+    def test_generate_key(self, auth_config):
+        entry = auth_config.generate_key()
+        assert len(entry["key"]) == 32
+        assert entry["id"] == entry["key"][:8]
+        assert len(auth_config.api_keys) == 1
+
+    def test_enable_generates_key(self, auth_config):
+        entry = auth_config.enable()
+        assert auth_config.enabled is True
+        assert len(auth_config.api_keys) == 1
+        assert entry["key"] in auth_config.valid_keys()
+
+    def test_enable_reuses_existing_key(self, auth_config):
+        first = auth_config.generate_key()
+        entry = auth_config.enable()
+        assert entry["key"] == first["key"]
+        assert len(auth_config.api_keys) == 1
+
+    def test_disable(self, auth_config):
+        auth_config.enable()
+        auth_config.disable()
+        assert auth_config.enabled is False
+        # Keys are kept
+        assert len(auth_config.api_keys) == 1
+
+    def test_revoke_key(self, auth_config):
+        entry = auth_config.generate_key()
+        assert auth_config.revoke_key(entry["id"]) is True
+        assert len(auth_config.api_keys) == 0
+
+    def test_revoke_nonexistent(self, auth_config):
+        assert auth_config.revoke_key("nope") is False
+
+    def test_save_and_load(self, auth_config, tmp_auth_file):
+        auth_config.enable()
+        key = auth_config.api_keys[0]["key"]
+
+        # Load from disk
+        loaded = AuthConfig.load()
+        assert loaded.enabled is True
+        assert loaded.api_keys[0]["key"] == key
+
+    def test_load_missing_file(self, tmp_auth_file):
+        cfg = AuthConfig.load()
+        assert cfg.enabled is False
+        assert cfg.api_keys == []
+
+
+# =============================================================================
+# Middleware tests — auth disabled (default)
+# =============================================================================
+
+class TestMiddlewareDisabled:
+    @pytest_asyncio.fixture
+    async def client(self, auth_config):
+        app = _make_app(auth_config)
+        async with TestClient(TestServer(app)) as c:
+            yield c
+
+    @pytest.mark.asyncio
+    async def test_passthrough_no_auth(self, client):
+        """When auth is disabled, all requests pass through."""
+        resp = await client.get("/v1/models")
+        assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_health_no_auth(self, client):
+        resp = await client.get("/api/health")
+        assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_index_no_auth(self, client):
+        resp = await client.get("/")
+        assert resp.status == 200
+
+
+# =============================================================================
+# Middleware tests — auth enabled
+# =============================================================================
+
+class TestMiddlewareEnabled:
+    @pytest_asyncio.fixture
+    async def client_and_key(self, auth_config):
+        entry = auth_config.enable()
+        app = _make_app(auth_config)
+        async with TestClient(TestServer(app)) as c:
+            yield c, entry["key"]
+
+    @pytest.mark.asyncio
+    async def test_protected_without_key_returns_401(self, client_and_key):
+        client, _ = client_and_key
+        resp = await client.get("/v1/models")
+        assert resp.status == 401
+        data = await resp.json()
+        assert "auth_error" in str(data)
+
+    @pytest.mark.asyncio
+    async def test_protected_with_invalid_key_returns_401(self, client_and_key):
+        client, _ = client_and_key
+        resp = await client.get("/v1/models", headers={"Authorization": "Bearer badkey"})
+        assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_protected_with_valid_key(self, client_and_key):
+        client, key = client_and_key
+        resp = await client.get("/v1/models", headers={"Authorization": f"Bearer {key}"})
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["data"] == "secret"
+
+    @pytest.mark.asyncio
+    async def test_post_with_valid_key(self, client_and_key):
+        client, key = client_and_key
+        resp = await client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": f"Bearer {key}"},
+            json={"model": "test"},
+        )
+        assert resp.status == 200
+
+    # -- Skip paths -----------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_index_skips_auth(self, client_and_key):
+        client, _ = client_and_key
+        resp = await client.get("/")
+        assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_health_skips_auth(self, client_and_key):
+        client, _ = client_and_key
+        resp = await client.get("/api/health")
+        assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_onboarding_skips_auth(self, client_and_key):
+        client, _ = client_and_key
+        resp = await client.get("/api/onboarding/config")
+        assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_status_requires_auth(self, client_and_key):
+        """Non-exempt paths require auth."""
+        client, _ = client_and_key
+        resp = await client.get("/api/status")
+        assert resp.status == 401
+
+
+# =============================================================================
+# Auth API routes
+# =============================================================================
+
+class TestAuthRoutes:
+    @pytest_asyncio.fixture
+    async def client_and_key(self, auth_config):
+        entry = auth_config.enable()
+        app = _make_app(auth_config)
+        async with TestClient(TestServer(app)) as c:
+            yield c, entry["key"]
+
+    def _auth_headers(self, key):
+        return {"Authorization": f"Bearer {key}"}
+
+    @pytest.mark.asyncio
+    async def test_auth_status(self, client_and_key):
+        client, key = client_and_key
+        resp = await client.get("/api/auth/status", headers=self._auth_headers(key))
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["enabled"] is True
+        assert data["key_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_auth_disable(self, client_and_key):
+        client, key = client_and_key
+        resp = await client.post("/api/auth/disable", headers=self._auth_headers(key))
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["enabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_auth_enable(self, auth_config):
+        # Start disabled
+        app = _make_app(auth_config)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post("/api/auth/enable")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["enabled"] is True
+            assert "api_key" in data
+            assert len(data["api_key"]) == 32
+
+    @pytest.mark.asyncio
+    async def test_create_key(self, client_and_key):
+        client, key = client_and_key
+        resp = await client.post("/api/auth/keys", headers=self._auth_headers(key))
+        assert resp.status == 200
+        data = await resp.json()
+        assert "api_key" in data
+        assert len(data["api_key"]) == 32
+
+    @pytest.mark.asyncio
+    async def test_revoke_key(self, client_and_key):
+        client, key = client_and_key
+        # Create a second key, then revoke it
+        resp = await client.post("/api/auth/keys", headers=self._auth_headers(key))
+        new_key_data = await resp.json()
+        key_id = new_key_data["key_id"]
+
+        resp = await client.delete(f"/api/auth/keys/{key_id}", headers=self._auth_headers(key))
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["revoked"] is True
+
+    @pytest.mark.asyncio
+    async def test_revoke_nonexistent_key(self, client_and_key):
+        client, key = client_and_key
+        resp = await client.delete("/api/auth/keys/nope", headers=self._auth_headers(key))
+        assert resp.status == 404

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,13 @@
 """Tests for ainode.cli.main — argument parsing and command dispatch."""
 
+import os
 import sys
-from unittest.mock import patch
-from ainode.cli.main import main
+from unittest.mock import patch, MagicMock
+from ainode.cli.main import (
+    main, _banner, _write_pid, _read_pid, _remove_pid, _pid_alive,
+    _tail_log, _gpu_info_table,
+    cmd_config, cmd_logs, cmd_stop,
+)
 
 
 def test_version(capsys):
@@ -44,3 +49,234 @@ def test_models_subcommand(monkeypatch):
     with patch.object(sys, "argv", ["ainode", "models"]):
         main()
     assert called.get("models") is True
+
+
+def test_stop_subcommand(monkeypatch):
+    called = {}
+    def fake_stop(args):
+        called["stop"] = True
+    monkeypatch.setattr("ainode.cli.main.cmd_stop", fake_stop)
+    with patch.object(sys, "argv", ["ainode", "stop"]):
+        main()
+    assert called.get("stop") is True
+
+
+def test_config_subcommand(monkeypatch):
+    called = {}
+    def fake_config(args):
+        called["config"] = True
+    monkeypatch.setattr("ainode.cli.main.cmd_config", fake_config)
+    with patch.object(sys, "argv", ["ainode", "config", "--show"]):
+        main()
+    assert called.get("config") is True
+
+
+def test_logs_subcommand(monkeypatch):
+    called = {}
+    def fake_logs(args):
+        called["logs"] = True
+    monkeypatch.setattr("ainode.cli.main.cmd_logs", fake_logs)
+    with patch.object(sys, "argv", ["ainode", "logs"]):
+        main()
+    assert called.get("logs") is True
+
+
+def test_logs_follow_flag(monkeypatch):
+    """Ensure --follow flag is parsed correctly."""
+    captured_args = {}
+    def fake_logs(args):
+        captured_args["follow"] = args.follow
+    monkeypatch.setattr("ainode.cli.main.cmd_logs", fake_logs)
+    with patch.object(sys, "argv", ["ainode", "logs", "--follow"]):
+        main()
+    assert captured_args["follow"] is True
+
+
+def test_config_model_flag(monkeypatch):
+    """Ensure --model flag is parsed for config subcommand."""
+    captured_args = {}
+    def fake_config(args):
+        captured_args["model"] = args.model
+    monkeypatch.setattr("ainode.cli.main.cmd_config", fake_config)
+    with patch.object(sys, "argv", ["ainode", "config", "--model", "llama-3.1-8b"]):
+        main()
+    assert captured_args["model"] == "llama-3.1-8b"
+
+
+# ---------------------------------------------------------------------------
+# Banner
+# ---------------------------------------------------------------------------
+
+def test_banner_returns_panel():
+    from rich.panel import Panel
+    panel = _banner()
+    assert isinstance(panel, Panel)
+
+
+# ---------------------------------------------------------------------------
+# PID helpers
+# ---------------------------------------------------------------------------
+
+def test_pid_write_read_remove(tmp_path, monkeypatch):
+    pid_file = tmp_path / "ainode.pid"
+    monkeypatch.setattr("ainode.cli.main.PID_FILE", pid_file)
+    monkeypatch.setattr("ainode.cli.main.AINODE_HOME", tmp_path)
+
+    _write_pid()
+    assert pid_file.exists()
+    assert _read_pid() == os.getpid()
+
+    _remove_pid()
+    assert not pid_file.exists()
+
+
+def test_read_pid_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr("ainode.cli.main.PID_FILE", tmp_path / "nope.pid")
+    assert _read_pid() is None
+
+
+def test_pid_alive_current():
+    assert _pid_alive(os.getpid()) is True
+
+
+def test_pid_alive_none():
+    assert _pid_alive(None) is False
+
+
+def test_pid_alive_dead():
+    # PID 99999999 almost certainly doesn't exist
+    assert _pid_alive(99999999) is False
+
+
+# ---------------------------------------------------------------------------
+# _tail_log
+# ---------------------------------------------------------------------------
+
+def test_tail_log(tmp_path):
+    log = tmp_path / "test.log"
+    log.write_text("\n".join(f"line {i}" for i in range(100)))
+    lines = _tail_log(log, lines=5)
+    assert len(lines) == 5
+    assert "line 99" in lines[-1]
+
+
+def test_tail_log_missing():
+    lines = _tail_log("/nonexistent/file.log")
+    assert lines == []
+
+
+# ---------------------------------------------------------------------------
+# GPU info table
+# ---------------------------------------------------------------------------
+
+def test_gpu_info_table():
+    from ainode.core.gpu import GPUInfo
+    from rich.table import Table
+    gpu = GPUInfo(
+        name="NVIDIA GH200",
+        memory_total_mb=131072,
+        memory_free_mb=120000,
+        cuda_version="12.4",
+        driver_version="550.54",
+        compute_capability="9.0",
+        unified_memory=True,
+    )
+    table = _gpu_info_table(gpu)
+    assert isinstance(table, Table)
+
+
+# ---------------------------------------------------------------------------
+# cmd_config
+# ---------------------------------------------------------------------------
+
+def test_cmd_config_show(tmp_path, monkeypatch):
+    """config --show renders a table with config keys."""
+    monkeypatch.setattr("ainode.core.config.AINODE_HOME", tmp_path)
+    monkeypatch.setattr("ainode.core.config.CONFIG_FILE", tmp_path / "config.json")
+
+    args = MagicMock()
+    args.model = None
+    args.port = None
+    args.show = True
+
+    cmd_config(args)
+
+
+def test_cmd_config_set_model(tmp_path, monkeypatch):
+    """config --model writes the new model to disk."""
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr("ainode.core.config.AINODE_HOME", tmp_path)
+    monkeypatch.setattr("ainode.core.config.CONFIG_FILE", config_file)
+
+    args = MagicMock()
+    args.model = "deepseek-r1-7b"
+    args.port = None
+
+    cmd_config(args)
+
+    from ainode.core.config import NodeConfig
+    monkeypatch.setattr("ainode.core.config.CONFIG_FILE", config_file)
+    loaded = NodeConfig.load()
+    assert loaded.model == "deepseek-r1-7b"
+
+
+def test_cmd_config_set_port(tmp_path, monkeypatch):
+    """config --port writes the new port to disk."""
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr("ainode.core.config.AINODE_HOME", tmp_path)
+    monkeypatch.setattr("ainode.core.config.CONFIG_FILE", config_file)
+
+    args = MagicMock()
+    args.model = None
+    args.port = 9000
+
+    cmd_config(args)
+
+    from ainode.core.config import NodeConfig
+    monkeypatch.setattr("ainode.core.config.CONFIG_FILE", config_file)
+    loaded = NodeConfig.load()
+    assert loaded.api_port == 9000
+
+
+# ---------------------------------------------------------------------------
+# cmd_logs
+# ---------------------------------------------------------------------------
+
+def test_cmd_logs_no_file(tmp_path, monkeypatch):
+    """logs command with no log file prints a helpful message."""
+    monkeypatch.setattr("ainode.cli.main.VLLM_LOG", tmp_path / "nope.log")
+
+    args = MagicMock()
+    args.follow = False
+    args.lines = 50
+
+    cmd_logs(args)
+
+
+def test_cmd_logs_reads_lines(tmp_path, monkeypatch):
+    """logs command reads last N lines from log."""
+    log_file = tmp_path / "vllm.log"
+    log_file.write_text("\n".join(f"log line {i}" for i in range(100)))
+    monkeypatch.setattr("ainode.cli.main.VLLM_LOG", log_file)
+
+    args = MagicMock()
+    args.follow = False
+    args.lines = 10
+
+    cmd_logs(args)
+
+
+# ---------------------------------------------------------------------------
+# cmd_stop
+# ---------------------------------------------------------------------------
+
+def test_cmd_stop_no_running_instance(tmp_path, monkeypatch):
+    """stop command with no running instance prints informational message."""
+    monkeypatch.setattr("ainode.cli.main.PID_FILE", tmp_path / "ainode.pid")
+    monkeypatch.setattr("ainode.cli.main.AINODE_HOME", tmp_path)
+
+    # Mock pgrep to return nothing
+    monkeypatch.setattr("subprocess.run", lambda *a, **kw: MagicMock(stdout="", returncode=1))
+
+    args = MagicMock()
+    cmd_stop(args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,46 @@
+"""Tests for ainode.cli.main — argument parsing and command dispatch."""
+
+import sys
+from unittest.mock import patch
+from ainode.cli.main import main
+
+
+def test_version(capsys):
+    with patch.object(sys, "argv", ["ainode", "--version"]):
+        try:
+            main()
+        except SystemExit:
+            pass
+    captured = capsys.readouterr()
+    assert "0.1.0" in captured.out
+
+
+def test_no_args_calls_start(monkeypatch):
+    """Running `ainode` with no subcommand calls cmd_start."""
+    called = {}
+    def fake_start(args):
+        called["start"] = True
+    monkeypatch.setattr("ainode.cli.main.cmd_start", fake_start)
+    with patch.object(sys, "argv", ["ainode"]):
+        main()
+    assert called.get("start") is True
+
+
+def test_status_subcommand(monkeypatch):
+    called = {}
+    def fake_status(args):
+        called["status"] = True
+    monkeypatch.setattr("ainode.cli.main.cmd_status", fake_status)
+    with patch.object(sys, "argv", ["ainode", "status"]):
+        main()
+    assert called.get("status") is True
+
+
+def test_models_subcommand(monkeypatch):
+    called = {}
+    def fake_models(args):
+        called["models"] = True
+    monkeypatch.setattr("ainode.cli.main.cmd_models", fake_models)
+    with patch.object(sys, "argv", ["ainode", "models"]):
+        main()
+    assert called.get("models") is True

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,0 +1,232 @@
+"""Tests for cluster state, leader election, model routing, and summary."""
+
+import time
+import pytest
+
+from ainode.discovery.broadcast import (
+    NodeAnnouncement,
+    NodeStatus,
+    DiscoveredNode,
+)
+from ainode.discovery.cluster import ClusterState, ClusterNode
+
+
+def _make_announcement(**overrides) -> NodeAnnouncement:
+    defaults = dict(
+        node_id="node-aaa",
+        node_name="spark-1",
+        gpu_name="GB10",
+        gpu_memory_gb=128.0,
+        unified_memory=True,
+        model="meta-llama/Llama-3.2-3B-Instruct",
+        status="serving",
+        api_port=8000,
+        web_port=3000,
+        timestamp=time.time(),
+    )
+    defaults.update(overrides)
+    return NodeAnnouncement(**defaults)
+
+
+def _make_cluster_node(**overrides) -> ClusterNode:
+    defaults = dict(
+        node_id="node-aaa",
+        node_name="spark-1",
+        gpu_name="GB10",
+        gpu_memory_gb=128.0,
+        unified_memory=True,
+        model="meta-llama/Llama-3.2-3B-Instruct",
+        status=NodeStatus.ONLINE,
+        api_port=8000,
+        web_port=3000,
+        last_seen=time.time(),
+    )
+    defaults.update(overrides)
+    return ClusterNode(**defaults)
+
+
+class TestClusterState:
+    def test_local_node_added_on_init(self):
+        ann = _make_announcement(node_id="local-1")
+        cluster = ClusterState(local_announcement=ann)
+        assert cluster.get_node("local-1") is not None
+
+    def test_empty_cluster(self):
+        cluster = ClusterState()
+        assert cluster.get_nodes() == []
+        assert cluster.get_leader() is None
+
+    def test_add_and_get_node(self):
+        cluster = ClusterState()
+        node = _make_cluster_node(node_id="n1")
+        cluster.add_node(node)
+        assert cluster.get_node("n1") is not None
+        assert cluster.get_node("n1").gpu_memory_gb == 128.0
+
+    def test_remove_node(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="n1"))
+        cluster.remove_node("n1")
+        assert cluster.get_node("n1") is None
+
+    def test_remove_nonexistent_node_no_error(self):
+        cluster = ClusterState()
+        cluster.remove_node("nope")
+
+    def test_get_nodes_excludes_offline(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="online", status=NodeStatus.ONLINE))
+        cluster.add_node(_make_cluster_node(node_id="offline", status=NodeStatus.OFFLINE))
+        nodes = cluster.get_nodes(include_offline=False)
+        assert len(nodes) == 1
+        assert nodes[0].node_id == "online"
+
+    def test_get_nodes_includes_offline(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="online", status=NodeStatus.ONLINE))
+        cluster.add_node(_make_cluster_node(node_id="offline", status=NodeStatus.OFFLINE))
+        assert len(cluster.get_nodes(include_offline=True)) == 2
+
+
+class TestLeaderElection:
+    def test_single_node_is_leader(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="node-aaa"))
+        leader = cluster.get_leader()
+        assert leader is not None
+        assert leader.node_id == "node-aaa"
+
+    def test_lowest_id_wins(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="node-ccc"))
+        cluster.add_node(_make_cluster_node(node_id="node-aaa"))
+        cluster.add_node(_make_cluster_node(node_id="node-bbb"))
+        leader = cluster.get_leader()
+        assert leader.node_id == "node-aaa"
+
+    def test_offline_nodes_excluded_from_election(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="node-aaa", status=NodeStatus.OFFLINE))
+        cluster.add_node(_make_cluster_node(node_id="node-bbb", status=NodeStatus.ONLINE))
+        leader = cluster.get_leader()
+        assert leader.node_id == "node-bbb"
+
+    def test_stale_nodes_excluded_from_election(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="node-aaa", status=NodeStatus.STALE))
+        cluster.add_node(_make_cluster_node(node_id="node-bbb", status=NodeStatus.ONLINE))
+        leader = cluster.get_leader()
+        assert leader.node_id == "node-bbb"
+
+    def test_no_leader_when_all_offline(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="node-aaa", status=NodeStatus.OFFLINE))
+        assert cluster.get_leader() is None
+
+    def test_leader_changes_when_node_goes_offline(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="node-aaa", status=NodeStatus.ONLINE))
+        cluster.add_node(_make_cluster_node(node_id="node-bbb", status=NodeStatus.ONLINE))
+        assert cluster.get_leader().node_id == "node-aaa"
+        cluster.add_node(_make_cluster_node(node_id="node-aaa", status=NodeStatus.OFFLINE))
+        assert cluster.get_leader().node_id == "node-bbb"
+
+
+class TestModelRouting:
+    def test_find_model_single_match(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="n1", model="llama-3"))
+        cluster.add_node(_make_cluster_node(node_id="n2", model="mistral-7b"))
+        results = cluster.find_model("llama-3")
+        assert len(results) == 1
+        assert results[0].node_id == "n1"
+
+    def test_find_model_multiple_matches(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="n1", model="llama-3"))
+        cluster.add_node(_make_cluster_node(node_id="n2", model="llama-3"))
+        results = cluster.find_model("llama-3")
+        assert len(results) == 2
+
+    def test_find_model_no_match(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="n1", model="llama-3"))
+        assert cluster.find_model("gpt-4") == []
+
+    def test_find_model_excludes_offline(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="n1", model="llama-3", status=NodeStatus.ONLINE))
+        cluster.add_node(_make_cluster_node(node_id="n2", model="llama-3", status=NodeStatus.OFFLINE))
+        results = cluster.find_model("llama-3")
+        assert len(results) == 1
+        assert results[0].node_id == "n1"
+
+    def test_find_model_includes_stale(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="n1", model="llama-3", status=NodeStatus.STALE))
+        results = cluster.find_model("llama-3")
+        assert len(results) == 1
+
+
+class TestClusterSummary:
+    def test_summary_two_sparks(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(
+            node_id="spark-1", gpu_name="GB10", gpu_memory_gb=128.0,
+            model="meta-llama/Llama-3.2-70B-Instruct",
+        ))
+        cluster.add_node(_make_cluster_node(
+            node_id="spark-2", gpu_name="GB10", gpu_memory_gb=128.0,
+            model="meta-llama/Llama-3.2-3B-Instruct",
+        ))
+        summary = cluster.cluster_summary()
+        assert summary["total_nodes"] == 2
+        assert summary["total_gpus"] == 2
+        assert summary["total_memory_gb"] == 256.0
+        assert len(summary["models_available"]) == 2
+        assert summary["leader_id"] == "spark-1"
+
+    def test_summary_excludes_offline(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="n1", gpu_memory_gb=128.0))
+        cluster.add_node(_make_cluster_node(node_id="n2", gpu_memory_gb=128.0, status=NodeStatus.OFFLINE))
+        summary = cluster.cluster_summary()
+        assert summary["total_nodes"] == 1
+        assert summary["total_memory_gb"] == 128.0
+
+    def test_summary_empty_cluster(self):
+        cluster = ClusterState()
+        summary = cluster.cluster_summary()
+        assert summary["total_nodes"] == 0
+        assert summary["total_gpus"] == 0
+        assert summary["total_memory_gb"] == 0
+        assert summary["models_available"] == []
+        assert summary["leader_id"] is None
+
+    def test_summary_models_sorted(self):
+        cluster = ClusterState()
+        cluster.add_node(_make_cluster_node(node_id="n1", model="zebra-model"))
+        cluster.add_node(_make_cluster_node(node_id="n2", model="alpha-model"))
+        summary = cluster.cluster_summary()
+        assert summary["models_available"] == ["alpha-model", "zebra-model"]
+
+    def test_update_from_discovered(self):
+        local_ann = _make_announcement(node_id="local-1")
+        cluster = ClusterState(local_announcement=local_ann)
+        discovered = {
+            "remote-1": DiscoveredNode(
+                announcement=_make_announcement(node_id="remote-1", model="mistral"),
+                last_seen=time.time(),
+            ),
+        }
+        cluster.update_from_discovered(discovered)
+        assert cluster.get_node("local-1") is not None
+        assert cluster.get_node("remote-1") is not None
+        assert cluster.get_node("remote-1").model == "mistral"
+
+    def test_cluster_node_from_discovered(self):
+        ann = _make_announcement(node_id="test-node")
+        discovered = DiscoveredNode(announcement=ann, last_seen=time.time())
+        cn = ClusterNode.from_discovered(discovered)
+        assert cn.node_id == "test-node"
+        assert cn.status == NodeStatus.ONLINE

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,50 @@
+"""Tests for ainode.core.config."""
+
+import json
+from pathlib import Path
+from ainode.core.config import NodeConfig
+
+
+def test_config_defaults():
+    """Default config has expected values."""
+    config = NodeConfig()
+    assert config.api_port == 8000
+    assert config.web_port == 3000
+    assert config.host == "0.0.0.0"
+    assert config.model == "meta-llama/Llama-3.2-3B-Instruct"
+    assert config.gpu_memory_utilization == 0.9
+    assert config.onboarded is False
+    assert config.node_id is None
+
+
+def test_config_save_load(tmp_path, monkeypatch):
+    """Config round-trips through save/load."""
+    monkeypatch.setattr("ainode.core.config.AINODE_HOME", tmp_path)
+    monkeypatch.setattr("ainode.core.config.CONFIG_FILE", tmp_path / "config.json")
+
+    config = NodeConfig(node_id="abc123", model="test-model", api_port=9000)
+    config.save()
+
+    loaded = NodeConfig.load()
+    assert loaded.node_id == "abc123"
+    assert loaded.model == "test-model"
+    assert loaded.api_port == 9000
+
+
+def test_config_load_missing(tmp_path, monkeypatch):
+    """Loading from nonexistent file returns defaults."""
+    monkeypatch.setattr("ainode.core.config.CONFIG_FILE", tmp_path / "nope.json")
+    config = NodeConfig.load()
+    assert config.api_port == 8000
+    assert config.node_id is None
+
+
+def test_config_load_ignores_unknown_fields(tmp_path, monkeypatch):
+    """Unknown fields in config file are silently ignored."""
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps({"node_id": "x", "unknown_field": True}))
+    monkeypatch.setattr("ainode.core.config.CONFIG_FILE", config_file)
+
+    config = NodeConfig.load()
+    assert config.node_id == "x"
+    assert not hasattr(config, "unknown_field")

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,173 @@
+"""Tests for UDP broadcast discovery -- announcement serialization, registry, health."""
+
+import time
+import json
+import pytest
+from unittest.mock import MagicMock
+
+from ainode.discovery.broadcast import (
+    NodeAnnouncement,
+    NodeStatus,
+    DiscoveredNode,
+    BroadcastListener,
+    ONLINE_THRESHOLD,
+    STALE_THRESHOLD,
+)
+
+
+def _make_announcement(**overrides) -> NodeAnnouncement:
+    defaults = dict(
+        node_id="node-aaa",
+        node_name="spark-1",
+        gpu_name="GB10",
+        gpu_memory_gb=128.0,
+        unified_memory=True,
+        model="meta-llama/Llama-3.2-3B-Instruct",
+        status="serving",
+        api_port=8000,
+        web_port=3000,
+        timestamp=1700000000.0,
+    )
+    defaults.update(overrides)
+    return NodeAnnouncement(**defaults)
+
+
+class TestNodeAnnouncement:
+    def test_to_json_roundtrip(self):
+        ann = _make_announcement()
+        raw = ann.to_json()
+        restored = NodeAnnouncement.from_json(raw)
+        assert restored.node_id == ann.node_id
+        assert restored.gpu_memory_gb == 128.0
+        assert restored.unified_memory is True
+        assert restored.model == ann.model
+
+    def test_json_contains_all_fields(self):
+        ann = _make_announcement()
+        data = json.loads(ann.to_json())
+        expected_keys = {
+            "node_id", "node_name", "gpu_name", "gpu_memory_gb",
+            "unified_memory", "model", "status", "api_port", "web_port", "timestamp",
+        }
+        assert set(data.keys()) == expected_keys
+
+    def test_default_timestamp(self):
+        ann = NodeAnnouncement(
+            node_id="x", node_name="x", gpu_name="x",
+            gpu_memory_gb=0, unified_memory=False, model="",
+            status="idle", api_port=8000, web_port=3000,
+        )
+        assert abs(ann.timestamp - time.time()) < 2
+
+
+class TestDiscoveredNodeHealth:
+    def test_online_when_fresh(self):
+        node = DiscoveredNode(announcement=_make_announcement(), last_seen=time.time())
+        assert node.health == NodeStatus.ONLINE
+
+    def test_stale_after_threshold(self):
+        node = DiscoveredNode(
+            announcement=_make_announcement(),
+            last_seen=time.time() - (ONLINE_THRESHOLD + 1),
+        )
+        assert node.health == NodeStatus.STALE
+
+    def test_offline_after_threshold(self):
+        node = DiscoveredNode(
+            announcement=_make_announcement(),
+            last_seen=time.time() - (STALE_THRESHOLD + 1),
+        )
+        assert node.health == NodeStatus.OFFLINE
+
+    def test_age_property(self):
+        now = time.time()
+        node = DiscoveredNode(announcement=_make_announcement(), last_seen=now - 10)
+        assert abs(node.age - 10) < 1
+
+    def test_health_transition_online_to_stale(self):
+        node = DiscoveredNode(announcement=_make_announcement(), last_seen=time.time())
+        assert node.health == NodeStatus.ONLINE
+        node.last_seen = time.time() - (ONLINE_THRESHOLD + 1)
+        assert node.health == NodeStatus.STALE
+
+    def test_health_transition_stale_to_offline(self):
+        node = DiscoveredNode(
+            announcement=_make_announcement(),
+            last_seen=time.time() - (ONLINE_THRESHOLD + 1),
+        )
+        assert node.health == NodeStatus.STALE
+        node.last_seen = time.time() - (STALE_THRESHOLD + 1)
+        assert node.health == NodeStatus.OFFLINE
+
+    def test_health_recovery(self):
+        node = DiscoveredNode(
+            announcement=_make_announcement(),
+            last_seen=time.time() - (ONLINE_THRESHOLD + 1),
+        )
+        assert node.health == NodeStatus.STALE
+        node.last_seen = time.time()
+        assert node.health == NodeStatus.ONLINE
+
+
+class TestBroadcastListenerRegistry:
+    def test_process_announcement_adds_node(self):
+        listener = BroadcastListener(local_node_id="local-node")
+        ann = _make_announcement(node_id="remote-1")
+        listener._process_announcement(ann)
+        assert "remote-1" in listener._registry
+        assert listener._registry["remote-1"].announcement.node_id == "remote-1"
+
+    def test_ignores_own_announcements(self):
+        listener = BroadcastListener(local_node_id="local-node")
+        ann = _make_announcement(node_id="local-node")
+        listener._process_announcement(ann)
+        assert "local-node" not in listener._registry
+
+    def test_updates_existing_node(self):
+        listener = BroadcastListener(local_node_id="local-node")
+        ann1 = _make_announcement(node_id="remote-1", model="model-a")
+        listener._process_announcement(ann1)
+        ann2 = _make_announcement(node_id="remote-1", model="model-b")
+        listener._process_announcement(ann2)
+        assert listener._registry["remote-1"].announcement.model == "model-b"
+
+    def test_on_node_found_callback(self):
+        callback = MagicMock()
+        listener = BroadcastListener(local_node_id="local-node", on_node_found=callback)
+        ann = _make_announcement(node_id="remote-1")
+        listener._process_announcement(ann)
+        callback.assert_called_once_with(ann)
+
+    def test_on_node_found_not_called_on_update(self):
+        callback = MagicMock()
+        listener = BroadcastListener(local_node_id="local-node", on_node_found=callback)
+        ann = _make_announcement(node_id="remote-1")
+        listener._process_announcement(ann)
+        listener._process_announcement(ann)
+        callback.assert_called_once()
+
+    def test_get_nodes_excludes_offline(self):
+        listener = BroadcastListener(local_node_id="local-node")
+        listener._process_announcement(_make_announcement(node_id="online-node"))
+        listener._process_announcement(_make_announcement(node_id="old-node"))
+        listener._registry["old-node"].last_seen = time.time() - (STALE_THRESHOLD + 1)
+        nodes = listener.get_nodes(include_offline=False)
+        assert len(nodes) == 1
+        assert nodes[0].announcement.node_id == "online-node"
+
+    def test_get_nodes_includes_offline(self):
+        listener = BroadcastListener(local_node_id="local-node")
+        listener._process_announcement(_make_announcement(node_id="online-node"))
+        listener._process_announcement(_make_announcement(node_id="old-node"))
+        listener._registry["old-node"].last_seen = time.time() - (STALE_THRESHOLD + 1)
+        nodes = listener.get_nodes(include_offline=True)
+        assert len(nodes) == 2
+
+    def test_get_node(self):
+        listener = BroadcastListener(local_node_id="local-node")
+        ann = _make_announcement(node_id="remote-1")
+        listener._process_announcement(ann)
+        node = listener.get_node("remote-1")
+        assert node is not None
+        assert node.announcement.node_name == "spark-1"
+        assert listener.get_node("nonexistent") is None

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,113 @@
+"""Tests for ainode.engine.vllm_engine."""
+
+import sys
+from unittest.mock import patch, MagicMock
+from ainode.core.config import NodeConfig
+from ainode.core.gpu import GPUInfo
+from ainode.engine.vllm_engine import VLLMEngine
+
+
+def _make_engine(**config_overrides):
+    config = NodeConfig(**config_overrides)
+    return VLLMEngine(config)
+
+
+def test_build_cmd_defaults():
+    engine = _make_engine()
+    with patch("ainode.engine.vllm_engine.detect_gpu", return_value=None):
+        cmd = engine.build_cmd()
+
+    assert sys.executable in cmd[0]
+    assert "-m" in cmd
+    assert "vllm.entrypoints.openai.api_server" in cmd
+    assert "--model" in cmd
+    assert "meta-llama/Llama-3.2-3B-Instruct" in cmd
+    assert "--port" in cmd
+    assert "8000" in cmd
+    assert "--trust-remote-code" in cmd
+
+
+def test_build_cmd_with_quantization():
+    engine = _make_engine(quantization="awq")
+    with patch("ainode.engine.vllm_engine.detect_gpu", return_value=None):
+        cmd = engine.build_cmd()
+    assert "--quantization" in cmd
+    assert "awq" in cmd
+
+
+def test_build_cmd_with_max_model_len():
+    engine = _make_engine(max_model_len=4096)
+    with patch("ainode.engine.vllm_engine.detect_gpu", return_value=None):
+        cmd = engine.build_cmd()
+    assert "--max-model-len" in cmd
+    assert "4096" in cmd
+
+
+def test_build_cmd_unified_memory_adds_dtype():
+    gpu = GPUInfo(
+        name="NVIDIA GB10", memory_total_mb=131072, memory_free_mb=120000,
+        cuda_version="12.8", driver_version="570.86",
+        compute_capability="10.0", unified_memory=True,
+    )
+    engine = _make_engine()
+    with patch("ainode.engine.vllm_engine.detect_gpu", return_value=gpu):
+        cmd = engine.build_cmd()
+    assert "--dtype" in cmd
+    assert "bfloat16" in cmd
+
+
+def test_build_cmd_discrete_gpu_no_dtype():
+    gpu = GPUInfo(
+        name="RTX 4090", memory_total_mb=24576, memory_free_mb=20000,
+        cuda_version="12.4", driver_version="550.00",
+        compute_capability="8.9", unified_memory=False,
+    )
+    engine = _make_engine()
+    with patch("ainode.engine.vllm_engine.detect_gpu", return_value=gpu):
+        cmd = engine.build_cmd()
+    assert "--dtype" not in cmd
+
+
+def test_api_url():
+    engine = _make_engine(api_port=9999)
+    assert engine.api_url == "http://localhost:9999/v1"
+
+
+def test_is_running_no_process():
+    engine = _make_engine()
+    assert engine.is_running() is False
+
+
+def test_is_running_with_live_process():
+    engine = _make_engine()
+    proc = MagicMock()
+    proc.poll.return_value = None
+    engine.process = proc
+    assert engine.is_running() is True
+
+
+def test_is_running_with_dead_process():
+    engine = _make_engine()
+    proc = MagicMock()
+    proc.poll.return_value = 1
+    engine.process = proc
+    assert engine.is_running() is False
+
+
+def test_health_check_api_down():
+    engine = _make_engine()
+    health = engine.health_check()
+    assert health["process_alive"] is False
+    assert health["api_responding"] is False
+    assert health["models_loaded"] == []
+
+
+def test_ready_default_false():
+    engine = _make_engine()
+    assert engine.ready is False
+
+
+def test_stop_no_process():
+    """Stop is a no-op when no process exists."""
+    engine = _make_engine()
+    engine.stop()  # Should not raise

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -1,0 +1,46 @@
+"""Tests for ainode.core.gpu."""
+
+from unittest.mock import patch, MagicMock
+from ainode.core.gpu import GPUInfo, detect_gpu, gpu_summary
+
+
+def _make_gpu(**overrides):
+    defaults = dict(
+        name="NVIDIA GB10",
+        memory_total_mb=131072,
+        memory_free_mb=120000,
+        cuda_version="12.8",
+        driver_version="570.86",
+        compute_capability="10.0",
+        unified_memory=True,
+    )
+    defaults.update(overrides)
+    return GPUInfo(**defaults)
+
+
+def test_gpu_info_fields():
+    gpu = _make_gpu()
+    assert gpu.name == "NVIDIA GB10"
+    assert gpu.unified_memory is True
+    assert gpu.memory_total_mb == 131072
+
+
+def test_detect_gpu_no_pynvml():
+    """Returns None when pynvml is not available."""
+    with patch.dict("sys.modules", {"pynvml": None}):
+        result = detect_gpu()
+        assert result is None
+
+
+def test_gpu_summary_no_gpu():
+    with patch("ainode.core.gpu.detect_gpu", return_value=None):
+        assert gpu_summary() == "No NVIDIA GPU detected"
+
+
+def test_gpu_summary_with_gpu():
+    gpu = _make_gpu()
+    with patch("ainode.core.gpu.detect_gpu", return_value=gpu):
+        summary = gpu_summary()
+        assert "NVIDIA GB10" in summary
+        assert "128 GB" in summary
+        assert "unified memory" in summary

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,144 @@
+"""Tests for ainode.metrics."""
+
+import time
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from ainode.metrics.collector import MetricsCollector
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_pynvml():
+    """Return a mock pynvml module with realistic GPU stats."""
+    mod = MagicMock()
+
+    util = MagicMock()
+    util.gpu = 42
+    mod.nvmlDeviceGetUtilizationRates.return_value = util
+
+    mem = MagicMock()
+    mem.used = 8 * 1024 * 1024 * 1024  # 8 GB
+    mem.total = 128 * 1024 * 1024 * 1024  # 128 GB
+    mod.nvmlDeviceGetMemoryInfo.return_value = mem
+
+    mod.NVML_TEMPERATURE_GPU = 0
+    mod.nvmlDeviceGetTemperature.return_value = 55
+
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# MetricsCollector — recording & snapshot
+# ---------------------------------------------------------------------------
+
+class TestRecordAndSnapshot:
+    def test_initial_snapshot_is_empty(self):
+        mc = MetricsCollector()
+        snap = mc.get_snapshot()
+        assert snap["requests"]["total"] == 0
+        assert snap["requests"]["errors"] == 0
+        assert snap["requests"]["latency_ms"]["p50"] == 0
+        assert snap["uptime_seconds"] >= 0
+
+    def test_record_single_request(self):
+        mc = MetricsCollector()
+        mc.record_request("llama-3", 120.5, tokens_generated=50)
+        stats = mc.get_request_stats()
+        assert stats["total"] == 1
+        assert stats["errors"] == 0
+        assert stats["by_model"]["llama-3"] == 1
+        assert stats["tokens_generated"] == 50
+        assert stats["latency_ms"]["p50"] == 120.5
+
+    def test_record_error(self):
+        mc = MetricsCollector()
+        mc.record_request("llama-3", 500.0, error=True)
+        stats = mc.get_request_stats()
+        assert stats["total"] == 1
+        assert stats["errors"] == 1
+
+    def test_multiple_models(self):
+        mc = MetricsCollector()
+        mc.record_request("llama-3", 100.0)
+        mc.record_request("llama-3", 110.0)
+        mc.record_request("mistral-7b", 80.0)
+        stats = mc.get_request_stats()
+        assert stats["by_model"]["llama-3"] == 2
+        assert stats["by_model"]["mistral-7b"] == 1
+        assert stats["total"] == 3
+
+    def test_latency_percentiles(self):
+        mc = MetricsCollector()
+        # Record 100 requests with latencies 1..100
+        for i in range(1, 101):
+            mc.record_request("m", float(i))
+        stats = mc.get_request_stats()
+        lat = stats["latency_ms"]
+        assert lat["p50"] == pytest.approx(50.5, abs=1)
+        assert lat["p95"] == pytest.approx(95.05, abs=1)
+        assert lat["p99"] == pytest.approx(99.01, abs=1)
+
+    def test_tokens_per_second(self):
+        mc = MetricsCollector()
+        # Backdate start_time to get predictable tps
+        mc._start_time = time.time() - 10.0
+        mc.record_request("m", 50.0, tokens_generated=500)
+        stats = mc.get_request_stats()
+        # 500 tokens / 10s = 50 tps (approximately)
+        assert stats["tokens_per_second"] == pytest.approx(50.0, abs=5)
+
+
+# ---------------------------------------------------------------------------
+# GPU metrics
+# ---------------------------------------------------------------------------
+
+class TestGPUMetrics:
+    def test_gpu_metrics_with_pynvml(self):
+        mock_mod = _mock_pynvml()
+        with patch.dict("sys.modules", {"pynvml": mock_mod}):
+            mc = MetricsCollector()
+            gpu = mc.get_gpu_metrics()
+        assert gpu["utilization_percent"] == 42
+        assert gpu["memory_used_mb"] == 8192
+        assert gpu["memory_total_mb"] == 131072
+        assert gpu["temperature_c"] == 55
+
+    def test_gpu_metrics_without_pynvml(self):
+        mc = MetricsCollector()
+        with patch.dict("sys.modules", {"pynvml": None}):
+            gpu = mc.get_gpu_metrics()
+        assert "error" in gpu
+
+
+# ---------------------------------------------------------------------------
+# Thread safety (smoke test)
+# ---------------------------------------------------------------------------
+
+class TestThreadSafety:
+    def test_concurrent_recording(self):
+        import threading
+
+        mc = MetricsCollector()
+        errors: list[Exception] = []
+
+        def worker():
+            try:
+                for _ in range(100):
+                    mc.record_request("m", 10.0, tokens_generated=1)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        stats = mc.get_request_stats()
+        assert stats["total"] == 800
+        assert stats["tokens_generated"] == 800

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,305 @@
+"""Tests for the model registry, manager, and API routes."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from ainode.models.registry import MODEL_CATALOG, ModelInfo, ModelManager
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tmp_models_dir(tmp_path: Path) -> Path:
+    """Provide a temporary models directory."""
+    d = tmp_path / "models"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def manager(tmp_models_dir: Path) -> ModelManager:
+    return ModelManager(models_dir=tmp_models_dir)
+
+
+def _fake_downloaded(manager: ModelManager, model_id: str) -> Path:
+    """Create a fake downloaded model directory with a dummy file."""
+    info = MODEL_CATALOG[model_id]
+    dirname = ModelManager._repo_to_dirname(info.hf_repo)
+    model_dir = manager.models_dir / dirname
+    model_dir.mkdir(parents=True, exist_ok=True)
+    (model_dir / "config.json").write_text('{"test": true}')
+    (model_dir / "model.safetensors").write_bytes(b"\x00" * 1024)
+    return model_dir
+
+
+# ---------------------------------------------------------------------------
+# Catalog tests
+# ---------------------------------------------------------------------------
+
+class TestCatalog:
+    def test_catalog_has_expected_models(self):
+        expected = {
+            "llama-3.2-3b",
+            "llama-3.1-8b",
+            "llama-3.1-70b-awq",
+            "qwen-2.5-72b",
+            "deepseek-r1-7b",
+            "mistral-7b",
+            "phi-3-mini",
+            "codellama-34b",
+        }
+        assert set(MODEL_CATALOG.keys()) == expected
+
+    def test_all_entries_are_model_info(self):
+        for model_id, info in MODEL_CATALOG.items():
+            assert isinstance(info, ModelInfo), f"{model_id} is not ModelInfo"
+            assert info.id == model_id
+            assert info.hf_repo
+            assert info.size_gb > 0
+            assert info.min_memory_gb > 0
+
+    def test_model_info_to_dict(self):
+        info = MODEL_CATALOG["llama-3.2-3b"]
+        d = info.to_dict()
+        assert d["id"] == "llama-3.2-3b"
+        assert "hf_repo" in d
+        assert "size_gb" in d
+
+
+# ---------------------------------------------------------------------------
+# Manager — list / info tests
+# ---------------------------------------------------------------------------
+
+class TestManagerList:
+    def test_list_available_all_not_downloaded(self, manager: ModelManager):
+        models = manager.list_available()
+        assert len(models) == len(MODEL_CATALOG)
+        for m in models:
+            assert m["downloaded"] is False
+
+    def test_list_available_with_downloaded(self, manager: ModelManager):
+        _fake_downloaded(manager, "llama-3.2-3b")
+        models = manager.list_available()
+        by_id = {m["id"]: m for m in models}
+        assert by_id["llama-3.2-3b"]["downloaded"] is True
+        assert by_id["mistral-7b"]["downloaded"] is False
+
+    def test_list_downloaded_empty(self, manager: ModelManager):
+        assert manager.list_downloaded() == []
+
+    def test_list_downloaded_with_model(self, manager: ModelManager):
+        _fake_downloaded(manager, "phi-3-mini")
+        downloaded = manager.list_downloaded()
+        assert len(downloaded) == 1
+        assert downloaded[0]["id"] == "phi-3-mini"
+        assert downloaded[0]["downloaded"] is True
+        assert downloaded[0]["local_size_gb"] >= 0
+
+    def test_list_downloaded_unknown_dir(self, manager: ModelManager):
+        """Directories not in catalog show as user-added."""
+        custom_dir = manager.models_dir / "some-org--custom-model"
+        custom_dir.mkdir()
+        (custom_dir / "weights.bin").write_bytes(b"\x00" * 512)
+        downloaded = manager.list_downloaded()
+        assert len(downloaded) == 1
+        assert downloaded[0]["id"] == "some-org--custom-model"
+        assert "not in catalog" in downloaded[0]["description"].lower()
+
+
+class TestManagerInfo:
+    def test_get_model_info_exists(self, manager: ModelManager):
+        info = manager.get_model_info("mistral-7b")
+        assert info is not None
+        assert info["id"] == "mistral-7b"
+        assert info["downloaded"] is False
+
+    def test_get_model_info_downloaded(self, manager: ModelManager):
+        _fake_downloaded(manager, "mistral-7b")
+        info = manager.get_model_info("mistral-7b")
+        assert info["downloaded"] is True
+        assert "local_size_gb" in info
+
+    def test_get_model_info_unknown(self, manager: ModelManager):
+        assert manager.get_model_info("nonexistent") is None
+
+
+# ---------------------------------------------------------------------------
+# Recommendations
+# ---------------------------------------------------------------------------
+
+class TestRecommendations:
+    def test_recommend_small_gpu(self, manager: ModelManager):
+        recs = manager.recommend_for_gpu(8)
+        ids = {r["id"] for r in recs}
+        assert "llama-3.2-3b" in ids
+        assert "phi-3-mini" in ids
+        # 70B should NOT fit
+        assert "llama-3.1-70b-awq" not in ids
+
+    def test_recommend_large_gpu(self, manager: ModelManager):
+        recs = manager.recommend_for_gpu(256)
+        # Everything should fit on 256 GB
+        assert len(recs) == len(MODEL_CATALOG)
+
+    def test_recommend_tiny_gpu(self, manager: ModelManager):
+        recs = manager.recommend_for_gpu(4)
+        assert len(recs) == 0
+
+    def test_recommend_sorted_by_size_desc(self, manager: ModelManager):
+        recs = manager.recommend_for_gpu(256)
+        sizes = [r["size_gb"] for r in recs]
+        assert sizes == sorted(sizes, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# Download (mocked)
+# ---------------------------------------------------------------------------
+
+class TestDownload:
+    def test_download_unknown_model_raises(self, manager: ModelManager):
+        with pytest.raises(ValueError, match="Unknown model"):
+            manager.download_model("nonexistent")
+
+    def test_download_missing_huggingface_hub(self, manager: ModelManager):
+        """If huggingface_hub is not installed, raise RuntimeError."""
+        import builtins
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "huggingface_hub":
+                raise ImportError("no module")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            with pytest.raises(RuntimeError, match="huggingface_hub"):
+                manager.download_model("llama-3.2-3b")
+
+    @patch("ainode.models.registry.snapshot_download", create=True)
+    def test_download_calls_snapshot_download(self, mock_sd, manager: ModelManager):
+        """Verify download_model calls huggingface_hub.snapshot_download correctly."""
+        expected_dir = manager.models_dir / "meta-llama--Llama-3.2-3B-Instruct"
+        mock_sd.return_value = str(expected_dir)
+
+        with patch.dict("sys.modules", {"huggingface_hub": MagicMock(snapshot_download=mock_sd)}):
+            result = manager.download_model("llama-3.2-3b")
+
+        mock_sd.assert_called_once_with(
+            repo_id="meta-llama/Llama-3.2-3B-Instruct",
+            local_dir=str(expected_dir),
+            local_dir_use_symlinks=False,
+        )
+        assert result == expected_dir
+
+
+# ---------------------------------------------------------------------------
+# Delete
+# ---------------------------------------------------------------------------
+
+class TestDelete:
+    def test_delete_downloaded_model(self, manager: ModelManager):
+        model_dir = _fake_downloaded(manager, "deepseek-r1-7b")
+        assert model_dir.exists()
+        assert manager.delete_model("deepseek-r1-7b") is True
+        assert not model_dir.exists()
+
+    def test_delete_not_downloaded(self, manager: ModelManager):
+        assert manager.delete_model("deepseek-r1-7b") is False
+
+    def test_delete_unknown_raises(self, manager: ModelManager):
+        with pytest.raises(ValueError, match="Unknown model"):
+            manager.delete_model("nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# API routes (aiohttp test client)
+# ---------------------------------------------------------------------------
+
+pytest.importorskip("aiohttp")
+from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
+from aiohttp import web
+from ainode.models.api_routes import register_model_routes
+
+
+class TestModelAPI:
+    """Test API routes using aiohttp test client via pytest-aiohttp."""
+
+    @pytest.fixture
+    def app(self, manager: ModelManager) -> web.Application:
+        app = web.Application()
+        register_model_routes(app, manager=manager)
+        return app
+
+    @pytest.fixture
+    def client(self, app, aiohttp_client, event_loop):
+        """Create aiohttp test client. Requires pytest-aiohttp."""
+        return event_loop.run_until_complete(aiohttp_client(app))
+
+    @pytest.mark.asyncio
+    async def test_list_models(self, app, aiohttp_client):
+        client = await aiohttp_client(app)
+        resp = await client.get("/api/models")
+        assert resp.status == 200
+        data = await resp.json()
+        assert "models" in data
+        assert len(data["models"]) == len(MODEL_CATALOG)
+
+    @pytest.mark.asyncio
+    async def test_get_model(self, app, aiohttp_client):
+        client = await aiohttp_client(app)
+        resp = await client.get("/api/models/llama-3.2-3b")
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["id"] == "llama-3.2-3b"
+
+    @pytest.mark.asyncio
+    async def test_get_model_not_found(self, app, aiohttp_client):
+        client = await aiohttp_client(app)
+        resp = await client.get("/api/models/nonexistent")
+        assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_download_model(self, app, aiohttp_client):
+        client = await aiohttp_client(app)
+        resp = await client.post("/api/models/llama-3.2-3b/download")
+        assert resp.status == 202
+        data = await resp.json()
+        assert data["status"] == "downloading"
+        assert "job_id" in data
+
+    @pytest.mark.asyncio
+    async def test_download_unknown(self, app, aiohttp_client):
+        client = await aiohttp_client(app)
+        resp = await client.post("/api/models/nonexistent/download")
+        assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_model_not_downloaded(self, app, aiohttp_client):
+        client = await aiohttp_client(app)
+        resp = await client.delete("/api/models/llama-3.2-3b")
+        assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_model_downloaded(self, app, aiohttp_client, manager):
+        _fake_downloaded(manager, "llama-3.2-3b")
+        client = await aiohttp_client(app)
+        resp = await client.delete("/api/models/llama-3.2-3b")
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["status"] == "deleted"
+
+    @pytest.mark.asyncio
+    async def test_recommended_no_gpu(self, app, aiohttp_client):
+        with patch("ainode.models.api_routes.detect_gpu", return_value=None):
+            client = await aiohttp_client(app)
+            resp = await client.get("/api/models/recommended")
+            assert resp.status == 200
+            data = await resp.json()
+            assert "error" in data

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,195 @@
+"""Tests for onboarding API routes."""
+
+import pytest
+import pytest_asyncio
+from aiohttp.test_utils import TestClient, TestServer
+
+from ainode.api.server import create_app
+from ainode.core.config import NodeConfig
+
+
+@pytest.fixture
+def fresh_config(tmp_path):
+    """A config that has NOT completed onboarding, using a temp dir for saves."""
+    config = NodeConfig(
+        node_id="test-node-1",
+        node_name="TestNode",
+        model="test-model",
+        onboarded=False,
+    )
+    # Override save to write to tmp instead of ~/.ainode
+    config_file = tmp_path / "config.json"
+    original_save = config.save
+
+    def save_to_tmp():
+        import json
+        from dataclasses import asdict
+        config_file.write_text(json.dumps(asdict(config), indent=2))
+
+    config.save = save_to_tmp
+    return config
+
+
+@pytest.fixture
+def onboarded_config():
+    """A config that HAS completed onboarding."""
+    return NodeConfig(
+        node_id="test-node-2",
+        node_name="MyNode",
+        model="meta-llama/Llama-3.1-8B-Instruct",
+        onboarded=True,
+    )
+
+
+@pytest.fixture
+def app_fresh(fresh_config):
+    return create_app(config=fresh_config, engine=None)
+
+
+@pytest.fixture
+def app_onboarded(onboarded_config):
+    return create_app(config=onboarded_config, engine=None)
+
+
+@pytest_asyncio.fixture
+async def client_fresh(app_fresh):
+    async with TestClient(TestServer(app_fresh)) as c:
+        yield c
+
+
+@pytest_asyncio.fixture
+async def client_onboarded(app_onboarded):
+    async with TestClient(TestServer(app_onboarded)) as c:
+        yield c
+
+
+# ---- GET /api/onboarding/status --------------------------------------------
+
+@pytest.mark.asyncio
+async def test_status_needs_setup(client_fresh):
+    resp = await client_fresh.get("/api/onboarding/status")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["onboarded"] is False
+    assert data["needs_setup"] is True
+
+
+@pytest.mark.asyncio
+async def test_status_already_onboarded(client_onboarded):
+    resp = await client_onboarded.get("/api/onboarding/status")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["onboarded"] is True
+    assert data["needs_setup"] is False
+
+
+# ---- GET /api/onboarding/suggestions ---------------------------------------
+
+@pytest.mark.asyncio
+async def test_suggestions_returns_hostname_and_models(client_fresh):
+    resp = await client_fresh.get("/api/onboarding/suggestions")
+    assert resp.status == 200
+    data = await resp.json()
+    assert "hostname" in data
+    assert isinstance(data["hostname"], str)
+    assert "models" in data
+    assert isinstance(data["models"], list)
+    assert len(data["models"]) > 0
+    # Each model should have required fields
+    m = data["models"][0]
+    assert "id" in m
+    assert "name" in m
+    assert "hf_repo" in m
+    assert "size_gb" in m
+    assert "fits_gpu" in m
+
+
+# ---- POST /api/onboarding/complete -----------------------------------------
+
+@pytest.mark.asyncio
+async def test_complete_saves_config(client_fresh, fresh_config):
+    payload = {
+        "node_name": "my-spark",
+        "model": "meta-llama/Llama-3.1-8B-Instruct",
+        "email": "test@example.com",
+    }
+    resp = await client_fresh.post("/api/onboarding/complete", json=payload)
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["status"] == "ok"
+    assert data["onboarded"] is True
+    assert data["node_name"] == "my-spark"
+    assert data["model"] == "meta-llama/Llama-3.1-8B-Instruct"
+
+    # Config object should be updated
+    assert fresh_config.onboarded is True
+    assert fresh_config.node_name == "my-spark"
+    assert fresh_config.model == "meta-llama/Llama-3.1-8B-Instruct"
+    assert fresh_config.email == "test@example.com"
+
+
+@pytest.mark.asyncio
+async def test_complete_sets_awq_quantization(client_fresh, fresh_config):
+    payload = {
+        "node_name": "awq-node",
+        "model": "hugging-quants/Meta-Llama-3.1-70B-Instruct-AWQ-INT4",
+    }
+    resp = await client_fresh.post("/api/onboarding/complete", json=payload)
+    assert resp.status == 200
+    assert fresh_config.quantization == "awq"
+
+
+@pytest.mark.asyncio
+async def test_complete_without_email(client_fresh, fresh_config):
+    payload = {
+        "node_name": "no-email-node",
+        "model": "meta-llama/Llama-3.2-3B-Instruct",
+    }
+    resp = await client_fresh.post("/api/onboarding/complete", json=payload)
+    assert resp.status == 200
+    assert fresh_config.onboarded is True
+    assert fresh_config.email is None
+
+
+@pytest.mark.asyncio
+async def test_complete_rejects_invalid_json(client_fresh):
+    resp = await client_fresh.post(
+        "/api/onboarding/complete",
+        data=b"not json",
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status == 400
+    data = await resp.json()
+    assert "error" in data
+
+
+# ---- Index redirect logic ---------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_index_redirects_to_onboarding_when_not_setup(client_fresh):
+    resp = await client_fresh.get("/", allow_redirects=False)
+    assert resp.status == 302
+    assert "/onboarding" in resp.headers.get("Location", "")
+
+
+@pytest.mark.asyncio
+async def test_index_serves_dashboard_when_onboarded(client_onboarded):
+    resp = await client_onboarded.get("/")
+    assert resp.status == 200
+    text = await resp.text()
+    assert "AINode" in text
+
+
+@pytest.mark.asyncio
+async def test_onboarding_page_serves_wizard_when_not_setup(client_fresh):
+    resp = await client_fresh.get("/onboarding")
+    assert resp.status == 200
+    text = await resp.text()
+    assert "Let's get you set up" in text or "onboarding" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_onboarding_page_redirects_when_already_done(client_onboarded):
+    resp = await client_onboarded.get("/onboarding", allow_redirects=False)
+    assert resp.status == 302
+    assert resp.headers.get("Location", "").endswith("/")

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,230 @@
+"""Tests for ainode.service.systemd — unit file generation and service management."""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from ainode.service import systemd
+
+
+class TestUnitFileGeneration:
+    """Test systemd unit file content generation."""
+
+    def test_generate_system_unit(self):
+        """System-level unit file uses multi-user.target."""
+        content = systemd.generate_unit_file(user_mode=False)
+        assert "WantedBy=multi-user.target" in content
+        assert "ainode start" in content
+        assert "NVIDIA_VISIBLE_DEVICES=all" in content
+        assert "After=network.target nvidia-persistenced.service" in content
+        assert "Restart=on-failure" in content
+
+    def test_generate_user_unit(self):
+        """User-level unit file uses default.target."""
+        content = systemd.generate_unit_file(user_mode=True)
+        assert "WantedBy=default.target" in content
+        assert "ainode start" in content
+
+    def test_unit_has_gpu_env_vars(self):
+        content = systemd.generate_unit_file()
+        assert "NVIDIA_VISIBLE_DEVICES=all" in content
+        assert "CUDA_DEVICE_ORDER=PCI_BUS_ID" in content
+
+    def test_unit_has_hardening(self):
+        content = systemd.generate_unit_file()
+        assert "NoNewPrivileges=true" in content
+        assert "ProtectSystem=strict" in content
+
+    def test_unit_has_restart_policy(self):
+        content = systemd.generate_unit_file()
+        assert "Restart=on-failure" in content
+        assert "RestartSec=10" in content
+
+    def test_unit_has_description(self):
+        content = systemd.generate_unit_file()
+        assert "Description=AINode" in content
+        assert "Documentation=https://ainode.dev" in content
+
+
+class TestIsInstalled:
+    """Test is_installed checks."""
+
+    def test_not_installed(self, tmp_path):
+        with patch.object(systemd, "SYSTEM_UNIT_DIR", tmp_path):
+            assert systemd.is_installed(user_mode=False) is False
+
+    def test_installed(self, tmp_path):
+        unit_file = tmp_path / "ainode.service"
+        unit_file.write_text("[Unit]\nDescription=test\n")
+        with patch.object(systemd, "SYSTEM_UNIT_DIR", tmp_path):
+            assert systemd.is_installed(user_mode=False) is True
+
+    def test_user_mode_not_installed(self, tmp_path):
+        with patch.object(systemd, "USER_UNIT_DIR", tmp_path):
+            assert systemd.is_installed(user_mode=True) is False
+
+
+class TestInstallService:
+    """Test install_service writes unit file and reloads daemon."""
+
+    def test_install_writes_unit_file(self, tmp_path):
+        with (
+            patch.object(systemd, "SYSTEM_UNIT_DIR", tmp_path),
+            patch.object(systemd, "_systemctl") as mock_ctl,
+        ):
+            systemd.install_service(user_mode=False)
+
+            unit_path = tmp_path / "ainode.service"
+            assert unit_path.exists()
+            content = unit_path.read_text()
+            assert "ainode start" in content
+            mock_ctl.assert_called_once_with(["daemon-reload"], user_mode=False)
+
+    def test_install_user_mode(self, tmp_path):
+        with (
+            patch.object(systemd, "USER_UNIT_DIR", tmp_path),
+            patch.object(systemd, "_systemctl") as mock_ctl,
+        ):
+            systemd.install_service(user_mode=True)
+
+            unit_path = tmp_path / "ainode.service"
+            assert unit_path.exists()
+            content = unit_path.read_text()
+            assert "WantedBy=default.target" in content
+            mock_ctl.assert_called_once_with(["daemon-reload"], user_mode=True)
+
+
+class TestUninstallService:
+    """Test uninstall_service stops, disables, removes, and reloads."""
+
+    def test_uninstall_removes_unit(self, tmp_path):
+        unit_file = tmp_path / "ainode.service"
+        unit_file.write_text("[Unit]\nDescription=test\n")
+
+        with (
+            patch.object(systemd, "SYSTEM_UNIT_DIR", tmp_path),
+            patch.object(systemd, "_systemctl") as mock_ctl,
+        ):
+            systemd.uninstall_service(user_mode=False)
+
+            assert not unit_file.exists()
+            # Should have called stop, disable, daemon-reload
+            calls = mock_ctl.call_args_list
+            assert any("stop" in str(c) for c in calls)
+            assert any("disable" in str(c) for c in calls)
+            assert any("daemon-reload" in str(c) for c in calls)
+
+    def test_uninstall_noop_if_not_installed(self, tmp_path):
+        with (
+            patch.object(systemd, "SYSTEM_UNIT_DIR", tmp_path),
+            patch.object(systemd, "_systemctl") as mock_ctl,
+        ):
+            systemd.uninstall_service(user_mode=False)
+            mock_ctl.assert_not_called()
+
+
+class TestServiceActions:
+    """Test enable, disable, start, stop, restart delegate to systemctl."""
+
+    @patch.object(systemd, "_systemctl")
+    def test_enable(self, mock_ctl):
+        systemd.enable_service(user_mode=False)
+        mock_ctl.assert_called_once_with(["enable", "ainode.service"], user_mode=False)
+
+    @patch.object(systemd, "_systemctl")
+    def test_disable(self, mock_ctl):
+        systemd.disable_service(user_mode=True)
+        mock_ctl.assert_called_once_with(["disable", "ainode.service"], user_mode=True)
+
+    @patch.object(systemd, "_systemctl")
+    def test_start(self, mock_ctl):
+        systemd.start_service()
+        mock_ctl.assert_called_once_with(["start", "ainode.service"], user_mode=False)
+
+    @patch.object(systemd, "_systemctl")
+    def test_stop(self, mock_ctl):
+        systemd.stop_service()
+        mock_ctl.assert_called_once_with(["stop", "ainode.service"], user_mode=False)
+
+    @patch.object(systemd, "_systemctl")
+    def test_restart(self, mock_ctl):
+        systemd.restart_service()
+        mock_ctl.assert_called_once_with(["restart", "ainode.service"], user_mode=False)
+
+
+class TestStatusService:
+    """Test status_service returns structured info."""
+
+    @patch.object(systemd, "get_journal_lines", return_value=["line1", "line2"])
+    @patch.object(systemd, "_systemctl")
+    def test_status_active(self, mock_ctl, mock_journal):
+        mock_ctl.side_effect = [
+            MagicMock(stdout="active\n"),   # is-active
+            MagicMock(stdout="enabled\n"),  # is-enabled
+        ]
+        info = systemd.status_service(user_mode=False)
+        assert info["state"] == "active"
+        assert info["enabled"] is True
+        assert info["journal_lines"] == ["line1", "line2"]
+
+    @patch.object(systemd, "get_journal_lines", return_value=[])
+    @patch.object(systemd, "_systemctl")
+    def test_status_inactive(self, mock_ctl, mock_journal):
+        mock_ctl.side_effect = [
+            MagicMock(stdout="inactive\n"),
+            MagicMock(stdout="disabled\n"),
+        ]
+        info = systemd.status_service()
+        assert info["state"] == "inactive"
+        assert info["enabled"] is False
+
+
+class TestGetJournalLines:
+    """Test journal line fetching."""
+
+    @patch("subprocess.run")
+    def test_returns_lines(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="line1\nline2\nline3\n")
+        lines = systemd.get_journal_lines(lines=3)
+        assert lines == ["line1", "line2", "line3"]
+
+    @patch("subprocess.run", side_effect=FileNotFoundError)
+    def test_returns_empty_on_missing_journalctl(self, mock_run):
+        lines = systemd.get_journal_lines()
+        assert lines == []
+
+    @patch("subprocess.run", side_effect=subprocess.TimeoutExpired("journalctl", 10))
+    def test_returns_empty_on_timeout(self, mock_run):
+        lines = systemd.get_journal_lines()
+        assert lines == []
+
+
+class TestSystemctlHelper:
+    """Test _systemctl builds the correct command."""
+
+    @patch("subprocess.run")
+    def test_system_mode(self, mock_run):
+        systemd._systemctl(["start", "ainode.service"], user_mode=False)
+        mock_run.assert_called_once_with(
+            ["systemctl", "start", "ainode.service"], check=True, timeout=30
+        )
+
+    @patch("subprocess.run")
+    def test_user_mode(self, mock_run):
+        systemd._systemctl(["start", "ainode.service"], user_mode=True)
+        mock_run.assert_called_once_with(
+            ["systemctl", "--user", "start", "ainode.service"], check=True, timeout=30
+        )
+
+    @patch("subprocess.run")
+    def test_capture_mode(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="active\n")
+        result = systemd._systemctl(["is-active", "ainode.service"], capture=True)
+        mock_run.assert_called_once_with(
+            ["systemctl", "is-active", "ainode.service"],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert result.stdout == "active\n"

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,296 @@
+"""Tests for ainode.training — config validation, job lifecycle, manager queue."""
+
+import asyncio
+import pytest
+
+from ainode.training.engine import (
+    TrainingConfig,
+    TrainingJob,
+    TrainingManager,
+    JobStatus,
+)
+
+
+# =============================================================================
+# TrainingConfig validation
+# =============================================================================
+
+
+class TestTrainingConfig:
+    def test_valid_config(self):
+        config = TrainingConfig(
+            base_model="meta-llama/Llama-3.2-3B-Instruct",
+            dataset_path="/data/train.jsonl",
+        )
+        assert config.validate() == []
+
+    def test_missing_base_model(self):
+        config = TrainingConfig(base_model="", dataset_path="/data/train.jsonl")
+        errors = config.validate()
+        assert any("base_model" in e for e in errors)
+
+    def test_missing_dataset_path(self):
+        config = TrainingConfig(base_model="some-model", dataset_path="")
+        errors = config.validate()
+        assert any("dataset_path" in e for e in errors)
+
+    def test_invalid_method(self):
+        config = TrainingConfig(
+            base_model="model", dataset_path="/data", method="qlora"
+        )
+        errors = config.validate()
+        assert any("method" in e for e in errors)
+
+    def test_invalid_num_epochs(self):
+        config = TrainingConfig(
+            base_model="model", dataset_path="/data", num_epochs=0
+        )
+        errors = config.validate()
+        assert any("num_epochs" in e for e in errors)
+
+    def test_invalid_batch_size(self):
+        config = TrainingConfig(
+            base_model="model", dataset_path="/data", batch_size=-1
+        )
+        errors = config.validate()
+        assert any("batch_size" in e for e in errors)
+
+    def test_invalid_learning_rate(self):
+        config = TrainingConfig(
+            base_model="model", dataset_path="/data", learning_rate=0
+        )
+        errors = config.validate()
+        assert any("learning_rate" in e for e in errors)
+
+    def test_invalid_lora_rank(self):
+        config = TrainingConfig(
+            base_model="model", dataset_path="/data", lora_rank=0
+        )
+        errors = config.validate()
+        assert any("lora_rank" in e for e in errors)
+
+    def test_invalid_lora_alpha(self):
+        config = TrainingConfig(
+            base_model="model", dataset_path="/data", lora_alpha=0
+        )
+        errors = config.validate()
+        assert any("lora_alpha" in e for e in errors)
+
+    def test_invalid_max_seq_length(self):
+        config = TrainingConfig(
+            base_model="model", dataset_path="/data", max_seq_length=0
+        )
+        errors = config.validate()
+        assert any("max_seq_length" in e for e in errors)
+
+    def test_multiple_errors(self):
+        config = TrainingConfig(
+            base_model="",
+            dataset_path="",
+            method="bad",
+            num_epochs=0,
+        )
+        errors = config.validate()
+        assert len(errors) >= 3
+
+    def test_defaults(self):
+        config = TrainingConfig(base_model="m", dataset_path="/d")
+        assert config.method == "lora"
+        assert config.num_epochs == 3
+        assert config.batch_size == 4
+        assert config.learning_rate == 2e-4
+        assert config.lora_rank == 16
+        assert config.lora_alpha == 32
+        assert config.max_seq_length == 2048
+
+    def test_to_dict(self):
+        config = TrainingConfig(base_model="m", dataset_path="/d")
+        d = config.to_dict()
+        assert d["base_model"] == "m"
+        assert d["dataset_path"] == "/d"
+        assert isinstance(d, dict)
+
+    def test_from_dict(self):
+        data = {
+            "base_model": "model-x",
+            "dataset_path": "/data/file.json",
+            "method": "full",
+            "num_epochs": 5,
+            "extra_field": "ignored",
+        }
+        config = TrainingConfig.from_dict(data)
+        assert config.base_model == "model-x"
+        assert config.method == "full"
+        assert config.num_epochs == 5
+
+    def test_from_dict_defaults(self):
+        config = TrainingConfig.from_dict({
+            "base_model": "m",
+            "dataset_path": "/d",
+        })
+        assert config.lora_rank == 16
+
+
+# =============================================================================
+# TrainingJob lifecycle
+# =============================================================================
+
+
+class TestTrainingJob:
+    def test_initial_state(self):
+        config = TrainingConfig(base_model="m", dataset_path="/d")
+        job = TrainingJob(config)
+        assert job.status == JobStatus.PENDING
+        assert job.progress == 0.0
+        assert job.current_epoch == 0
+        assert job.current_loss is None
+        assert job.start_time is None
+        assert job.end_time is None
+        assert len(job.job_id) == 12
+
+    def test_custom_job_id(self):
+        config = TrainingConfig(base_model="m", dataset_path="/d")
+        job = TrainingJob(config, job_id="custom123")
+        assert job.job_id == "custom123"
+
+    def test_get_status(self):
+        config = TrainingConfig(base_model="m", dataset_path="/d")
+        job = TrainingJob(config)
+        status = job.get_status()
+        assert status["job_id"] == job.job_id
+        assert status["status"] == "pending"
+        assert status["progress"] == 0.0
+        assert status["config"]["base_model"] == "m"
+
+    def test_output_dir_default(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
+        config = TrainingConfig(base_model="m", dataset_path="/d")
+        job = TrainingJob(config)
+        assert "output" in job.config.output_dir
+        assert job.job_id in job.config.output_dir
+
+    def test_output_dir_custom(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
+        config = TrainingConfig(
+            base_model="m", dataset_path="/d", output_dir="/custom/out"
+        )
+        job = TrainingJob(config)
+        assert job.config.output_dir == "/custom/out"
+
+    @pytest.mark.asyncio
+    async def test_cancel_pending_job(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
+        config = TrainingConfig(base_model="m", dataset_path="/d")
+        job = TrainingJob(config)
+        assert job.status == JobStatus.PENDING
+        await job.stop()
+        assert job.status == JobStatus.CANCELLED
+        assert job.end_time is not None
+
+    def test_parse_progress(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
+        config = TrainingConfig(base_model="m", dataset_path="/d")
+        job = TrainingJob(config)
+        line = 'AINODE_PROGRESS:{"epoch":2,"loss":0.45,"progress":66.7}'
+        job._parse_progress(line)
+        assert job.current_epoch == 2
+        assert job.current_loss == 0.45
+        assert job.progress == 66.7
+
+    def test_parse_progress_invalid_json(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
+        config = TrainingConfig(base_model="m", dataset_path="/d")
+        job = TrainingJob(config)
+        job._parse_progress("AINODE_PROGRESS:{invalid}")
+        assert job.current_epoch == 0  # Unchanged
+
+    def test_parse_progress_no_marker(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
+        config = TrainingConfig(base_model="m", dataset_path="/d")
+        job = TrainingJob(config)
+        job._parse_progress("some random log line")
+        assert job.current_epoch == 0  # Unchanged
+
+
+# =============================================================================
+# TrainingManager queue operations
+# =============================================================================
+
+
+class TestTrainingManager:
+    def _make_config(self, model="m", dataset="/d"):
+        return TrainingConfig(base_model=model, dataset_path=dataset)
+
+    def test_submit_job(self):
+        mgr = TrainingManager()
+        job = mgr.submit_job(self._make_config())
+        assert job.status == JobStatus.PENDING
+        assert mgr.get_job(job.job_id) is job
+
+    def test_submit_invalid_config(self):
+        mgr = TrainingManager()
+        config = TrainingConfig(base_model="", dataset_path="")
+        with pytest.raises(ValueError, match="Invalid training config"):
+            mgr.submit_job(config)
+
+    def test_list_jobs(self):
+        mgr = TrainingManager()
+        mgr.submit_job(self._make_config())
+        mgr.submit_job(self._make_config(model="model-2"))
+        jobs = mgr.list_jobs()
+        assert len(jobs) == 2
+        assert all(j["status"] == "pending" for j in jobs)
+
+    def test_list_jobs_empty(self):
+        mgr = TrainingManager()
+        assert mgr.list_jobs() == []
+
+    def test_get_job_not_found(self):
+        mgr = TrainingManager()
+        assert mgr.get_job("nonexistent") is None
+
+    @pytest.mark.asyncio
+    async def test_cancel_pending_job(self):
+        mgr = TrainingManager()
+        job = mgr.submit_job(self._make_config())
+        result = await mgr.cancel_job(job.job_id)
+        assert result is True
+        assert job.status == JobStatus.CANCELLED
+
+    @pytest.mark.asyncio
+    async def test_cancel_nonexistent_job(self):
+        mgr = TrainingManager()
+        result = await mgr.cancel_job("nope")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_cancel_already_cancelled(self):
+        mgr = TrainingManager()
+        job = mgr.submit_job(self._make_config())
+        await mgr.cancel_job(job.job_id)
+        result = await mgr.cancel_job(job.job_id)
+        assert result is False
+
+    def test_queue_size(self):
+        mgr = TrainingManager()
+        mgr.submit_job(self._make_config())
+        mgr.submit_job(self._make_config())
+        assert mgr.queue_size == 2
+
+    @pytest.mark.asyncio
+    async def test_queue_size_after_cancel(self):
+        mgr = TrainingManager()
+        j1 = mgr.submit_job(self._make_config())
+        mgr.submit_job(self._make_config())
+        await mgr.cancel_job(j1.job_id)
+        assert mgr.queue_size == 1
+
+    def test_active_job_none(self):
+        mgr = TrainingManager()
+        assert mgr.active_job is None
+
+    def test_submit_preserves_order(self):
+        mgr = TrainingManager()
+        j1 = mgr.submit_job(self._make_config(model="first"))
+        j2 = mgr.submit_job(self._make_config(model="second"))
+        assert mgr._queue == [j1.job_id, j2.job_id]

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,53 @@
+"""Tests for ainode.web — template and static file serving."""
+
+from pathlib import Path
+from ainode.web.serve import get_index_html, get_static_path, STATIC_DIR, TEMPLATES_DIR
+
+
+def test_templates_dir_exists():
+    assert TEMPLATES_DIR.is_dir()
+
+
+def test_static_dir_exists():
+    assert STATIC_DIR.is_dir()
+
+
+def test_get_index_html():
+    html = get_index_html()
+    assert "AINode" in html
+    assert "argentos.ai" in html
+    assert "dashboard" in html
+    assert "chat" in html
+    assert "models" in html
+    assert "training" in html
+
+
+def test_get_index_html_has_js():
+    html = get_index_html()
+    assert "app.js" in html
+
+
+def test_get_index_html_has_css():
+    html = get_index_html()
+    assert "style.css" in html
+
+
+def test_get_static_path():
+    path = get_static_path()
+    assert isinstance(path, Path)
+    assert path.is_dir()
+
+
+def test_css_exists():
+    css = STATIC_DIR / "css" / "style.css"
+    assert css.exists()
+    content = css.read_text()
+    assert "--bg-primary" in content
+
+
+def test_js_exists():
+    js = STATIC_DIR / "js" / "app.js"
+    assert js.exists()
+    content = js.read_text()
+    assert "AINode" in content
+    assert "fetchJSON" in content


### PR DESCRIPTION
## Summary

Complete AINode v0.1.0 build from scaffold to full platform. 12 slices merged across all priority tiers.

### P0 — MVP Core
- **engine-vllm** (PR #2): vLLM engine lifecycle, health checks, readiness wait, log streaming
- **api-proxy** (PR #4): aiohttp OpenAI-compatible proxy, /api/* endpoints, CORS, SSE streaming
- **web-ui** (PR #3): Full SPA dashboard — nodes, chat, models, training views, dark theme

### P1 — Cluster + Polish
- **discovery-cluster** (PR #5): UDP broadcast, node health (online/stale/offline), leader election, model routing
- **cli-polish** (PR #10): Rich panels/tables/spinners, PID management, `config` and `logs` subcommands
- **onboarding-web** (PR #11): 5-step browser setup wizard, GPU-aware model recommendations

### P2 — Differentiators
- **model-manager** (PR #7): 8-model catalog, HuggingFace download, delete, GPU recommendations, API routes
- **metrics** (PR #6): GPU utilization/memory/temp via pynvml, request latency percentiles, thread-safe
- **training-engine** (PR #8): LoRA + full fine-tuning, job queue, progress parsing, subprocess management
- **training-ui** (PR #13): Job dashboard, new job form, real-time progress, loss chart, log viewer

### P3 — Production
- **systemd-service** (PR #9): Unit file generation, install/enable/start lifecycle, service hardening
- **auth** (PR #12): Optional Bearer token auth, middleware, key management CLI + API

### Test suite
- **238 tests passing** across 14 test files
- Covers: config, GPU detection, engine, CLI, API, auth, discovery, cluster, metrics, models, onboarding, service, training, web

## Test plan
- [x] `pip install -e .` succeeds
- [x] `ainode --version` → `ainode 0.1.0`
- [x] `pytest tests/` → 238/238 passing
- [x] `ainode models` renders Rich table
- [ ] Full hardware test on DGX Spark (deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)