### PR TITLE
Add interactive topology graph to dashboard

### DIFF
--- a/ainode/web/static/css/style.css
+++ b/ainode/web/static/css/style.css
@@ -1112,3 +1112,96 @@ body {
   0% { background-position: -200% 0; }
   100% { background-position: 200% 0; }
 }
+
+/* Topology Graph */
+.topology-container {
+  position: relative;
+  width: 100%;
+  min-height: 360px;
+  height: 420px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.topology-container canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.topology-detail {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+  animation: topologyDetailIn 0.2s ease;
+}
+
+@keyframes topologyDetailIn {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.topology-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.topology-detail-name {
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.topology-detail-id {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  margin-top: 2px;
+}
+
+.topology-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+
+.topology-detail-stat {
+  background: var(--bg-secondary);
+  border-radius: var(--radius-sm);
+  padding: 12px 16px;
+}
+
+.topology-detail-stat .stat-value {
+  font-size: 20px;
+}
+
+.topology-detail-close {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  padding: 6px 12px;
+  font-size: 12px;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: all 0.15s ease;
+}
+
+.topology-detail-close:hover {
+  background: var(--bg-card-hover);
+  color: var(--text-primary);
+}
+
+@media (max-width: 1024px) {
+  .topology-detail-grid { grid-template-columns: repeat(2, 1fr); }
+  .topology-container { height: 360px; }
+}
+
+@media (max-width: 768px) {
+  .topology-detail-grid { grid-template-columns: 1fr; }
+  .topology-container { height: 300px; min-height: 300px; }
+}

--- a/ainode/web/static/js/app.js
+++ b/ainode/web/static/js/app.js
@@ -12,6 +12,17 @@ const AINode = {
     trainingView: 'list',
     trainingDetailId: null,
     trainingLossData: [],
+    // Models management
+    modelsCatalog: [],
+    modelsRecommended: [],
+    modelsGpuMemory: null,
+    modelsFilter: 'all',
+    modelsSearch: '',
+    modelsSort: 'recommended',
+    modelsExpanded: null,
+    modelsDownloading: {},
+    modelsDeleteTarget: null,
+    modelsBound: false,
   },
 
   // --- Initialization ---
@@ -92,47 +103,97 @@ const AINode = {
       <div class="card"><div class="stat-value">${totalMem || (s.gpu?.memory_gb || 0)} GB</div><div class="stat-label">Total Memory</div></div>
       <div class="card"><div class="stat-value">${modelsLoaded}</div><div class="stat-label">Models Loaded</div></div>
     `;
-    this.renderNodes(nodes, s);
+    this.renderTopology(nodes, s);
     this.renderClusterHealth(s);
   },
 
-  renderNodes(nodes, status) {
-    const container = document.getElementById('dashboard-nodes');
-    if (!container) return;
+  _topologyInitialized: false,
+
+  renderTopology(nodes, status) {
+    // Build node list — fallback to local node from status
     if (nodes.length === 0 && status) {
       nodes = [{
         node_id: status.node_id || 'local',
         node_name: status.node_name || 'This Node',
         gpu_name: status.gpu?.name || 'Unknown GPU',
         gpu_memory_gb: status.gpu?.memory_gb || 0,
+        gpu_memory_used_pct: status.gpu?.memory_used_pct || 0,
+        gpu_utilization_pct: status.gpu?.utilization_pct || null,
         unified_memory: status.gpu?.unified_memory || false,
         model: status.model || 'none',
         status: status.engine_ready ? 'online' : 'starting',
         is_leader: true,
+        uptime_seconds: status.uptime_seconds || null,
       }];
     }
-    container.innerHTML = nodes.map(node => {
-      const statusClass = node.status === 'online' ? 'status-online' : node.status === 'starting' ? 'status-starting' : 'status-offline';
-      const leaderClass = node.is_leader ? 'is-leader' : '';
-      const memLabel = node.unified_memory ? 'unified' : 'VRAM';
-      const memPct = node.gpu_memory_used_pct || 0;
-      const barClass = memPct > 90 ? 'red' : memPct > 70 ? 'yellow' : 'green';
-      return `
-        <div class="node-card ${leaderClass}">
-          <div style="display:flex; justify-content:space-between; align-items:start; margin-bottom:12px">
-            <div>
-              <div class="node-name">${this.esc(node.node_name || node.node_id)}</div>
-              <div class="node-id">${this.esc(node.node_id)}</div>
-            </div>
-            <div class="status ${statusClass}"><span class="status-dot"></span>${node.status || 'unknown'}</div>
-          </div>
-          <div class="node-gpu">${this.esc(node.gpu_name || 'Unknown')} &middot; ${node.gpu_memory_gb || '?'} GB ${memLabel}</div>
-          <div class="node-model">${this.esc(node.model || 'no model')}</div>
-          <div class="progress-bar"><div class="progress-fill ${barClass}" style="width:${memPct}%"></div></div>
-          <div style="font-size:11px; color:var(--text-muted); margin-top:4px">Memory: ${memPct}% used</div>
+
+    // Initialize topology canvas once
+    if (!this._topologyInitialized) {
+      const canvas = document.getElementById('topology-canvas');
+      if (canvas && typeof Topology !== 'undefined') {
+        Topology.init(canvas, (nodeData) => this.showTopologyDetail(nodeData));
+        this._topologyInitialized = true;
+      }
+    }
+
+    // Update topology data
+    if (typeof Topology !== 'undefined') {
+      Topology.update(nodes);
+    }
+  },
+
+  showTopologyDetail(nodeData) {
+    const panel = document.getElementById('topology-detail');
+    if (!panel) return;
+    if (!nodeData) {
+      panel.style.display = 'none';
+      return;
+    }
+    const d = nodeData;
+    const statusClass = d.status === 'online' ? 'status-online' : d.status === 'starting' ? 'status-starting' : 'status-offline';
+    const memLabel = d.unified_memory ? 'unified' : 'VRAM';
+    const memPct = d.gpu_memory_used_pct || 0;
+    const gpuUtil = d.gpu_utilization_pct != null ? d.gpu_utilization_pct + '%' : 'N/A';
+    const uptime = d.uptime_seconds ? this.formatUptime(d.uptime_seconds) : 'N/A';
+    panel.style.display = 'block';
+    panel.innerHTML = `
+      <div class="topology-detail-header">
+        <div>
+          <div class="topology-detail-name">${this.esc(d.node_name || d.node_id)}${d.is_leader ? ' <span style="color:var(--accent);font-size:12px;font-weight:600">LEADER</span>' : ''}</div>
+          <div class="topology-detail-id">${this.esc(d.node_id)}</div>
         </div>
-      `;
-    }).join('');
+        <div style="display:flex;align-items:center;gap:12px">
+          <div class="status ${statusClass}"><span class="status-dot"></span>${d.status || 'unknown'}</div>
+          <button class="topology-detail-close" id="topology-detail-close">Close</button>
+        </div>
+      </div>
+      <div class="topology-detail-grid">
+        <div class="topology-detail-stat">
+          <div class="stat-value" style="color:var(--text-primary)">${this.esc(d.gpu_name || 'Unknown')}</div>
+          <div class="stat-label">GPU</div>
+        </div>
+        <div class="topology-detail-stat">
+          <div class="stat-value">${d.gpu_memory_gb || '?'} <span style="font-size:14px;color:var(--text-muted)">GB ${memLabel}</span></div>
+          <div class="stat-label">Memory</div>
+          <div class="progress-bar" style="margin-top:6px"><div class="progress-fill ${memPct > 90 ? 'red' : memPct > 70 ? 'yellow' : 'green'}" style="width:${memPct}%"></div></div>
+          <div style="font-size:11px;color:var(--text-muted);margin-top:2px">${memPct}% used</div>
+        </div>
+        <div class="topology-detail-stat">
+          <div class="stat-value">${gpuUtil}</div>
+          <div class="stat-label">GPU Utilization</div>
+        </div>
+        <div class="topology-detail-stat">
+          <div class="stat-value">${uptime}</div>
+          <div class="stat-label">Uptime</div>
+        </div>
+      </div>
+      <div style="margin-top:12px;font-family:var(--font-mono);font-size:13px;color:var(--accent)">
+        Model: ${this.esc(d.model || 'no model loaded')}
+      </div>
+    `;
+    document.getElementById('topology-detail-close')?.addEventListener('click', () => {
+      panel.style.display = 'none';
+    });
   },
 
   renderClusterHealth(status) {

--- a/ainode/web/static/js/topology.js
+++ b/ainode/web/static/js/topology.js
@@ -1,0 +1,685 @@
+/* AINode Topology — Interactive Force-Directed Node Graph */
+
+const Topology = (() => {
+  // --- Configuration ---
+  const CONFIG = {
+    nodeWidth: 220,
+    nodeHeight: 88,
+    nodeRadius: 14,
+    minHeight: 360,
+    padding: 60,
+    // Physics
+    repulsionStrength: 8000,
+    attractionStrength: 0.005,
+    centerGravity: 0.03,
+    damping: 0.88,
+    minVelocity: 0.01,
+    // Appearance
+    connectionWidth: 2,
+    pulseSpeed: 0.002,
+    hoverExpandHeight: 56,
+    // Colors (read from CSS vars at init)
+    colors: {},
+  };
+
+  // --- State ---
+  let canvas = null;
+  let ctx = null;
+  let width = 0;
+  let height = 0;
+  let dpr = 1;
+  let animFrameId = null;
+  let time = 0;
+  let selectedNodeId = null;
+  let hoveredNodeId = null;
+  let onSelectCallback = null;
+
+  // Graph data
+  let graphNodes = [];
+  let graphEdges = [];
+
+  // Mouse state
+  let mouse = { x: 0, y: 0, down: false };
+  let dragNode = null;
+  let dragOffset = { x: 0, y: 0 };
+
+  // --- Color Helpers ---
+  function readCSSColors() {
+    const style = getComputedStyle(document.documentElement);
+    const get = (v) => style.getPropertyValue(v).trim();
+    CONFIG.colors = {
+      bgPrimary: get('--bg-primary') || '#0a0e17',
+      bgCard: get('--bg-card') || '#1a2332',
+      bgCardHover: get('--bg-card-hover') || '#1e2a3d',
+      border: get('--border') || '#2d3748',
+      borderActive: get('--border-active') || '#4a90d9',
+      textPrimary: get('--text-primary') || '#e2e8f0',
+      textSecondary: get('--text-secondary') || '#94a3b8',
+      textMuted: get('--text-muted') || '#64748b',
+      accent: get('--accent') || '#4a90d9',
+      green: get('--green') || '#10b981',
+      yellow: get('--yellow') || '#f59e0b',
+      red: get('--red') || '#ef4444',
+      purple: get('--purple') || '#8b5cf6',
+    };
+  }
+
+  function hexToRgba(hex, alpha) {
+    hex = hex.replace('#', '');
+    if (hex.length === 3) hex = hex[0]+hex[0]+hex[1]+hex[1]+hex[2]+hex[2];
+    const r = parseInt(hex.substring(0,2), 16);
+    const g = parseInt(hex.substring(2,4), 16);
+    const b = parseInt(hex.substring(4,6), 16);
+    return `rgba(${r},${g},${b},${alpha})`;
+  }
+
+  // --- Initialization ---
+  function init(canvasEl, onSelect) {
+    canvas = canvasEl;
+    ctx = canvas.getContext('2d');
+    onSelectCallback = onSelect;
+    dpr = window.devicePixelRatio || 1;
+    readCSSColors();
+    resize();
+    bindEvents();
+    startLoop();
+  }
+
+  function destroy() {
+    if (animFrameId) cancelAnimationFrame(animFrameId);
+    animFrameId = null;
+    unbindEvents();
+  }
+
+  function resize() {
+    if (!canvas || !canvas.parentElement) return;
+    const rect = canvas.parentElement.getBoundingClientRect();
+    width = rect.width;
+    height = Math.max(rect.height, CONFIG.minHeight);
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    canvas.style.width = width + 'px';
+    canvas.style.height = height + 'px';
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  }
+
+  // --- Event Binding ---
+  let boundHandlers = {};
+
+  function bindEvents() {
+    boundHandlers.mouseMove = (e) => {
+      const rect = canvas.getBoundingClientRect();
+      mouse.x = e.clientX - rect.left;
+      mouse.y = e.clientY - rect.top;
+      if (dragNode) {
+        dragNode.x = mouse.x - dragOffset.x;
+        dragNode.y = mouse.y - dragOffset.y;
+        dragNode.vx = 0;
+        dragNode.vy = 0;
+        dragNode.pinned = true;
+      }
+      updateHover();
+    };
+    boundHandlers.mouseDown = (e) => {
+      mouse.down = true;
+      const node = getNodeAt(mouse.x, mouse.y);
+      if (node) {
+        dragNode = node;
+        dragOffset.x = mouse.x - node.x;
+        dragOffset.y = mouse.y - node.y;
+        canvas.style.cursor = 'grabbing';
+      }
+    };
+    boundHandlers.mouseUp = () => {
+      if (dragNode) {
+        // If barely moved, treat as click
+        const dx = mouse.x - (dragNode.x + dragOffset.x);
+        const dy = mouse.y - (dragNode.y + dragOffset.y);
+        if (Math.abs(dx) < 3 && Math.abs(dy) < 3) {
+          selectNode(dragNode.id);
+        }
+        dragNode.pinned = false;
+        dragNode = null;
+        canvas.style.cursor = 'default';
+      }
+      mouse.down = false;
+    };
+    boundHandlers.resize = () => {
+      resize();
+      // Re-center nodes if needed
+      graphNodes.forEach(n => {
+        n.x = Math.min(Math.max(n.x, CONFIG.padding), width - CONFIG.padding);
+        n.y = Math.min(Math.max(n.y, CONFIG.padding), height - CONFIG.padding);
+      });
+    };
+    boundHandlers.click = (e) => {
+      const node = getNodeAt(mouse.x, mouse.y);
+      if (!node && !dragNode) {
+        selectNode(null);
+      }
+    };
+
+    canvas.addEventListener('mousemove', boundHandlers.mouseMove);
+    canvas.addEventListener('mousedown', boundHandlers.mouseDown);
+    canvas.addEventListener('mouseup', boundHandlers.mouseUp);
+    canvas.addEventListener('mouseleave', () => {
+      hoveredNodeId = null;
+      if (dragNode) { dragNode.pinned = false; dragNode = null; }
+      mouse.down = false;
+      canvas.style.cursor = 'default';
+    });
+    canvas.addEventListener('click', boundHandlers.click);
+    window.addEventListener('resize', boundHandlers.resize);
+  }
+
+  function unbindEvents() {
+    if (!canvas) return;
+    canvas.removeEventListener('mousemove', boundHandlers.mouseMove);
+    canvas.removeEventListener('mousedown', boundHandlers.mouseDown);
+    canvas.removeEventListener('mouseup', boundHandlers.mouseUp);
+    canvas.removeEventListener('click', boundHandlers.click);
+    window.removeEventListener('resize', boundHandlers.resize);
+  }
+
+  function updateHover() {
+    const node = getNodeAt(mouse.x, mouse.y);
+    const newHovered = node ? node.id : null;
+    if (newHovered !== hoveredNodeId) {
+      hoveredNodeId = newHovered;
+      canvas.style.cursor = newHovered ? 'grab' : 'default';
+      if (dragNode) canvas.style.cursor = 'grabbing';
+    }
+  }
+
+  function getNodeAt(mx, my) {
+    // Reverse order so topmost (last drawn) is checked first
+    for (let i = graphNodes.length - 1; i >= 0; i--) {
+      const n = graphNodes[i];
+      const nw = CONFIG.nodeWidth;
+      const nh = getNodeHeight(n);
+      if (mx >= n.x - nw/2 && mx <= n.x + nw/2 &&
+          my >= n.y - nh/2 && my <= n.y + nh/2) {
+        return n;
+      }
+    }
+    return null;
+  }
+
+  function getNodeHeight(n) {
+    const base = CONFIG.nodeHeight;
+    if (hoveredNodeId === n.id) return base + CONFIG.hoverExpandHeight;
+    return base;
+  }
+
+  function selectNode(id) {
+    selectedNodeId = id;
+    if (onSelectCallback) {
+      const node = graphNodes.find(n => n.id === id);
+      onSelectCallback(node ? node.data : null);
+    }
+  }
+
+  // --- Data Update ---
+  function update(nodesData) {
+    if (!nodesData || !Array.isArray(nodesData)) return;
+
+    const existingMap = {};
+    graphNodes.forEach(n => { existingMap[n.id] = n; });
+
+    const newIds = new Set(nodesData.map(n => n.node_id || n.id || 'local'));
+    const updatedNodes = [];
+
+    nodesData.forEach((nd, i) => {
+      const id = nd.node_id || nd.id || 'local';
+      let gn = existingMap[id];
+      if (gn) {
+        // Update data, keep position
+        gn.data = nd;
+      } else {
+        // New node — place with initial position
+        gn = {
+          id,
+          data: nd,
+          x: width / 2 + (Math.random() - 0.5) * 100,
+          y: height / 2 + (Math.random() - 0.5) * 100,
+          vx: 0,
+          vy: 0,
+          pinned: false,
+          targetAlpha: 1,
+          alpha: 0, // fade in
+        };
+      }
+      updatedNodes.push(gn);
+    });
+
+    graphNodes = updatedNodes;
+
+    // Build edges: all-to-all mesh for discovered cluster
+    graphEdges = [];
+    for (let i = 0; i < graphNodes.length; i++) {
+      for (let j = i + 1; j < graphNodes.length; j++) {
+        const a = graphNodes[i];
+        const b = graphNodes[j];
+        const aOnline = a.data.status === 'online';
+        const bOnline = b.data.status === 'online';
+        graphEdges.push({
+          source: a,
+          target: b,
+          solid: aOnline && bOnline,
+          label: 'LAN',
+        });
+      }
+    }
+
+    // If single node, position at center
+    if (graphNodes.length === 1) {
+      const n = graphNodes[0];
+      if (!n.pinned) {
+        n.x = width / 2;
+        n.y = height / 2;
+      }
+    }
+    // For 2-4 nodes, arrange in a circle initially if new
+    else if (graphNodes.length <= 4) {
+      layoutCircle(false);
+    }
+  }
+
+  function layoutCircle(force) {
+    const cx = width / 2;
+    const cy = height / 2;
+    const radius = Math.min(width, height) * 0.25;
+    graphNodes.forEach((n, i) => {
+      if (force || (n.alpha < 0.1 && !n.pinned)) {
+        const angle = (i / graphNodes.length) * Math.PI * 2 - Math.PI / 2;
+        n.x = cx + Math.cos(angle) * radius;
+        n.y = cy + Math.sin(angle) * radius;
+      }
+    });
+  }
+
+  // --- Physics ---
+  function simulate() {
+    const N = graphNodes.length;
+    if (N === 0) return;
+    if (N === 1) {
+      // Single node: gently drift to center
+      const n = graphNodes[0];
+      if (!n.pinned) {
+        n.vx += (width / 2 - n.x) * 0.02;
+        n.vy += (height / 2 - n.y) * 0.02;
+        n.vx *= CONFIG.damping;
+        n.vy *= CONFIG.damping;
+        n.x += n.vx;
+        n.y += n.vy;
+      }
+      n.alpha += (n.targetAlpha - n.alpha) * 0.05;
+      return;
+    }
+
+    // Repulsion between all node pairs
+    for (let i = 0; i < N; i++) {
+      for (let j = i + 1; j < N; j++) {
+        const a = graphNodes[i];
+        const b = graphNodes[j];
+        let dx = b.x - a.x;
+        let dy = b.y - a.y;
+        let dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist < 1) dist = 1;
+        const force = CONFIG.repulsionStrength / (dist * dist);
+        const fx = (dx / dist) * force;
+        const fy = (dy / dist) * force;
+        if (!a.pinned) { a.vx -= fx; a.vy -= fy; }
+        if (!b.pinned) { b.vx += fx; b.vy += fy; }
+      }
+    }
+
+    // Attraction along edges
+    graphEdges.forEach(edge => {
+      const a = edge.source;
+      const b = edge.target;
+      let dx = b.x - a.x;
+      let dy = b.y - a.y;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      const idealDist = 280;
+      const force = (dist - idealDist) * CONFIG.attractionStrength;
+      const fx = (dx / (dist || 1)) * force;
+      const fy = (dy / (dist || 1)) * force;
+      if (!a.pinned) { a.vx += fx; a.vy += fy; }
+      if (!b.pinned) { b.vx -= fx; b.vy -= fy; }
+    });
+
+    // Center gravity
+    const cx = width / 2;
+    const cy = height / 2;
+    graphNodes.forEach(n => {
+      if (n.pinned) return;
+      n.vx += (cx - n.x) * CONFIG.centerGravity;
+      n.vy += (cy - n.y) * CONFIG.centerGravity;
+      // Damping
+      n.vx *= CONFIG.damping;
+      n.vy *= CONFIG.damping;
+      // Apply
+      n.x += n.vx;
+      n.y += n.vy;
+      // Bounds
+      const hw = CONFIG.nodeWidth / 2 + 10;
+      const hh = CONFIG.nodeHeight / 2 + 10;
+      n.x = Math.max(hw, Math.min(width - hw, n.x));
+      n.y = Math.max(hh, Math.min(height - hh, n.y));
+      // Fade in
+      n.alpha += (n.targetAlpha - n.alpha) * 0.05;
+    });
+  }
+
+  // --- Rendering ---
+  function draw() {
+    const c = CONFIG.colors;
+    ctx.clearRect(0, 0, width, height);
+
+    // Background subtle grid
+    drawGrid();
+
+    // Draw edges
+    graphEdges.forEach(edge => drawEdge(edge));
+
+    // Draw nodes (selected on top)
+    const sorted = [...graphNodes].sort((a, b) => {
+      if (a.id === selectedNodeId) return 1;
+      if (b.id === selectedNodeId) return -1;
+      return 0;
+    });
+    sorted.forEach(n => drawNode(n));
+
+    // Single node: pulsing ring and subtitle
+    if (graphNodes.length === 1) {
+      drawSingleNodeEffects(graphNodes[0]);
+    }
+  }
+
+  function drawGrid() {
+    const c = CONFIG.colors;
+    ctx.strokeStyle = hexToRgba(c.border, 0.15);
+    ctx.lineWidth = 1;
+    const gridSize = 40;
+    for (let x = gridSize; x < width; x += gridSize) {
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, height);
+      ctx.stroke();
+    }
+    for (let y = gridSize; y < height; y += gridSize) {
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(width, y);
+      ctx.stroke();
+    }
+  }
+
+  function drawEdge(edge) {
+    const c = CONFIG.colors;
+    const a = edge.source;
+    const b = edge.target;
+    const alpha = Math.min(a.alpha, b.alpha) * 0.6;
+    if (alpha < 0.01) return;
+
+    ctx.save();
+    ctx.globalAlpha = alpha;
+    ctx.strokeStyle = edge.solid ? hexToRgba(c.accent, 0.4) : hexToRgba(c.textMuted, 0.3);
+    ctx.lineWidth = CONFIG.connectionWidth;
+    if (!edge.solid) {
+      ctx.setLineDash([6, 4]);
+    }
+    ctx.beginPath();
+    ctx.moveTo(a.x, a.y);
+    ctx.lineTo(b.x, b.y);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // Connection label at midpoint
+    const mx = (a.x + b.x) / 2;
+    const my = (a.y + b.y) / 2;
+    ctx.font = '10px Inter, -apple-system, sans-serif';
+    ctx.fillStyle = hexToRgba(c.textMuted, 0.7);
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    // Background pill for label
+    const labelText = edge.label || 'LAN';
+    const tw = ctx.measureText(labelText).width + 10;
+    ctx.fillStyle = hexToRgba(c.bgPrimary, 0.85);
+    roundRect(ctx, mx - tw/2, my - 8, tw, 16, 4);
+    ctx.fill();
+    ctx.fillStyle = hexToRgba(c.textMuted, 0.7);
+    ctx.fillText(labelText, mx, my);
+
+    ctx.restore();
+  }
+
+  function drawNode(n) {
+    const c = CONFIG.colors;
+    const d = n.data;
+    const isHovered = hoveredNodeId === n.id;
+    const isSelected = selectedNodeId === n.id;
+    const isLeader = d.is_leader;
+    const nw = CONFIG.nodeWidth;
+    const nh = getNodeHeight(n);
+    const x = n.x - nw / 2;
+    const y = n.y - nh / 2;
+    const r = CONFIG.nodeRadius;
+
+    ctx.save();
+    ctx.globalAlpha = n.alpha;
+
+    // Glow for leader
+    if (isLeader) {
+      const glowPulse = 0.15 + Math.sin(time * 3) * 0.08;
+      ctx.shadowColor = c.accent;
+      ctx.shadowBlur = 20 + Math.sin(time * 3) * 5;
+      ctx.fillStyle = hexToRgba(c.accent, glowPulse);
+      roundRect(ctx, x - 3, y - 3, nw + 6, nh + 6, r + 2);
+      ctx.fill();
+      ctx.shadowBlur = 0;
+    }
+
+    // Selected glow
+    if (isSelected) {
+      ctx.shadowColor = c.accent;
+      ctx.shadowBlur = 16;
+    }
+
+    // Node background
+    ctx.fillStyle = isHovered ? c.bgCardHover : c.bgCard;
+    roundRect(ctx, x, y, nw, nh, r);
+    ctx.fill();
+
+    // Border
+    ctx.strokeStyle = isLeader ? c.accent : isSelected ? c.borderActive : c.border;
+    ctx.lineWidth = isLeader || isSelected ? 2 : 1;
+    roundRect(ctx, x, y, nw, nh, r);
+    ctx.stroke();
+    ctx.shadowBlur = 0;
+
+    // Status indicator dot with pulse
+    const statusColor = d.status === 'online' ? c.green : d.status === 'starting' ? c.yellow : c.red;
+    const dotX = x + nw - 16;
+    const dotY = y + 16;
+    // Pulse ring for online
+    if (d.status === 'online') {
+      const pulseAlpha = 0.3 + Math.sin(time * 4) * 0.2;
+      const pulseR = 6 + Math.sin(time * 4) * 3;
+      ctx.fillStyle = hexToRgba(statusColor, pulseAlpha);
+      ctx.beginPath();
+      ctx.arc(dotX, dotY, pulseR, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    // Solid dot
+    ctx.fillStyle = statusColor;
+    ctx.beginPath();
+    ctx.arc(dotX, dotY, 4, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Leader crown indicator
+    if (isLeader) {
+      ctx.fillStyle = c.accent;
+      ctx.font = 'bold 9px Inter, -apple-system, sans-serif';
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'top';
+      // Crown icon as text
+      const crownX = x + 10;
+      const crownY = y + 6;
+      ctx.fillStyle = hexToRgba(c.accent, 0.8);
+      ctx.font = '11px Inter, -apple-system, sans-serif';
+      ctx.fillText('\u2605', crownX, crownY); // star
+      ctx.fillStyle = c.accent;
+      ctx.font = 'bold 9px Inter, -apple-system, sans-serif';
+      ctx.fillText('LEADER', crownX + 14, crownY + 1);
+    }
+
+    // Node name
+    const nameY = isLeader ? y + 22 : y + 14;
+    ctx.fillStyle = c.textPrimary;
+    ctx.font = 'bold 13px Inter, -apple-system, sans-serif';
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    const name = truncate(d.node_name || d.node_id || 'Node', 22);
+    ctx.fillText(name, x + 12, nameY);
+
+    // GPU name
+    ctx.fillStyle = c.textSecondary;
+    ctx.font = '11px Inter, -apple-system, sans-serif';
+    const gpuText = truncate(d.gpu_name || 'Unknown GPU', 28);
+    ctx.fillText(gpuText, x + 12, nameY + 18);
+
+    // Memory + model line
+    const memText = (d.gpu_memory_gb || '?') + ' GB';
+    const modelText = truncate(d.model || 'no model', 18);
+    ctx.fillStyle = c.textMuted;
+    ctx.font = '10px JetBrains Mono, Fira Code, monospace';
+    ctx.fillText(memText + '  |  ' + modelText, x + 12, nameY + 34);
+
+    // Hover expanded info
+    if (isHovered) {
+      const expandY = nameY + 52;
+      ctx.fillStyle = hexToRgba(c.border, 0.5);
+      ctx.fillRect(x + 12, expandY - 4, nw - 24, 1);
+
+      ctx.font = '10px Inter, -apple-system, sans-serif';
+      ctx.fillStyle = c.textSecondary;
+      const gpuUtil = d.gpu_utilization_pct != null ? d.gpu_utilization_pct + '%' : 'N/A';
+      const memUsed = d.gpu_memory_used_pct != null ? d.gpu_memory_used_pct + '%' : 'N/A';
+      const memLabel = d.unified_memory ? 'unified' : 'VRAM';
+      const uptime = d.uptime_seconds ? formatUptime(d.uptime_seconds) : 'N/A';
+      ctx.fillText('GPU: ' + gpuUtil + '   Mem: ' + memUsed + ' ' + memLabel, x + 12, expandY + 4);
+      ctx.fillText('Uptime: ' + uptime + '   Status: ' + (d.status || 'unknown'), x + 12, expandY + 20);
+
+      // Memory bar
+      const barX = x + 12;
+      const barY = expandY + 36;
+      const barW = nw - 24;
+      const barH = 4;
+      const pct = d.gpu_memory_used_pct || 0;
+      ctx.fillStyle = hexToRgba(c.bgPrimary, 0.8);
+      roundRect(ctx, barX, barY, barW, barH, 2);
+      ctx.fill();
+      const barColor = pct > 90 ? c.red : pct > 70 ? c.yellow : c.green;
+      ctx.fillStyle = barColor;
+      roundRect(ctx, barX, barY, barW * (pct / 100), barH, 2);
+      ctx.fill();
+    }
+
+    ctx.restore();
+  }
+
+  function drawSingleNodeEffects(n) {
+    const c = CONFIG.colors;
+    ctx.save();
+    ctx.globalAlpha = n.alpha;
+
+    // Pulsing ring
+    const pulsePhase = (time * 1.5) % (Math.PI * 2);
+    const ringRadius = CONFIG.nodeWidth * 0.75 + Math.sin(pulsePhase) * 10;
+    const ringAlpha = 0.1 + Math.sin(pulsePhase) * 0.05;
+    ctx.strokeStyle = hexToRgba(c.accent, ringAlpha);
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(n.x, n.y, ringRadius, 0, Math.PI * 2);
+    ctx.stroke();
+
+    // Second ring offset
+    const ring2Radius = CONFIG.nodeWidth * 0.95 + Math.cos(pulsePhase * 0.7) * 15;
+    const ring2Alpha = 0.06 + Math.cos(pulsePhase * 0.7) * 0.03;
+    ctx.strokeStyle = hexToRgba(c.accent, ring2Alpha);
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.arc(n.x, n.y, ring2Radius, 0, Math.PI * 2);
+    ctx.stroke();
+
+    // "Waiting for peers..." subtitle
+    ctx.font = '12px Inter, -apple-system, sans-serif';
+    ctx.fillStyle = hexToRgba(c.textMuted, 0.5 + Math.sin(time * 2) * 0.2);
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    ctx.fillText('Waiting for peers...', n.x, n.y + CONFIG.nodeHeight / 2 + 20);
+
+    // Scanning dots
+    for (let i = 0; i < 3; i++) {
+      const dotAngle = time * 0.8 + (i * Math.PI * 2 / 3);
+      const dotR = CONFIG.nodeWidth * 0.85;
+      const dx = n.x + Math.cos(dotAngle) * dotR;
+      const dy = n.y + Math.sin(dotAngle) * dotR;
+      const dotAlpha = 0.15 + Math.sin(time * 3 + i) * 0.1;
+      ctx.fillStyle = hexToRgba(c.accent, dotAlpha);
+      ctx.beginPath();
+      ctx.arc(dx, dy, 3, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    ctx.restore();
+  }
+
+  // --- Utilities ---
+  function roundRect(ctx, x, y, w, h, r) {
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.lineTo(x + w - r, y);
+    ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+    ctx.lineTo(x + w, y + h - r);
+    ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+    ctx.lineTo(x + r, y + h);
+    ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+    ctx.lineTo(x, y + r);
+    ctx.quadraticCurveTo(x, y, x + r, y);
+    ctx.closePath();
+  }
+
+  function truncate(str, max) {
+    if (!str) return '';
+    return str.length > max ? str.slice(0, max - 1) + '\u2026' : str;
+  }
+
+  function formatUptime(seconds) {
+    if (seconds < 60) return seconds + 's';
+    if (seconds < 3600) return Math.floor(seconds / 60) + 'm';
+    return Math.floor(seconds / 3600) + 'h ' + Math.floor((seconds % 3600) / 60) + 'm';
+  }
+
+  // --- Animation Loop ---
+  function startLoop() {
+    function frame(ts) {
+      time = ts * CONFIG.pulseSpeed;
+      simulate();
+      draw();
+      animFrameId = requestAnimationFrame(frame);
+    }
+    animFrameId = requestAnimationFrame(frame);
+  }
+
+  // --- Public API ---
+  return {
+    init,
+    destroy,
+    update,
+    resize,
+    getSelectedNodeId: () => selectedNodeId,
+  };
+})();

--- a/ainode/web/templates/index.html
+++ b/ainode/web/templates/index.html
@@ -70,10 +70,13 @@
         </div>
 
         <div class="card-header" style="margin-bottom:12px">
-          <div class="card-title">Nodes</div>
+          <div class="card-title">Cluster Topology</div>
         </div>
-        <div id="dashboard-nodes" class="grid-3" style="margin-bottom:24px">
-          <!-- Filled by JS -->
+        <div id="topology-container" class="topology-container" style="margin-bottom:24px">
+          <canvas id="topology-canvas"></canvas>
+        </div>
+        <div id="topology-detail" class="topology-detail" style="display:none; margin-bottom:24px">
+          <!-- Filled by JS on node click -->
         </div>
 
         <div id="dashboard-health">
@@ -135,6 +138,7 @@
     </main>
   </div>
 
+  <script src="/static/js/topology.js"></script>
   <script src="/static/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace static node card grid with a canvas-based force-directed topology visualization
- New `topology.js` (zero dependencies) renders nodes as rounded rectangles with GPU info, status indicators (pulsing green/yellow/red), and leader crown/glow
- Connections between nodes shown as solid (online) or dashed (stale) lines with "LAN" labels
- Single-node mode shows pulsing rings and scanning dots with "Waiting for peers..." subtitle
- Click a node to expand a detail panel below with GPU utilization, memory bar, uptime
- Drag nodes to reposition; physics simulation with repulsion, attraction, and center gravity
- 60fps animation via requestAnimationFrame, responsive to container resizing
- Dark theme using existing CSS variables

## Test plan
- [x] `pytest tests/` passes (238 tests, 0 failures)
- [ ] Open dashboard with 1 node — verify centered node with pulsing ring animation
- [ ] Verify node shows GPU name, memory, model, and green status pulse
- [ ] Click node — detail panel appears below with full stats
- [ ] Test with multiple nodes via cluster discovery — verify force-directed layout and connection lines
- [ ] Resize browser window — canvas adapts responsively
- [ ] Drag a node — verify it follows mouse and settles back with physics

Generated with [Claude Code](https://claude.com/claude-code)