### PR TITLE
Add real-time monitoring widgets to dashboard

### DIFF
--- a/ainode/web/static/css/style.css
+++ b/ainode/web/static/css/style.css
@@ -1426,6 +1426,153 @@ body {
   background: var(--text-muted);
 }
 
+/* --- Monitoring Widgets --- */
+
+.monitoring-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1.5fr;
+  gap: 16px;
+}
+
+.monitoring-card {
+  display: flex;
+  flex-direction: column;
+}
+
+.gauge-container {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 0;
+}
+
+.arc-gauge {
+  width: 170px;
+  height: 140px;
+}
+
+.gauge-pct {
+  font-family: var(--font-mono);
+  font-size: 28px;
+  font-weight: 700;
+  fill: var(--text-primary);
+}
+
+.gauge-label {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  fill: var(--text-secondary);
+}
+
+.arc-gauge-fill {
+  filter: drop-shadow(0 0 6px currentColor);
+  transition: stroke 0.6s ease;
+}
+
+.temp-section {
+  margin-bottom: 16px;
+}
+
+.temp-bar-wrap {
+  padding: 4px 0;
+}
+
+.temp-value {
+  font-family: var(--font-mono);
+  font-size: 28px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.temp-bar {
+  width: 100%;
+  height: 8px;
+  background: var(--bg-primary);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.temp-bar-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.6s ease, background 0.6s ease;
+}
+
+.temp-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 10px;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+
+.metrics-table td {
+  padding: 6px 8px;
+  font-size: 13px;
+}
+
+.metrics-table td:first-child {
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.metric-val {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  text-align: right;
+}
+
+.metric-err {
+  color: var(--red);
+}
+
+.metric-model {
+  color: var(--accent);
+  font-size: 12px;
+  word-break: break-all;
+}
+
+.request-section {
+  margin-bottom: 12px;
+}
+
+.inference-section {
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
+}
+
+.inference-stats {
+  display: flex;
+  gap: 24px;
+}
+
+.inference-stat {
+  display: flex;
+  flex-direction: column;
+}
+
+.inference-num {
+  font-family: var(--font-mono);
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-primary);
+  line-height: 1;
+}
+
+.inference-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-top: 4px;
+}
+
+.monitoring-right-panel {
+  display: flex;
+  flex-direction: column;
+}
+
 /* Responsive */
 @media (max-width: 1024px) {
   .grid-4 { grid-template-columns: repeat(2, 1fr); }
@@ -1433,6 +1580,7 @@ body {
   .training-detail-grid { grid-template-columns: 1fr; }
   .training-config-card { position: static; }
   .training-stat-row { grid-template-columns: repeat(2, 1fr); }
+  .monitoring-grid { grid-template-columns: 1fr 1fr; }
 }
 
 @media (max-width: 768px) {
@@ -1447,6 +1595,7 @@ body {
   .model-detail { padding-left: 20px; }
   .model-detail-grid { grid-template-columns: 1fr 1fr; }
   .models-disk-space { display: none; }
+  .monitoring-grid { grid-template-columns: 1fr; }
 }
 
 /* Loading skeleton */


### PR DESCRIPTION
## Summary
- Adds CSS styles for the monitoring widgets section on the dashboard (GPU utilization gauge, memory ring, temperature bar, request metrics panel, inference stats)
- SVG arc gauge styles with animated color transitions (green/yellow/red thresholds)
- Temperature bar with color-coded ranges (blue <50C, green 50-70C, yellow 70-85C, red >85C)
- Compact request metrics table, inference stats display, and responsive grid layout
- Responsive: 3-column grid on desktop, 2-column on tablet, single column on mobile

Note: The JS logic (metrics polling, gauge rendering, monitoring section HTML generation) and HTML container div were committed to dev in a prior merge. This PR adds the corresponding CSS styles to complete the feature.

## Test plan
- [ ] Verify monitoring section renders between stat cards and nodes on the dashboard
- [ ] Confirm GPU utilization gauge animates with color transitions at 60%/85% thresholds
- [ ] Confirm memory ring displays used/total GB with proper gauge fill
- [ ] Verify temperature bar color-codes correctly by range
- [ ] Check request metrics table shows total, req/min, error rate, latency percentiles
- [ ] Verify inference stats appear when tokens are being generated
- [ ] Test responsive layout at 1024px and 768px breakpoints
- [ ] Run `pytest tests/` -- all 238 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)