### PR TITLE
Dashboard polish: topology graph, GPU gauges, chat UX, model management

### DIFF
--- a/ainode/web/static/css/style.css
+++ b/ainode/web/static/css/style.css
@@ -1426,6 +1426,153 @@ body {
   background: var(--text-muted);
 }
 
+/* --- Monitoring Widgets --- */
+
+.monitoring-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1.5fr;
+  gap: 16px;
+}
+
+.monitoring-card {
+  display: flex;
+  flex-direction: column;
+}
+
+.gauge-container {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 0;
+}
+
+.arc-gauge {
+  width: 170px;
+  height: 140px;
+}
+
+.gauge-pct {
+  font-family: var(--font-mono);
+  font-size: 28px;
+  font-weight: 700;
+  fill: var(--text-primary);
+}
+
+.gauge-label {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  fill: var(--text-secondary);
+}
+
+.arc-gauge-fill {
+  filter: drop-shadow(0 0 6px currentColor);
+  transition: stroke 0.6s ease;
+}
+
+.temp-section {
+  margin-bottom: 16px;
+}
+
+.temp-bar-wrap {
+  padding: 4px 0;
+}
+
+.temp-value {
+  font-family: var(--font-mono);
+  font-size: 28px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.temp-bar {
+  width: 100%;
+  height: 8px;
+  background: var(--bg-primary);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.temp-bar-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.6s ease, background 0.6s ease;
+}
+
+.temp-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 10px;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+
+.metrics-table td {
+  padding: 6px 8px;
+  font-size: 13px;
+}
+
+.metrics-table td:first-child {
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.metric-val {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  text-align: right;
+}
+
+.metric-err {
+  color: var(--red);
+}
+
+.metric-model {
+  color: var(--accent);
+  font-size: 12px;
+  word-break: break-all;
+}
+
+.request-section {
+  margin-bottom: 12px;
+}
+
+.inference-section {
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
+}
+
+.inference-stats {
+  display: flex;
+  gap: 24px;
+}
+
+.inference-stat {
+  display: flex;
+  flex-direction: column;
+}
+
+.inference-num {
+  font-family: var(--font-mono);
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-primary);
+  line-height: 1;
+}
+
+.inference-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-top: 4px;
+}
+
+.monitoring-right-panel {
+  display: flex;
+  flex-direction: column;
+}
+
 /* Responsive */
 @media (max-width: 1024px) {
   .grid-4 { grid-template-columns: repeat(2, 1fr); }
@@ -1433,6 +1580,7 @@ body {
   .training-detail-grid { grid-template-columns: 1fr; }
   .training-config-card { position: static; }
   .training-stat-row { grid-template-columns: repeat(2, 1fr); }
+  .monitoring-grid { grid-template-columns: 1fr 1fr; }
 }
 
 @media (max-width: 768px) {
@@ -1447,6 +1595,7 @@ body {
   .model-detail { padding-left: 20px; }
   .model-detail-grid { grid-template-columns: 1fr 1fr; }
   .models-disk-space { display: none; }
+  .monitoring-grid { grid-template-columns: 1fr; }
 }
 
 /* Loading skeleton */

--- a/ainode/web/static/css/style.css
+++ b/ainode/web/static/css/style.css
@@ -1112,3 +1112,71 @@ body {
   0% { background-position: -200% 0; }
   100% { background-position: 200% 0; }
 }
+
+/* ===== Chat Enhancements ===== */
+
+.chat-layout { display: flex; height: calc(100vh - 48px); margin: -24px -32px; }
+
+.chat-history-panel { width: 240px; min-width: 240px; background: var(--bg-secondary); border-right: 1px solid var(--border); display: flex; flex-direction: column; transition: width 0.2s ease, min-width 0.2s ease, opacity 0.2s ease; overflow: hidden; }
+.chat-history-panel.collapsed { width: 0; min-width: 0; opacity: 0; border-right: none; }
+.chat-history-header { display: flex; align-items: center; justify-content: space-between; padding: 12px; border-bottom: 1px solid var(--border); gap: 8px; }
+.chat-new-btn { flex: 1; }
+.btn-sm { padding: 6px 12px; font-size: 12px; }
+.btn-icon { padding: 6px; min-width: 32px; display: flex; align-items: center; justify-content: center; }
+.chat-history-list { flex: 1; overflow-y: auto; padding: 8px; }
+.chat-history-empty { text-align: center; color: var(--text-muted); font-size: 13px; padding: 24px 12px; }
+.chat-history-item { display: flex; align-items: center; justify-content: space-between; padding: 8px 10px; border-radius: var(--radius-sm); cursor: pointer; transition: background 0.15s ease; margin-bottom: 2px; }
+.chat-history-item:hover { background: var(--bg-card); }
+.chat-history-item.active { background: var(--bg-card); border: 1px solid var(--border-active); }
+.chat-history-item-content { flex: 1; min-width: 0; }
+.chat-history-item-title { font-size: 13px; font-weight: 500; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.chat-history-item-date { font-size: 11px; color: var(--text-muted); margin-top: 2px; }
+.chat-history-delete { background: none; border: none; color: var(--text-muted); font-size: 16px; cursor: pointer; padding: 2px 6px; border-radius: 4px; opacity: 0; transition: opacity 0.15s, color 0.15s; flex-shrink: 0; }
+.chat-history-item:hover .chat-history-delete { opacity: 1; }
+.chat-history-delete:hover { color: var(--red); background: var(--red-glow); }
+
+.chat-main { flex: 1; padding: 24px 32px; display: flex; flex-direction: column; min-width: 0; }
+.chat-main .chat-container { height: auto; flex: 1; }
+.chat-history-open-btn { flex-shrink: 0; }
+
+/* Streaming Metrics Bar */
+.chat-metrics-bar { display: flex; align-items: center; gap: 8px; padding: 6px 12px; background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius-sm); margin-bottom: 8px; font-family: var(--font-mono); font-size: 12px; color: var(--text-secondary); }
+.chat-metric-sep { color: var(--text-muted); }
+
+/* Stop Button */
+.chat-send.chat-stop { background: var(--red); }
+.chat-send.chat-stop:hover { background: #dc2626; }
+
+/* Copy Button */
+.chat-message { position: relative; }
+.chat-copy-btn { position: absolute; top: 8px; right: 8px; background: var(--bg-secondary); border: 1px solid var(--border); border-radius: 6px; padding: 4px 6px; cursor: pointer; color: var(--text-muted); opacity: 0; transition: opacity 0.15s ease, color 0.15s ease; display: flex; align-items: center; justify-content: center; }
+.chat-message:hover .chat-copy-btn { opacity: 1; }
+.chat-copy-btn:hover { color: var(--text-primary); border-color: var(--border-active); }
+
+/* Empty State */
+.chat-empty-state { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%; min-height: 300px; text-align: center; padding: 40px 20px; }
+.chat-empty-icon { color: var(--text-muted); opacity: 0.3; margin-bottom: 16px; }
+.chat-empty-title { font-size: 20px; font-weight: 600; color: var(--text-secondary); margin-bottom: 8px; }
+.chat-empty-desc { font-size: 14px; color: var(--text-muted); margin-bottom: 24px; }
+.chat-suggested-prompts { display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; max-width: 600px; }
+.chat-prompt-chip { background: var(--bg-card); border: 1px solid var(--border); border-radius: 20px; padding: 8px 16px; font-size: 13px; color: var(--text-secondary); cursor: pointer; transition: all 0.15s ease; font-family: var(--font-sans); }
+.chat-prompt-chip:hover { border-color: var(--accent); color: var(--accent); background: rgba(74, 144, 217, 0.08); }
+
+/* Toast Notifications */
+.toast-container { position: fixed; bottom: 24px; right: 24px; z-index: 9999; display: flex; flex-direction: column-reverse; gap: 8px; pointer-events: none; }
+.toast { display: flex; align-items: center; gap: 8px; padding: 10px 16px; border-radius: var(--radius-sm); font-size: 13px; font-weight: 500; color: white; pointer-events: auto; transform: translateX(120%); opacity: 0; transition: transform 0.3s ease, opacity 0.3s ease; box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4); max-width: 360px; }
+.toast-visible { transform: translateX(0); opacity: 1; }
+.toast-fade-out { transform: translateX(120%); opacity: 0; }
+.toast-success { background: var(--green); }
+.toast-error { background: var(--red); }
+.toast-info { background: var(--accent); }
+.toast-warning { background: var(--yellow); color: #1a1a1a; }
+.toast-message { flex: 1; }
+.toast-close { background: none; border: none; color: inherit; font-size: 18px; cursor: pointer; padding: 0 2px; opacity: 0.7; transition: opacity 0.15s; }
+.toast-close:hover { opacity: 1; }
+
+@media (max-width: 768px) {
+  .chat-history-panel { display: none; }
+  .chat-main { padding: 16px; }
+  .chat-layout { margin: -16px; }
+}

--- a/ainode/web/static/css/style.css
+++ b/ainode/web/static/css/style.css
@@ -461,41 +461,253 @@ body {
   margin-bottom: 12px;
 }
 
-/* Models list */
-.model-card {
+/* Models toolbar */
+.models-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.models-search-wrap {
+  position: relative;
+}
+
+.models-search-icon {
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+.models-search {
+  width: 100%;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px 14px 10px 40px;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-family: var(--font-sans);
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.models-search:focus {
+  border-color: var(--accent);
+}
+
+.models-search::placeholder {
+  color: var(--text-muted);
+}
+
+.models-filters {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+  -webkit-overflow-scrolling: touch;
+}
+
+.filter-pill {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 6px 16px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s ease;
+  font-family: var(--font-sans);
+}
+
+.filter-pill:hover {
+  border-color: var(--border-active);
+  color: var(--text-primary);
+}
+
+.filter-pill.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: white;
+}
+
+.models-sort {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.models-sort-label {
+  font-size: 12px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.models-sort-select {
+  width: auto;
+  min-width: 140px;
+  padding: 6px 32px 6px 10px;
+  font-size: 13px;
+}
+
+.models-disk-space {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-muted);
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 14px;
+  white-space: nowrap;
+}
+
+.models-disk-space svg {
+  flex-shrink: 0;
+}
+
+.models-empty {
+  text-align: center;
+  padding: 60px 20px;
+  color: var(--text-muted);
+}
+
+/* Enhanced model cards */
+.model-card-enhanced {
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 20px;
+  margin-bottom: 8px;
+  transition: all 0.15s ease;
+  overflow: hidden;
+}
+
+.model-card-enhanced:hover {
+  border-color: var(--border-active);
+}
+
+.model-card-enhanced.model-active {
+  border-color: var(--green);
+  box-shadow: 0 0 12px var(--green-glow);
+}
+
+.model-card-enhanced.model-expanded {
+  border-color: var(--accent);
+}
+
+.model-card-main {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  transition: border-color 0.15s ease;
-  margin-bottom: 8px;
+  padding: 16px 20px;
+  cursor: pointer;
+  gap: 16px;
 }
 
-.model-card:hover {
-  border-color: var(--border-active);
+.model-card-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+  min-width: 0;
+}
+
+.model-card-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+}
+
+/* GPU fit indicators */
+.gpu-fit {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.gpu-fit-yes {
+  background: var(--green-glow);
+  color: var(--green);
+}
+
+.gpu-fit-warn {
+  background: var(--yellow-glow);
+  color: var(--yellow);
+}
+
+.gpu-fit-no {
+  background: var(--red-glow);
+  color: var(--red);
 }
 
 .model-info {
   flex: 1;
+  min-width: 0;
+}
+
+.model-name-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 4px;
 }
 
 .model-name {
   font-size: 15px;
   font-weight: 600;
   font-family: var(--font-mono);
-  margin-bottom: 4px;
+}
+
+.model-quant-badge {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  background: rgba(139, 92, 246, 0.15);
+  color: var(--purple);
+  border: 1px solid rgba(139, 92, 246, 0.3);
+}
+
+.model-active-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  background: var(--green-glow);
+  color: var(--green);
+  border: 1px solid var(--green);
+  animation: pulse 2s infinite;
 }
 
 .model-meta {
-  font-size: 12px;
-  color: var(--text-muted);
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-bottom: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.model-status {
-  text-align: right;
+.model-meta-stats {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
 }
 
 .model-badge {
@@ -506,6 +718,7 @@ body {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
+  white-space: nowrap;
 }
 
 .model-badge.loaded {
@@ -518,6 +731,137 @@ body {
   background: rgba(74, 144, 217, 0.1);
   color: var(--accent);
   border: 1px solid var(--accent);
+}
+
+.model-badge.active {
+  background: var(--green-glow);
+  color: var(--green);
+  border: 1px solid var(--green);
+}
+
+.model-badge.downloading {
+  background: var(--yellow-glow);
+  color: var(--yellow);
+  border: 1px solid var(--yellow);
+  animation: pulse 1.5s infinite;
+}
+
+/* Model progress bar */
+.model-progress-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 120px;
+}
+
+.model-progress-bar {
+  height: 6px;
+}
+
+.model-progress-animated {
+  background: linear-gradient(90deg, var(--accent) 0%, var(--accent-hover) 50%, var(--accent) 100%);
+  background-size: 200% 100%;
+  animation: progress-shimmer 2s infinite linear;
+}
+
+.model-progress-text {
+  font-size: 10px;
+  color: var(--text-muted);
+  text-align: right;
+}
+
+/* Button sizes */
+.btn-sm {
+  padding: 6px 12px;
+  font-size: 12px;
+}
+
+/* Model detail expansion */
+.model-detail {
+  padding: 0 20px 16px 60px;
+  border-top: 1px solid var(--border);
+  animation: slideDown 0.2s ease;
+}
+
+@keyframes slideDown {
+  from { opacity: 0; max-height: 0; }
+  to { opacity: 1; max-height: 300px; }
+}
+
+.model-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 12px;
+  padding-top: 12px;
+}
+
+.model-detail-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.model-detail-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.model-detail-value {
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.model-detail-value.mono {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  word-break: break-all;
+}
+
+/* Delete confirmation modal */
+.model-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  backdrop-filter: blur(4px);
+}
+
+.model-modal {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 24px;
+  max-width: 440px;
+  width: 90%;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4);
+}
+
+.model-modal h3 {
+  font-size: 18px;
+  font-weight: 700;
+  margin-bottom: 12px;
+}
+
+.model-modal p {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin-bottom: 20px;
+}
+
+.model-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
 }
 
 /* --- Training Section --- */
@@ -1098,6 +1442,11 @@ body {
   .training-header { flex-direction: column; }
   .training-stat-row { grid-template-columns: repeat(2, 1fr); }
   .form-grid, .method-toggle { grid-template-columns: 1fr; }
+  .model-card-main { flex-direction: column; align-items: flex-start; }
+  .model-card-right { width: 100%; justify-content: space-between; }
+  .model-detail { padding-left: 20px; }
+  .model-detail-grid { grid-template-columns: 1fr 1fr; }
+  .models-disk-space { display: none; }
 }
 
 /* Loading skeleton */

--- a/ainode/web/static/css/style.css
+++ b/ainode/web/static/css/style.css
@@ -1112,3 +1112,96 @@ body {
   0% { background-position: -200% 0; }
   100% { background-position: 200% 0; }
 }
+
+/* Topology Graph */
+.topology-container {
+  position: relative;
+  width: 100%;
+  min-height: 360px;
+  height: 420px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.topology-container canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.topology-detail {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+  animation: topologyDetailIn 0.2s ease;
+}
+
+@keyframes topologyDetailIn {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.topology-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.topology-detail-name {
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.topology-detail-id {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  margin-top: 2px;
+}
+
+.topology-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+
+.topology-detail-stat {
+  background: var(--bg-secondary);
+  border-radius: var(--radius-sm);
+  padding: 12px 16px;
+}
+
+.topology-detail-stat .stat-value {
+  font-size: 20px;
+}
+
+.topology-detail-close {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  padding: 6px 12px;
+  font-size: 12px;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: all 0.15s ease;
+}
+
+.topology-detail-close:hover {
+  background: var(--bg-card-hover);
+  color: var(--text-primary);
+}
+
+@media (max-width: 1024px) {
+  .topology-detail-grid { grid-template-columns: repeat(2, 1fr); }
+  .topology-container { height: 360px; }
+}
+
+@media (max-width: 768px) {
+  .topology-detail-grid { grid-template-columns: 1fr; }
+  .topology-container { height: 300px; min-height: 300px; }
+}

--- a/ainode/web/static/js/app.js
+++ b/ainode/web/static/js/app.js
@@ -12,54 +12,133 @@ const AINode = {
     trainingView: 'list',
     trainingDetailId: null,
     trainingLossData: [],
+    currentConversationId: null,
+    conversations: [],
+    abortController: null,
+    historyVisible: true,
+    streamMetrics: { ttft: null, tps: 0, tokenCount: 0, startTime: 0, firstTokenTime: 0 },
   },
 
-  // --- Initialization ---
   init() {
+    this.loadConversations();
     this.bindNav();
     this.bindChat();
     this.navigate(window.location.hash.slice(1) || 'dashboard');
     this.startPolling();
   },
 
+  // --- Toast Notification System ---
+  toast(message, type) {
+    type = type || 'info';
+    var container = document.getElementById('toast-container');
+    if (!container) return;
+    var toast = document.createElement('div');
+    toast.className = 'toast toast-' + type;
+    toast.innerHTML = '<span class="toast-message">' + this.esc(message) + '</span><button class="toast-close">&times;</button>';
+    container.appendChild(toast);
+    requestAnimationFrame(function() { toast.classList.add('toast-visible'); });
+    var dismiss = function() {
+      toast.classList.remove('toast-visible');
+      toast.classList.add('toast-fade-out');
+      setTimeout(function() { toast.remove(); }, 300);
+    };
+    toast.querySelector('.toast-close').addEventListener('click', dismiss);
+    setTimeout(dismiss, 4000);
+  },
+
+  // --- Conversation History ---
+  loadConversations() {
+    try { this.state.conversations = JSON.parse(localStorage.getItem('ainode_conversations') || '[]'); }
+    catch(e) { this.state.conversations = []; }
+  },
+  saveConversations() { localStorage.setItem('ainode_conversations', JSON.stringify(this.state.conversations)); },
+  getCurrentConversation() { return this.state.conversations.find(c => c.id === this.state.currentConversationId) || null; },
+
+  newConversation() {
+    var id = 'conv_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8);
+    var sel = document.getElementById('chat-model');
+    var conv = { id: id, title: 'New Chat', messages: [], created_at: Date.now(), model: sel ? sel.value : '' };
+    this.state.conversations.unshift(conv);
+    this.state.currentConversationId = id;
+    this.state.messages = [];
+    this.saveConversations();
+    this.renderConversationList();
+    this.renderMessages();
+  },
+
+  loadConversation(id) {
+    var conv = this.state.conversations.find(c => c.id === id);
+    if (!conv) return;
+    this.state.currentConversationId = id;
+    this.state.messages = conv.messages.slice();
+    var select = document.getElementById('chat-model');
+    if (select && conv.model) { for (var i = 0; i < select.options.length; i++) { if (select.options[i].value === conv.model) { select.value = conv.model; break; } } }
+    this.renderConversationList();
+    this.renderMessages();
+  },
+
+  deleteConversation(id) {
+    this.state.conversations = this.state.conversations.filter(c => c.id !== id);
+    if (this.state.currentConversationId === id) { this.state.currentConversationId = null; this.state.messages = []; this.renderMessages(); }
+    this.saveConversations();
+    this.renderConversationList();
+    this.toast('Conversation deleted', 'info');
+  },
+
+  saveCurrentConversation() {
+    var conv = this.getCurrentConversation();
+    if (!conv) return;
+    conv.messages = this.state.messages.slice();
+    var sel = document.getElementById('chat-model');
+    if (sel) conv.model = sel.value || conv.model;
+    var firstUser = conv.messages.find(m => m.role === 'user');
+    if (firstUser) conv.title = firstUser.content.slice(0, 30) + (firstUser.content.length > 30 ? '...' : '');
+    this.saveConversations();
+    this.renderConversationList();
+  },
+
+  renderConversationList() {
+    var list = document.getElementById('chat-history-list');
+    if (!list) return;
+    var self = this;
+    if (this.state.conversations.length === 0) { list.innerHTML = '<div class="chat-history-empty">No conversations yet</div>'; return; }
+    list.innerHTML = this.state.conversations.map(function(conv) {
+      var active = conv.id === self.state.currentConversationId ? ' active' : '';
+      var dateStr = new Date(conv.created_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+      return '<div class="chat-history-item' + active + '" data-conv-id="' + self.esc(conv.id) + '"><div class="chat-history-item-content"><div class="chat-history-item-title">' + self.esc(conv.title) + '</div><div class="chat-history-item-date">' + dateStr + '</div></div><button class="chat-history-delete" data-delete-id="' + self.esc(conv.id) + '" title="Delete">&times;</button></div>';
+    }).join('');
+    list.querySelectorAll('.chat-history-item').forEach(function(el) { el.addEventListener('click', function(e) { if (e.target.closest('.chat-history-delete')) return; self.loadConversation(el.dataset.convId); }); });
+    list.querySelectorAll('.chat-history-delete').forEach(function(btn) { btn.addEventListener('click', function(e) { e.stopPropagation(); self.deleteConversation(btn.dataset.deleteId); }); });
+  },
+
+  toggleHistory() {
+    var panel = document.getElementById('chat-history-panel');
+    var openBtn = document.getElementById('chat-history-open');
+    if (!panel) return;
+    this.state.historyVisible = !this.state.historyVisible;
+    panel.classList.toggle('collapsed', !this.state.historyVisible);
+    if (openBtn) openBtn.style.display = this.state.historyVisible ? 'none' : '';
+  },
+
   // --- Navigation ---
   bindNav() {
-    document.querySelectorAll('.nav-item').forEach(el => {
-      el.addEventListener('click', () => {
-        const view = el.dataset.view;
-        if (view) this.navigate(view);
-      });
-    });
+    var self = this;
+    document.querySelectorAll('.nav-item').forEach(function(el) { el.addEventListener('click', function() { var view = el.dataset.view; if (view) self.navigate(view); }); });
   },
 
   navigate(view) {
     this.state.currentView = view;
     window.location.hash = view;
-    document.querySelectorAll('.nav-item').forEach(el => {
-      el.classList.toggle('active', el.dataset.view === view);
-    });
-    document.querySelectorAll('.view').forEach(el => {
-      el.style.display = el.id === `view-${view}` ? 'block' : 'none';
-    });
+    document.querySelectorAll('.nav-item').forEach(function(el) { el.classList.toggle('active', el.dataset.view === view); });
+    document.querySelectorAll('.view').forEach(function(el) { el.style.display = el.id === 'view-' + view ? 'block' : 'none'; });
+    if (view === 'chat') { this.renderConversationList(); this.renderMessages(); }
     this.refresh();
   },
 
-  // --- Data Fetching ---
-  async fetchJSON(url) {
-    try {
-      const resp = await fetch(url);
-      if (!resp.ok) return null;
-      return await resp.json();
-    } catch {
-      return null;
-    }
-  },
+  async fetchJSON(url) { try { const resp = await fetch(url); if (!resp.ok) return null; return await resp.json(); } catch(e) { return null; } },
 
   async refresh() {
-    const [status, nodes] = await Promise.all([
-      this.fetchJSON('/api/status'),
-      this.fetchJSON('/api/nodes'),
-    ]);
+    const [status, nodes] = await Promise.all([this.fetchJSON('/api/status'), this.fetchJSON('/api/nodes')]);
     this.state.status = status;
     this.state.nodes = nodes?.nodes || [];
     switch (this.state.currentView) {
@@ -70,168 +149,165 @@ const AINode = {
     }
   },
 
-  startPolling() {
-    this.state.pollInterval = setInterval(() => this.refresh(), 5000);
-  },
+  startPolling() { var self = this; this.state.pollInterval = setInterval(function() { self.refresh(); }, 5000); },
 
   // --- Dashboard View ---
   renderDashboard() {
-    const s = this.state.status;
-    const nodes = this.state.nodes;
-    if (!s) {
-      document.getElementById('dashboard-stats').innerHTML = this.skeletonCards(4);
-      return;
-    }
-    const totalGPUs = nodes.reduce((sum, n) => sum + (n.gpu_count || 1), 0);
-    const totalMem = nodes.reduce((sum, n) => sum + (n.gpu_memory_gb || 0), 0);
-    const onlineNodes = nodes.filter(n => n.status === 'online').length;
-    const modelsLoaded = s.models_loaded?.length || 0;
-    document.getElementById('dashboard-stats').innerHTML = `
-      <div class="card"><div class="stat-value">${onlineNodes || 1}</div><div class="stat-label">Nodes Online</div></div>
-      <div class="card"><div class="stat-value">${totalGPUs || 1}</div><div class="stat-label">GPUs</div></div>
-      <div class="card"><div class="stat-value">${totalMem || (s.gpu?.memory_gb || 0)} GB</div><div class="stat-label">Total Memory</div></div>
-      <div class="card"><div class="stat-value">${modelsLoaded}</div><div class="stat-label">Models Loaded</div></div>
-    `;
+    var s = this.state.status, nodes = this.state.nodes;
+    if (!s) { document.getElementById('dashboard-stats').innerHTML = this.skeletonCards(4); return; }
+    var totalGPUs = nodes.reduce((sum, n) => sum + (n.gpu_count || 1), 0);
+    var totalMem = nodes.reduce((sum, n) => sum + (n.gpu_memory_gb || 0), 0);
+    var onlineNodes = nodes.filter(n => n.status === 'online').length;
+    var modelsLoaded = s.models_loaded?.length || 0;
+    document.getElementById('dashboard-stats').innerHTML = '<div class="card"><div class="stat-value">' + (onlineNodes || 1) + '</div><div class="stat-label">Nodes Online</div></div><div class="card"><div class="stat-value">' + (totalGPUs || 1) + '</div><div class="stat-label">GPUs</div></div><div class="card"><div class="stat-value">' + (totalMem || (s.gpu?.memory_gb || 0)) + ' GB</div><div class="stat-label">Total Memory</div></div><div class="card"><div class="stat-value">' + modelsLoaded + '</div><div class="stat-label">Models Loaded</div></div>';
     this.renderNodes(nodes, s);
     this.renderClusterHealth(s);
   },
 
   renderNodes(nodes, status) {
-    const container = document.getElementById('dashboard-nodes');
+    var container = document.getElementById('dashboard-nodes');
     if (!container) return;
-    if (nodes.length === 0 && status) {
-      nodes = [{
-        node_id: status.node_id || 'local',
-        node_name: status.node_name || 'This Node',
-        gpu_name: status.gpu?.name || 'Unknown GPU',
-        gpu_memory_gb: status.gpu?.memory_gb || 0,
-        unified_memory: status.gpu?.unified_memory || false,
-        model: status.model || 'none',
-        status: status.engine_ready ? 'online' : 'starting',
-        is_leader: true,
-      }];
-    }
-    container.innerHTML = nodes.map(node => {
-      const statusClass = node.status === 'online' ? 'status-online' : node.status === 'starting' ? 'status-starting' : 'status-offline';
-      const leaderClass = node.is_leader ? 'is-leader' : '';
-      const memLabel = node.unified_memory ? 'unified' : 'VRAM';
-      const memPct = node.gpu_memory_used_pct || 0;
-      const barClass = memPct > 90 ? 'red' : memPct > 70 ? 'yellow' : 'green';
-      return `
-        <div class="node-card ${leaderClass}">
-          <div style="display:flex; justify-content:space-between; align-items:start; margin-bottom:12px">
-            <div>
-              <div class="node-name">${this.esc(node.node_name || node.node_id)}</div>
-              <div class="node-id">${this.esc(node.node_id)}</div>
-            </div>
-            <div class="status ${statusClass}"><span class="status-dot"></span>${node.status || 'unknown'}</div>
-          </div>
-          <div class="node-gpu">${this.esc(node.gpu_name || 'Unknown')} &middot; ${node.gpu_memory_gb || '?'} GB ${memLabel}</div>
-          <div class="node-model">${this.esc(node.model || 'no model')}</div>
-          <div class="progress-bar"><div class="progress-fill ${barClass}" style="width:${memPct}%"></div></div>
-          <div style="font-size:11px; color:var(--text-muted); margin-top:4px">Memory: ${memPct}% used</div>
-        </div>
-      `;
+    if (nodes.length === 0 && status) { nodes = [{ node_id: status.node_id || 'local', node_name: status.node_name || 'This Node', gpu_name: status.gpu?.name || 'Unknown GPU', gpu_memory_gb: status.gpu?.memory_gb || 0, unified_memory: status.gpu?.unified_memory || false, model: status.model || 'none', status: status.engine_ready ? 'online' : 'starting', is_leader: true }]; }
+    var self = this;
+    container.innerHTML = nodes.map(function(node) {
+      var sc = node.status === 'online' ? 'status-online' : node.status === 'starting' ? 'status-starting' : 'status-offline';
+      var lc = node.is_leader ? 'is-leader' : '';
+      var ml = node.unified_memory ? 'unified' : 'VRAM';
+      var mp = node.gpu_memory_used_pct || 0;
+      var bc = mp > 90 ? 'red' : mp > 70 ? 'yellow' : 'green';
+      return '<div class="node-card ' + lc + '"><div style="display:flex;justify-content:space-between;align-items:start;margin-bottom:12px"><div><div class="node-name">' + self.esc(node.node_name || node.node_id) + '</div><div class="node-id">' + self.esc(node.node_id) + '</div></div><div class="status ' + sc + '"><span class="status-dot"></span>' + (node.status || 'unknown') + '</div></div><div class="node-gpu">' + self.esc(node.gpu_name || 'Unknown') + ' &middot; ' + (node.gpu_memory_gb || '?') + ' GB ' + ml + '</div><div class="node-model">' + self.esc(node.model || 'no model') + '</div><div class="progress-bar"><div class="progress-fill ' + bc + '" style="width:' + mp + '%"></div></div><div style="font-size:11px;color:var(--text-muted);margin-top:4px">Memory: ' + mp + '% used</div></div>';
     }).join('');
   },
 
   renderClusterHealth(status) {
-    const container = document.getElementById('dashboard-health');
+    var container = document.getElementById('dashboard-health');
     if (!container) return;
-    const uptime = status.uptime_seconds ? this.formatUptime(status.uptime_seconds) : 'N/A';
-    container.innerHTML = `
-      <div class="card">
-        <div class="card-header"><div class="card-title">Engine Status</div></div>
-        <table class="table">
-          <tr><td>Engine</td><td>${status.engine_ready ? '<span class="status status-online"><span class="status-dot"></span>Ready</span>' : '<span class="status status-starting"><span class="status-dot"></span>Starting</span>'}</td></tr>
-          <tr><td>Model</td><td style="font-family:var(--font-mono)">${this.esc(status.model || 'none')}</td></tr>
-          <tr><td>API Port</td><td style="font-family:var(--font-mono)">${status.api_port || 8000}</td></tr>
-          <tr><td>Uptime</td><td>${uptime}</td></tr>
-          <tr><td>Version</td><td>${this.esc(status.version || 'unknown')}</td></tr>
-        </table>
-      </div>
-    `;
+    var uptime = status.uptime_seconds ? this.formatUptime(status.uptime_seconds) : 'N/A';
+    container.innerHTML = '<div class="card"><div class="card-header"><div class="card-title">Engine Status</div></div><table class="table"><tr><td>Engine</td><td>' + (status.engine_ready ? '<span class="status status-online"><span class="status-dot"></span>Ready</span>' : '<span class="status status-starting"><span class="status-dot"></span>Starting</span>') + '</td></tr><tr><td>Model</td><td style="font-family:var(--font-mono)">' + this.esc(status.model || 'none') + '</td></tr><tr><td>API Port</td><td style="font-family:var(--font-mono)">' + (status.api_port || 8000) + '</td></tr><tr><td>Uptime</td><td>' + uptime + '</td></tr><tr><td>Version</td><td>' + this.esc(status.version || 'unknown') + '</td></tr></table></div>';
   },
 
   // --- Chat View ---
   bindChat() {
-    const input = document.getElementById('chat-input');
-    const send = document.getElementById('chat-send');
+    var input = document.getElementById('chat-input'), send = document.getElementById('chat-send');
     if (!input || !send) return;
-    send.addEventListener('click', () => this.sendMessage());
-    input.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); this.sendMessage(); }
-    });
-    input.addEventListener('input', () => {
-      input.style.height = 'auto';
-      input.style.height = Math.min(input.scrollHeight, 200) + 'px';
-    });
+    var self = this;
+    send.addEventListener('click', function() { self.handleSendClick(); });
+    input.addEventListener('keydown', function(e) { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); self.handleSendClick(); } });
+    input.addEventListener('input', function() { input.style.height = 'auto'; input.style.height = Math.min(input.scrollHeight, 200) + 'px'; });
+    var nb = document.getElementById('chat-new-btn'); if (nb) nb.addEventListener('click', function() { self.newConversation(); });
+    var tb = document.getElementById('chat-history-toggle'); if (tb) tb.addEventListener('click', function() { self.toggleHistory(); });
+    var ob = document.getElementById('chat-history-open'); if (ob) ob.addEventListener('click', function() { self.toggleHistory(); });
+  },
+
+  handleSendClick() { if (this.state.streaming) this.stopGeneration(); else this.sendMessage(); },
+
+  stopGeneration() {
+    if (this.state.abortController) { this.state.abortController.abort(); this.state.abortController = null; }
+    this.state.streaming = false;
+    var sendBtn = document.getElementById('chat-send');
+    if (sendBtn) { sendBtn.textContent = 'Send'; sendBtn.classList.remove('chat-stop'); sendBtn.disabled = false; }
+    this.hideMetrics();
+    this.toast('Generation stopped', 'info');
   },
 
   renderChatHeader() {
-    const s = this.state.status;
-    const select = document.getElementById('chat-model');
+    var s = this.state.status, select = document.getElementById('chat-model');
     if (!select || !s) return;
-    const models = s.models_loaded || [];
+    var models = s.models_loaded || [], cv = select.value;
     if (models.length === 0) { select.innerHTML = '<option>No models loaded</option>'; }
-    else { select.innerHTML = models.map(m => `<option value="${this.esc(m)}">${this.esc(m)}</option>`).join(''); }
+    else { var self = this; select.innerHTML = models.map(function(m) { return '<option value="' + self.esc(m) + '">' + self.esc(m) + '</option>'; }).join(''); if (cv) { for (var i = 0; i < select.options.length; i++) { if (select.options[i].value === cv) { select.value = cv; break; } } } }
+  },
+
+  showMetrics() { var b = document.getElementById('chat-metrics-bar'); if (b) b.style.display = ''; },
+  hideMetrics() { var b = document.getElementById('chat-metrics-bar'); if (b) b.style.display = 'none'; },
+  updateMetrics() {
+    var m = this.state.streamMetrics;
+    var t1 = document.getElementById('chat-metric-ttft'), t2 = document.getElementById('chat-metric-tps'), t3 = document.getElementById('chat-metric-tokens');
+    if (t1) t1.textContent = m.ttft != null ? 'TTFT: ' + m.ttft + 'ms' : 'TTFT: --';
+    if (t2) t2.textContent = m.tps > 0 ? m.tps.toFixed(1) + ' tok/s' : '-- tok/s';
+    if (t3) t3.textContent = m.tokenCount + ' tokens';
   },
 
   async sendMessage() {
-    const input = document.getElementById('chat-input');
-    const content = input.value.trim();
+    var input = document.getElementById('chat-input'), content = input.value.trim();
     if (!content || this.state.streaming) return;
     input.value = ''; input.style.height = 'auto';
-    this.state.messages.push({ role: 'user', content });
+    if (!this.state.currentConversationId) this.newConversation();
+    this.state.messages.push({ role: 'user', content: content });
     this.renderMessages();
-    const select = document.getElementById('chat-model');
-    const model = select?.value || '';
+    var select = document.getElementById('chat-model'), model = select ? select.value : '';
     this.state.streaming = true;
-    document.getElementById('chat-send').disabled = true;
-    const assistantMsg = { role: 'assistant', content: '' };
+    var sendBtn = document.getElementById('chat-send');
+    if (sendBtn) { sendBtn.textContent = 'Stop'; sendBtn.classList.add('chat-stop'); sendBtn.disabled = false; }
+    this.state.streamMetrics = { ttft: null, tps: 0, tokenCount: 0, startTime: performance.now(), firstTokenTime: 0 };
+    this.showMetrics(); this.updateMetrics();
+    var assistantMsg = { role: 'assistant', content: '' };
     this.state.messages.push(assistantMsg);
+    this.state.abortController = new AbortController();
     try {
-      const resp = await fetch('/v1/chat/completions', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ model, messages: this.state.messages.slice(0, -1).map(m => ({ role: m.role, content: m.content })), stream: true }),
-      });
-      const reader = resp.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = '';
+      var resp = await fetch('/v1/chat/completions', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ model: model, messages: this.state.messages.slice(0, -1).map(function(m) { return { role: m.role, content: m.content }; }), stream: true }), signal: this.state.abortController.signal });
+      var reader = resp.body.getReader(), decoder = new TextDecoder(), buffer = '';
       while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split('\n');
-        buffer = lines.pop();
-        for (const line of lines) {
+        var chunk = await reader.read();
+        if (chunk.done) break;
+        buffer += decoder.decode(chunk.value, { stream: true });
+        var lines = buffer.split('\n'); buffer = lines.pop();
+        for (var li = 0; li < lines.length; li++) {
+          var line = lines[li];
           if (!line.startsWith('data: ')) continue;
-          const data = line.slice(6);
+          var data = line.slice(6);
           if (data === '[DONE]') break;
-          try { const json = JSON.parse(data); const delta = json.choices?.[0]?.delta?.content; if (delta) { assistantMsg.content += delta; this.renderMessages(); } } catch { }
+          try {
+            var json = JSON.parse(data), delta = json.choices && json.choices[0] && json.choices[0].delta && json.choices[0].delta.content;
+            if (delta) {
+              if (this.state.streamMetrics.tokenCount === 0) { this.state.streamMetrics.firstTokenTime = performance.now(); this.state.streamMetrics.ttft = Math.round(this.state.streamMetrics.firstTokenTime - this.state.streamMetrics.startTime); }
+              this.state.streamMetrics.tokenCount++;
+              var elapsed = (performance.now() - this.state.streamMetrics.firstTokenTime) / 1000;
+              if (elapsed > 0) this.state.streamMetrics.tps = this.state.streamMetrics.tokenCount / elapsed;
+              assistantMsg.content += delta;
+              this.renderMessages(); this.updateMetrics();
+            }
+          } catch(e) {}
         }
       }
-    } catch (err) { assistantMsg.content = 'Error: ' + err.message + '. Is the engine running?'; }
-    this.state.streaming = false;
-    document.getElementById('chat-send').disabled = false;
-    this.renderMessages();
+    } catch (err) {
+      if (err.name === 'AbortError') { if (!assistantMsg.content) this.state.messages.pop(); }
+      else { assistantMsg.content = 'Error: ' + err.message + '. Is the engine running?'; this.toast('Engine not responding', 'error'); }
+    }
+    this.state.streaming = false; this.state.abortController = null;
+    if (sendBtn) { sendBtn.textContent = 'Send'; sendBtn.classList.remove('chat-stop'); sendBtn.disabled = false; }
+    this.renderMessages(); this.saveCurrentConversation();
   },
 
   renderMessages() {
-    const container = document.getElementById('chat-messages');
+    var container = document.getElementById('chat-messages');
     if (!container) return;
-    container.innerHTML = this.state.messages.map(msg => `<div class="chat-message ${msg.role}">${this.formatMarkdown(msg.content)}</div>`).join('');
+    var self = this;
+    if (this.state.messages.length === 0) {
+      container.innerHTML = '<div class="chat-empty-state"><div class="chat-empty-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" width="48" height="48"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg></div><h3 class="chat-empty-title">Start a conversation</h3><p class="chat-empty-desc">Ask your local model anything. Try one of these:</p><div class="chat-suggested-prompts"><button class="chat-prompt-chip" data-prompt="Explain how transformer attention works">Explain how transformer attention works</button><button class="chat-prompt-chip" data-prompt="Write a Python script to monitor GPU usage">Write a Python script to monitor GPU usage</button><button class="chat-prompt-chip" data-prompt="What are the best practices for fine-tuning LLMs?">Best practices for fine-tuning LLMs</button><button class="chat-prompt-chip" data-prompt="Compare LoRA vs full fine-tuning">Compare LoRA vs full fine-tuning</button></div></div>';
+      container.querySelectorAll('.chat-prompt-chip').forEach(function(chip) { chip.addEventListener('click', function() { var inp = document.getElementById('chat-input'); if (inp) { inp.value = chip.dataset.prompt; inp.focus(); } }); });
+      return;
+    }
+    container.innerHTML = this.state.messages.map(function(msg, i) {
+      var html = '<div class="chat-message ' + msg.role + '">' + self.formatMarkdown(msg.content);
+      if (msg.role === 'assistant' && msg.content) html += '<button class="chat-copy-btn" data-msg-index="' + i + '" title="Copy to clipboard"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg></button>';
+      return html + '</div>';
+    }).join('');
     container.scrollTop = container.scrollHeight;
+    container.querySelectorAll('.chat-copy-btn').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var msg = self.state.messages[parseInt(btn.dataset.msgIndex)];
+        if (msg) navigator.clipboard.writeText(msg.content).then(function() { self.toast('Message copied', 'success'); }).catch(function() { self.toast('Failed to copy', 'error'); });
+      });
+    });
   },
 
   // --- Models View ---
   renderModels() {
-    const container = document.getElementById('models-list');
+    var container = document.getElementById('models-list');
     if (!container) return;
-    const s = this.state.status;
-    const loaded = s?.models_loaded || [];
-    const recommended = [
+    var s = this.state.status, loaded = s?.models_loaded || [], self = this;
+    var recommended = [
       { id: 'meta-llama/Llama-3.2-3B-Instruct', size: '~6 GB', desc: 'Quick start, fast inference' },
       { id: 'meta-llama/Llama-3.1-8B-Instruct', size: '~16 GB', desc: 'Recommended for most tasks' },
       { id: 'meta-llama/Llama-3.1-70B-Instruct-AWQ', size: '~35 GB', desc: 'High quality, needs 40+ GB' },
@@ -239,19 +315,9 @@ const AINode = {
       { id: 'deepseek-ai/DeepSeek-R1-Distill-Qwen-7B', size: '~14 GB', desc: 'Reasoning specialist' },
       { id: 'mistralai/Mistral-7B-Instruct-v0.3', size: '~14 GB', desc: 'Fast, general purpose' },
     ];
-    container.innerHTML = recommended.map(model => {
-      const isLoaded = loaded.includes(model.id);
-      return `
-        <div class="model-card">
-          <div class="model-info">
-            <div class="model-name">${this.esc(model.id)}</div>
-            <div class="model-meta">${model.size} &middot; ${model.desc}</div>
-          </div>
-          <div class="model-status">
-            ${isLoaded ? '<span class="model-badge loaded">Loaded</span>' : '<span class="model-badge available">Available</span>'}
-          </div>
-        </div>
-      `;
+    container.innerHTML = recommended.map(function(model) {
+      var isLoaded = loaded.includes(model.id);
+      return '<div class="model-card"><div class="model-info"><div class="model-name">' + self.esc(model.id) + '</div><div class="model-meta">' + model.size + ' &middot; ' + model.desc + '</div></div><div class="model-status">' + (isLoaded ? '<span class="model-badge loaded">Loaded</span>' : '<span class="model-badge available">Available</span>') + '</div></div>';
     }).join('');
   },
 
@@ -268,9 +334,9 @@ const AINode = {
   ],
 
   async renderTraining() {
-    const container = document.getElementById('training-content');
+    var container = document.getElementById('training-content');
     if (!container) return;
-    const data = await this.fetchJSON('/api/training/jobs');
+    var data = await this.fetchJSON('/api/training/jobs');
     this.state.trainingJobs = data?.jobs || [];
     switch (this.state.trainingView) {
       case 'list': this.renderTrainingList(container); break;
@@ -280,255 +346,109 @@ const AINode = {
   },
 
   renderTrainingList(container) {
-    const jobs = this.state.trainingJobs;
-    const hasJobs = jobs.length > 0;
-    container.innerHTML = '<div class="training-header">' +
-      '<div class="training-stat-row">' +
-        '<div class="card training-stat-card"><div class="stat-value">' + jobs.length + '</div><div class="stat-label">Total Jobs</div></div>' +
-        '<div class="card training-stat-card"><div class="stat-value">' + jobs.filter(j => j.status === 'running').length + '</div><div class="stat-label">Running</div></div>' +
-        '<div class="card training-stat-card"><div class="stat-value">' + jobs.filter(j => j.status === 'completed').length + '</div><div class="stat-label">Completed</div></div>' +
-        '<div class="card training-stat-card"><div class="stat-value">' + jobs.filter(j => j.status === 'pending').length + '</div><div class="stat-label">Queued</div></div>' +
-      '</div>' +
-      '<button class="btn btn-primary" id="training-new-btn">' +
-        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>' +
-        'New Training Job</button>' +
-    '</div>' +
-    (hasJobs ?
-      '<div class="training-jobs-list">' + jobs.sort((a, b) => (b.start_time || 0) - (a.start_time || 0)).map(job => this.renderJobCard(job)).join('') + '</div>'
-      :
-      '<div class="training-empty">' +
-        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" width="56" height="56"><path d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/></svg>' +
-        '<h3>No training jobs yet</h3><p>Create your first fine-tuning job to get started.</p>' +
-      '</div>'
-    );
-    document.getElementById('training-new-btn')?.addEventListener('click', () => { this.state.trainingView = 'new'; this.renderTraining(); });
-    container.querySelectorAll('.training-job-card').forEach(card => {
-      card.addEventListener('click', () => { this.state.trainingView = 'detail'; this.state.trainingDetailId = card.dataset.jobId; this.state.trainingLossData = []; this.renderTraining(); });
-    });
+    var jobs = this.state.trainingJobs, hasJobs = jobs.length > 0, self = this;
+    container.innerHTML = '<div class="training-header"><div class="training-stat-row"><div class="card training-stat-card"><div class="stat-value">' + jobs.length + '</div><div class="stat-label">Total Jobs</div></div><div class="card training-stat-card"><div class="stat-value">' + jobs.filter(j => j.status === 'running').length + '</div><div class="stat-label">Running</div></div><div class="card training-stat-card"><div class="stat-value">' + jobs.filter(j => j.status === 'completed').length + '</div><div class="stat-label">Completed</div></div><div class="card training-stat-card"><div class="stat-value">' + jobs.filter(j => j.status === 'pending').length + '</div><div class="stat-label">Queued</div></div></div><button class="btn btn-primary" id="training-new-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>New Training Job</button></div>' + (hasJobs ? '<div class="training-jobs-list">' + jobs.sort((a, b) => (b.start_time || 0) - (a.start_time || 0)).map(job => this.renderJobCard(job)).join('') + '</div>' : '<div class="training-empty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" width="56" height="56"><path d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/></svg><h3>No training jobs yet</h3><p>Create your first fine-tuning job to get started.</p></div>');
+    var nb = document.getElementById('training-new-btn'); if (nb) nb.addEventListener('click', function() { self.state.trainingView = 'new'; self.renderTraining(); });
+    container.querySelectorAll('.training-job-card').forEach(function(card) { card.addEventListener('click', function() { self.state.trainingView = 'detail'; self.state.trainingDetailId = card.dataset.jobId; self.state.trainingLossData = []; self.renderTraining(); }); });
   },
 
   renderJobCard(job) {
-    const statusMap = { pending: { cls: 'status-pending', label: 'Pending' }, running: { cls: 'status-running', label: 'Running' }, completed: { cls: 'status-completed', label: 'Completed' }, failed: { cls: 'status-failed', label: 'Failed' }, cancelled: { cls: 'status-cancelled', label: 'Cancelled' } };
-    const s = statusMap[job.status] || { cls: '', label: job.status };
-    const modelShort = job.config?.base_model?.split('/').pop() || 'Unknown';
-    const methodLabel = (job.config?.method || 'lora').toUpperCase();
-    const started = job.start_time ? new Date(job.start_time * 1000).toLocaleString() : 'Not started';
-    const elapsed = job.elapsed_seconds ? this.formatUptime(Math.round(job.elapsed_seconds)) : '--';
-    let html = '<div class="training-job-card" data-job-id="' + this.esc(job.job_id) + '">' +
-      '<div class="job-card-top"><div class="job-card-left">' +
-        '<div class="job-card-model">' + this.esc(modelShort) + '</div>' +
-        '<div class="job-card-meta"><span class="job-method-badge">' + methodLabel + '</span><span class="job-card-id">' + this.esc(job.job_id) + '</span></div>' +
-      '</div><div class="job-card-right"><span class="job-status-badge ' + s.cls + '">' + s.label + '</span></div></div>';
-    if (job.status === 'running') {
-      html += '<div class="job-card-progress">' +
-        '<div class="progress-bar training-progress-bar"><div class="progress-fill accent training-progress-animated" style="width:' + (job.progress || 0) + '%"></div></div>' +
-        '<div class="job-progress-text">' + (job.progress || 0).toFixed(1) + '% &middot; Epoch ' + (job.current_epoch || 0) + '/' + (job.config?.num_epochs || '?') + (job.current_loss != null ? ' &middot; Loss: ' + job.current_loss.toFixed(4) : '') + '</div></div>';
-    }
+    var statusMap = { pending: { cls: 'status-pending', label: 'Pending' }, running: { cls: 'status-running', label: 'Running' }, completed: { cls: 'status-completed', label: 'Completed' }, failed: { cls: 'status-failed', label: 'Failed' }, cancelled: { cls: 'status-cancelled', label: 'Cancelled' } };
+    var s = statusMap[job.status] || { cls: '', label: job.status };
+    var modelShort = job.config?.base_model?.split('/').pop() || 'Unknown';
+    var methodLabel = (job.config?.method || 'lora').toUpperCase();
+    var started = job.start_time ? new Date(job.start_time * 1000).toLocaleString() : 'Not started';
+    var elapsed = job.elapsed_seconds ? this.formatUptime(Math.round(job.elapsed_seconds)) : '--';
+    var html = '<div class="training-job-card" data-job-id="' + this.esc(job.job_id) + '"><div class="job-card-top"><div class="job-card-left"><div class="job-card-model">' + this.esc(modelShort) + '</div><div class="job-card-meta"><span class="job-method-badge">' + methodLabel + '</span><span class="job-card-id">' + this.esc(job.job_id) + '</span></div></div><div class="job-card-right"><span class="job-status-badge ' + s.cls + '">' + s.label + '</span></div></div>';
+    if (job.status === 'running') html += '<div class="job-card-progress"><div class="progress-bar training-progress-bar"><div class="progress-fill accent training-progress-animated" style="width:' + (job.progress || 0) + '%"></div></div><div class="job-progress-text">' + (job.progress || 0).toFixed(1) + '% &middot; Epoch ' + (job.current_epoch || 0) + '/' + (job.config?.num_epochs || '?') + (job.current_loss != null ? ' &middot; Loss: ' + job.current_loss.toFixed(4) : '') + '</div></div>';
     html += '<div class="job-card-footer"><span>Started: ' + started + '</span><span>Duration: ' + elapsed + '</span></div></div>';
     return html;
   },
 
   renderTrainingForm(container) {
-    const models = this.trainingModels;
-    const optionsHtml = models.map(m => '<option value="' + this.esc(m.id) + '">' + this.esc(m.name) + ' (' + m.size + ')</option>').join('');
-    container.innerHTML = '<div class="training-form-wrapper">' +
-      '<div class="training-form-header">' +
-        '<button class="btn btn-ghost" id="training-back-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><polyline points="15 18 9 12 15 6"/></svg>Back to Jobs</button>' +
-        '<h2 class="training-form-title">New Training Job</h2>' +
-      '</div>' +
-      '<form id="training-form" class="training-form">' +
-        '<div class="form-section"><div class="form-section-title">Model</div>' +
-          '<div class="form-group"><label class="form-label" for="train-model">Base Model</label><select id="train-model" class="form-select" required>' + optionsHtml + '</select><div class="form-hint">Or enter a custom HuggingFace model ID below</div></div>' +
-          '<div class="form-group"><label class="form-label" for="train-model-custom">Custom Model ID (optional)</label><input type="text" id="train-model-custom" class="form-input" placeholder="e.g. org/my-model"></div>' +
-        '</div>' +
-        '<div class="form-section"><div class="form-section-title">Dataset</div>' +
-          '<div class="form-group"><label class="form-label" for="train-dataset">Dataset Path</label><input type="text" id="train-dataset" class="form-input" placeholder="/path/to/dataset.jsonl" required><div class="form-hint">Path to a JSONL file on this machine. Each line should have &quot;instruction&quot; and &quot;output&quot; fields.</div></div>' +
-        '</div>' +
-        '<div class="form-section"><div class="form-section-title">Training Method</div>' +
-          '<div class="form-group"><div class="method-toggle">' +
-            '<button type="button" class="method-btn active" data-method="lora"><div class="method-btn-title">LoRA</div><div class="method-btn-desc">Recommended. Trains adapter weights only. Fast, memory-efficient.</div></button>' +
-            '<button type="button" class="method-btn" data-method="full"><div class="method-btn-title">Full Fine-Tune</div><div class="method-btn-desc">Updates all model weights. Requires more VRAM and time.</div></button>' +
-          '</div><input type="hidden" id="train-method" value="lora"></div>' +
-        '</div>' +
-        '<div class="form-section"><div class="form-section-title collapsible" id="advanced-toggle"><span>Advanced Settings</span><svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><polyline points="6 9 12 15 18 9"/></svg></div>' +
-          '<div class="advanced-settings collapsed" id="advanced-settings">' +
-            '<div class="form-grid">' +
-              '<div class="form-group"><label class="form-label" for="train-epochs">Epochs</label><input type="number" id="train-epochs" class="form-input" value="3" min="1" max="100"></div>' +
-              '<div class="form-group"><label class="form-label" for="train-batch">Batch Size</label><input type="number" id="train-batch" class="form-input" value="4" min="1" max="128"></div>' +
-              '<div class="form-group"><label class="form-label" for="train-lr">Learning Rate</label><input type="text" id="train-lr" class="form-input" value="2e-4"></div>' +
-              '<div class="form-group"><label class="form-label" for="train-seq-len">Max Sequence Length</label><input type="number" id="train-seq-len" class="form-input" value="2048" min="128" max="32768" step="128"></div>' +
-            '</div>' +
-            '<div class="form-grid lora-settings" id="lora-settings">' +
-              '<div class="form-group"><label class="form-label" for="train-lora-rank">LoRA Rank</label><input type="number" id="train-lora-rank" class="form-input" value="16" min="1" max="256"><div class="form-hint">Higher = more capacity, more memory</div></div>' +
-              '<div class="form-group"><label class="form-label" for="train-lora-alpha">LoRA Alpha</label><input type="number" id="train-lora-alpha" class="form-input" value="32" min="1" max="512"><div class="form-hint">Typically 2x the rank</div></div>' +
-            '</div>' +
-          '</div>' +
-        '</div>' +
-        '<div class="form-actions"><button type="button" class="btn btn-ghost" id="training-cancel-btn">Cancel</button><button type="submit" class="btn btn-primary btn-lg" id="training-submit-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><polygon points="5 3 19 12 5 21 5 3"/></svg>Start Training</button></div>' +
-      '</form></div>';
+    var models = this.trainingModels;
+    var optionsHtml = models.map(m => '<option value="' + this.esc(m.id) + '">' + this.esc(m.name) + ' (' + m.size + ')</option>').join('');
+    container.innerHTML = '<div class="training-form-wrapper"><div class="training-form-header"><button class="btn btn-ghost" id="training-back-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><polyline points="15 18 9 12 15 6"/></svg>Back to Jobs</button><h2 class="training-form-title">New Training Job</h2></div><form id="training-form" class="training-form"><div class="form-section"><div class="form-section-title">Model</div><div class="form-group"><label class="form-label" for="train-model">Base Model</label><select id="train-model" class="form-select" required>' + optionsHtml + '</select></div><div class="form-group"><label class="form-label" for="train-model-custom">Custom Model ID (optional)</label><input type="text" id="train-model-custom" class="form-input" placeholder="e.g. org/my-model"></div></div><div class="form-section"><div class="form-section-title">Dataset</div><div class="form-group"><label class="form-label" for="train-dataset">Dataset Path</label><input type="text" id="train-dataset" class="form-input" placeholder="/path/to/dataset.jsonl" required></div></div><div class="form-section"><div class="form-section-title">Training Method</div><div class="form-group"><div class="method-toggle"><button type="button" class="method-btn active" data-method="lora"><div class="method-btn-title">LoRA</div><div class="method-btn-desc">Recommended. Trains adapter weights only.</div></button><button type="button" class="method-btn" data-method="full"><div class="method-btn-title">Full Fine-Tune</div><div class="method-btn-desc">Updates all model weights.</div></button></div><input type="hidden" id="train-method" value="lora"></div></div><div class="form-section"><div class="form-section-title collapsible" id="advanced-toggle"><span>Advanced Settings</span><svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><polyline points="6 9 12 15 18 9"/></svg></div><div class="advanced-settings collapsed" id="advanced-settings"><div class="form-grid"><div class="form-group"><label class="form-label">Epochs</label><input type="number" id="train-epochs" class="form-input" value="3" min="1" max="100"></div><div class="form-group"><label class="form-label">Batch Size</label><input type="number" id="train-batch" class="form-input" value="4" min="1" max="128"></div><div class="form-group"><label class="form-label">Learning Rate</label><input type="text" id="train-lr" class="form-input" value="2e-4"></div><div class="form-group"><label class="form-label">Max Seq Length</label><input type="number" id="train-seq-len" class="form-input" value="2048" min="128" max="32768" step="128"></div></div><div class="form-grid lora-settings" id="lora-settings"><div class="form-group"><label class="form-label">LoRA Rank</label><input type="number" id="train-lora-rank" class="form-input" value="16" min="1" max="256"></div><div class="form-group"><label class="form-label">LoRA Alpha</label><input type="number" id="train-lora-alpha" class="form-input" value="32" min="1" max="512"></div></div></div></div><div class="form-actions"><button type="button" class="btn btn-ghost" id="training-cancel-btn">Cancel</button><button type="submit" class="btn btn-primary btn-lg" id="training-submit-btn">Start Training</button></div></form></div>';
     this.bindTrainingForm();
   },
 
   bindTrainingForm() {
-    const goBack = () => { this.state.trainingView = 'list'; this.renderTraining(); };
-    document.getElementById('training-back-btn')?.addEventListener('click', goBack);
-    document.getElementById('training-cancel-btn')?.addEventListener('click', goBack);
-    document.querySelectorAll('.method-btn').forEach(btn => {
-      btn.addEventListener('click', () => {
-        document.querySelectorAll('.method-btn').forEach(b => b.classList.remove('active'));
-        btn.classList.add('active');
-        document.getElementById('train-method').value = btn.dataset.method;
-        const ls = document.getElementById('lora-settings');
-        if (ls) ls.style.display = btn.dataset.method === 'lora' ? '' : 'none';
-      });
-    });
-    document.getElementById('advanced-toggle')?.addEventListener('click', () => {
-      const s = document.getElementById('advanced-settings');
-      const t = document.getElementById('advanced-toggle');
-      if (s) { s.classList.toggle('collapsed'); t.classList.toggle('open'); }
-    });
-    document.getElementById('training-form')?.addEventListener('submit', async (e) => { e.preventDefault(); await this.submitTrainingJob(); });
+    var self = this, goBack = function() { self.state.trainingView = 'list'; self.renderTraining(); };
+    var bb = document.getElementById('training-back-btn'); if (bb) bb.addEventListener('click', goBack);
+    var cb = document.getElementById('training-cancel-btn'); if (cb) cb.addEventListener('click', goBack);
+    document.querySelectorAll('.method-btn').forEach(function(btn) { btn.addEventListener('click', function() { document.querySelectorAll('.method-btn').forEach(function(b) { b.classList.remove('active'); }); btn.classList.add('active'); document.getElementById('train-method').value = btn.dataset.method; var ls = document.getElementById('lora-settings'); if (ls) ls.style.display = btn.dataset.method === 'lora' ? '' : 'none'; }); });
+    var at = document.getElementById('advanced-toggle'); if (at) at.addEventListener('click', function() { var s = document.getElementById('advanced-settings'), t = document.getElementById('advanced-toggle'); if (s) { s.classList.toggle('collapsed'); t.classList.toggle('open'); } });
+    var f = document.getElementById('training-form'); if (f) f.addEventListener('submit', function(e) { e.preventDefault(); self.submitTrainingJob(); });
   },
 
   async submitTrainingJob() {
-    const submitBtn = document.getElementById('training-submit-btn');
+    var submitBtn = document.getElementById('training-submit-btn');
     if (submitBtn) { submitBtn.disabled = true; submitBtn.textContent = 'Submitting...'; }
-    const customModel = document.getElementById('train-model-custom')?.value?.trim();
-    const baseModel = customModel || document.getElementById('train-model')?.value;
-    const method = document.getElementById('train-method')?.value || 'lora';
-    const payload = {
-      base_model: baseModel,
-      dataset_path: document.getElementById('train-dataset')?.value?.trim(),
-      method: method,
-      num_epochs: parseInt(document.getElementById('train-epochs')?.value) || 3,
-      batch_size: parseInt(document.getElementById('train-batch')?.value) || 4,
-      learning_rate: parseFloat(document.getElementById('train-lr')?.value) || 2e-4,
-      max_seq_length: parseInt(document.getElementById('train-seq-len')?.value) || 2048,
-    };
-    if (method === 'lora') {
-      payload.lora_rank = parseInt(document.getElementById('train-lora-rank')?.value) || 16;
-      payload.lora_alpha = parseInt(document.getElementById('train-lora-alpha')?.value) || 32;
-    }
+    var customModel = document.getElementById('train-model-custom')?.value?.trim();
+    var baseModel = customModel || document.getElementById('train-model')?.value;
+    var method = document.getElementById('train-method')?.value || 'lora';
+    var payload = { base_model: baseModel, dataset_path: document.getElementById('train-dataset')?.value?.trim(), method: method, num_epochs: parseInt(document.getElementById('train-epochs')?.value) || 3, batch_size: parseInt(document.getElementById('train-batch')?.value) || 4, learning_rate: parseFloat(document.getElementById('train-lr')?.value) || 2e-4, max_seq_length: parseInt(document.getElementById('train-seq-len')?.value) || 2048 };
+    if (method === 'lora') { payload.lora_rank = parseInt(document.getElementById('train-lora-rank')?.value) || 16; payload.lora_alpha = parseInt(document.getElementById('train-lora-alpha')?.value) || 32; }
     try {
-      const resp = await fetch('/api/training/jobs', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
-      const result = await resp.json();
-      if (!resp.ok) { alert('Error: ' + (result.error || 'Failed to create job')); if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = 'Start Training'; } return; }
+      var resp = await fetch('/api/training/jobs', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+      var result = await resp.json();
+      if (!resp.ok) { this.toast('Error: ' + (result.error || 'Failed to create job'), 'error'); if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = 'Start Training'; } return; }
       this.state.trainingView = 'detail'; this.state.trainingDetailId = result.job_id; this.state.trainingLossData = []; this.renderTraining();
-    } catch (err) { alert('Network error: ' + err.message); if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = 'Start Training'; } }
+    } catch (err) { this.toast('Network error: ' + err.message, 'error'); if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = 'Start Training'; } }
   },
 
   async renderTrainingDetail(container) {
-    const jobId = this.state.trainingDetailId;
+    var jobId = this.state.trainingDetailId;
     if (!jobId) { this.state.trainingView = 'list'; this.renderTraining(); return; }
-    const jobData = await this.fetchJSON('/api/training/jobs/' + jobId);
+    var jobData = await this.fetchJSON('/api/training/jobs/' + jobId);
     if (!jobData) { container.innerHTML = '<div class="training-empty"><h3>Job not found</h3></div>'; return; }
-    const logsData = await this.fetchJSON('/api/training/jobs/' + jobId + '/logs?tail=200');
-    const logs = logsData?.logs || [];
-    if (jobData.current_loss != null && jobData.progress > 0) {
-      const lastPoint = this.state.trainingLossData[this.state.trainingLossData.length - 1];
-      if (!lastPoint || lastPoint.progress !== jobData.progress) {
-        this.state.trainingLossData.push({ progress: jobData.progress, loss: jobData.current_loss, epoch: jobData.current_epoch });
-      }
-    }
-    if (this.state.trainingLossData.length === 0) {
-      for (const line of logs) {
-        const marker = 'AINODE_PROGRESS:'; const idx = line.indexOf(marker);
-        if (idx !== -1) { try { const p = JSON.parse(line.slice(idx + marker.length)); if (p.loss != null && p.progress != null) { this.state.trainingLossData.push({ progress: p.progress, loss: p.loss, epoch: p.epoch || 0 }); } } catch { } }
-      }
-    }
-    const statusMap = { pending: { cls: 'status-pending', label: 'Pending' }, running: { cls: 'status-running', label: 'Running' }, completed: { cls: 'status-completed', label: 'Completed' }, failed: { cls: 'status-failed', label: 'Failed' }, cancelled: { cls: 'status-cancelled', label: 'Cancelled' } };
-    const s = statusMap[jobData.status] || { cls: '', label: jobData.status };
-    const cfg = jobData.config || {};
-    const modelShort = cfg.base_model?.split('/').pop() || 'Unknown';
-    const started = jobData.start_time ? new Date(jobData.start_time * 1000).toLocaleString() : 'Not started';
-    const ended = jobData.end_time ? new Date(jobData.end_time * 1000).toLocaleString() : '--';
-    const elapsed = jobData.elapsed_seconds ? this.formatUptime(Math.round(jobData.elapsed_seconds)) : '--';
-    const isActive = jobData.status === 'running' || jobData.status === 'pending';
-    let html = '<div class="training-detail">' +
-      '<div class="training-form-header">' +
-        '<button class="btn btn-ghost" id="training-back-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><polyline points="15 18 9 12 15 6"/></svg>Back to Jobs</button>' +
-        '<div class="training-detail-title"><h2>' + this.esc(modelShort) + '</h2><span class="job-status-badge ' + s.cls + '">' + s.label + '</span></div>' +
-      '</div>';
-    if (jobData.status === 'running') {
-      html += '<div class="training-detail-progress card">' +
-        '<div class="progress-header"><span class="progress-pct">' + (jobData.progress || 0).toFixed(1) + '%</span><span class="progress-epoch">Epoch ' + (jobData.current_epoch || 0) + ' / ' + (cfg.num_epochs || '?') + '</span></div>' +
-        '<div class="progress-bar training-progress-bar-lg"><div class="progress-fill accent training-progress-animated" style="width:' + (jobData.progress || 0) + '%"></div></div>' +
-        '<div class="progress-stats">' + (jobData.current_loss != null ? '<span>Loss: <strong>' + jobData.current_loss.toFixed(4) + '</strong></span>' : '') + '<span>Elapsed: <strong>' + elapsed + '</strong></span></div></div>';
-    }
-    html += '<div class="training-detail-grid">' +
-      '<div class="card training-config-card"><div class="card-header"><div class="card-title">Configuration</div></div><table class="table">' +
-        '<tr><td>Model</td><td style="font-family:var(--font-mono)">' + this.esc(cfg.base_model || '') + '</td></tr>' +
-        '<tr><td>Method</td><td>' + (cfg.method || 'lora').toUpperCase() + '</td></tr>' +
-        '<tr><td>Dataset</td><td style="font-family:var(--font-mono);word-break:break-all">' + this.esc(cfg.dataset_path || '') + '</td></tr>' +
-        '<tr><td>Epochs</td><td>' + (cfg.num_epochs || '?') + '</td></tr>' +
-        '<tr><td>Batch Size</td><td>' + (cfg.batch_size || '?') + '</td></tr>' +
-        '<tr><td>Learning Rate</td><td>' + (cfg.learning_rate || '?') + '</td></tr>' +
-        '<tr><td>Max Seq Length</td><td>' + (cfg.max_seq_length || '?') + '</td></tr>' +
-        (cfg.method === 'lora' ? '<tr><td>LoRA Rank</td><td>' + (cfg.lora_rank || '?') + '</td></tr><tr><td>LoRA Alpha</td><td>' + (cfg.lora_alpha || '?') + '</td></tr>' : '') +
-        '<tr><td>Job ID</td><td style="font-family:var(--font-mono)">' + this.esc(jobData.job_id) + '</td></tr>' +
-        '<tr><td>Started</td><td>' + started + '</td></tr><tr><td>Ended</td><td>' + ended + '</td></tr><tr><td>Duration</td><td>' + elapsed + '</td></tr>' +
-      '</table>' + (isActive ? '<div style="margin-top:16px"><button class="btn btn-danger" id="training-cancel-job-btn">Cancel Job</button></div>' : '') + '</div>' +
-      '<div class="training-right-col">' +
-        (this.state.trainingLossData.length > 1 ? '<div class="card training-chart-card"><div class="card-header"><div class="card-title">Training Loss</div></div><div class="loss-chart-container"><canvas id="loss-chart" width="460" height="200"></canvas></div></div>' : '') +
-        '<div class="card training-log-card"><div class="card-header"><div class="card-title">Logs</div><span class="log-line-count">' + (logsData?.total_lines || 0) + ' lines</span></div>' +
-        '<div class="training-log-viewer" id="training-log-viewer">' + (logs.length > 0 ? logs.map(l => '<div class="log-line">' + this.esc(l) + '</div>').join('') : '<div class="log-empty">No logs yet</div>') + '</div></div>' +
-      '</div></div></div>';
+    var logsData = await this.fetchJSON('/api/training/jobs/' + jobId + '/logs?tail=200');
+    var logs = logsData?.logs || [];
+    if (jobData.current_loss != null && jobData.progress > 0) { var lp = this.state.trainingLossData[this.state.trainingLossData.length - 1]; if (!lp || lp.progress !== jobData.progress) this.state.trainingLossData.push({ progress: jobData.progress, loss: jobData.current_loss, epoch: jobData.current_epoch }); }
+    if (this.state.trainingLossData.length === 0) { for (var i = 0; i < logs.length; i++) { var marker = 'AINODE_PROGRESS:', idx = logs[i].indexOf(marker); if (idx !== -1) { try { var p = JSON.parse(logs[i].slice(idx + marker.length)); if (p.loss != null && p.progress != null) this.state.trainingLossData.push({ progress: p.progress, loss: p.loss, epoch: p.epoch || 0 }); } catch(e) {} } } }
+    var statusMap = { pending: { cls: 'status-pending', label: 'Pending' }, running: { cls: 'status-running', label: 'Running' }, completed: { cls: 'status-completed', label: 'Completed' }, failed: { cls: 'status-failed', label: 'Failed' }, cancelled: { cls: 'status-cancelled', label: 'Cancelled' } };
+    var s = statusMap[jobData.status] || { cls: '', label: jobData.status }, cfg = jobData.config || {};
+    var modelShort = cfg.base_model?.split('/').pop() || 'Unknown';
+    var started = jobData.start_time ? new Date(jobData.start_time * 1000).toLocaleString() : 'Not started';
+    var ended = jobData.end_time ? new Date(jobData.end_time * 1000).toLocaleString() : '--';
+    var elapsed = jobData.elapsed_seconds ? this.formatUptime(Math.round(jobData.elapsed_seconds)) : '--';
+    var isActive = jobData.status === 'running' || jobData.status === 'pending';
+    var html = '<div class="training-detail"><div class="training-form-header"><button class="btn btn-ghost" id="training-back-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><polyline points="15 18 9 12 15 6"/></svg>Back to Jobs</button><div class="training-detail-title"><h2>' + this.esc(modelShort) + '</h2><span class="job-status-badge ' + s.cls + '">' + s.label + '</span></div></div>';
+    if (jobData.status === 'running') html += '<div class="training-detail-progress card"><div class="progress-header"><span class="progress-pct">' + (jobData.progress || 0).toFixed(1) + '%</span><span class="progress-epoch">Epoch ' + (jobData.current_epoch || 0) + ' / ' + (cfg.num_epochs || '?') + '</span></div><div class="progress-bar training-progress-bar-lg"><div class="progress-fill accent training-progress-animated" style="width:' + (jobData.progress || 0) + '%"></div></div><div class="progress-stats">' + (jobData.current_loss != null ? '<span>Loss: <strong>' + jobData.current_loss.toFixed(4) + '</strong></span>' : '') + '<span>Elapsed: <strong>' + elapsed + '</strong></span></div></div>';
+    html += '<div class="training-detail-grid"><div class="card training-config-card"><div class="card-header"><div class="card-title">Configuration</div></div><table class="table"><tr><td>Model</td><td style="font-family:var(--font-mono)">' + this.esc(cfg.base_model || '') + '</td></tr><tr><td>Method</td><td>' + (cfg.method || 'lora').toUpperCase() + '</td></tr><tr><td>Dataset</td><td style="font-family:var(--font-mono);word-break:break-all">' + this.esc(cfg.dataset_path || '') + '</td></tr><tr><td>Epochs</td><td>' + (cfg.num_epochs || '?') + '</td></tr><tr><td>Batch Size</td><td>' + (cfg.batch_size || '?') + '</td></tr><tr><td>Learning Rate</td><td>' + (cfg.learning_rate || '?') + '</td></tr><tr><td>Max Seq Length</td><td>' + (cfg.max_seq_length || '?') + '</td></tr>' + (cfg.method === 'lora' ? '<tr><td>LoRA Rank</td><td>' + (cfg.lora_rank || '?') + '</td></tr><tr><td>LoRA Alpha</td><td>' + (cfg.lora_alpha || '?') + '</td></tr>' : '') + '<tr><td>Job ID</td><td style="font-family:var(--font-mono)">' + this.esc(jobData.job_id) + '</td></tr><tr><td>Started</td><td>' + started + '</td></tr><tr><td>Ended</td><td>' + ended + '</td></tr><tr><td>Duration</td><td>' + elapsed + '</td></tr></table>' + (isActive ? '<div style="margin-top:16px"><button class="btn btn-danger" id="training-cancel-job-btn">Cancel Job</button></div>' : '') + '</div><div class="training-right-col">' + (this.state.trainingLossData.length > 1 ? '<div class="card training-chart-card"><div class="card-header"><div class="card-title">Training Loss</div></div><div class="loss-chart-container"><canvas id="loss-chart" width="460" height="200"></canvas></div></div>' : '') + '<div class="card training-log-card"><div class="card-header"><div class="card-title">Logs</div><span class="log-line-count">' + (logsData?.total_lines || 0) + ' lines</span></div><div class="training-log-viewer" id="training-log-viewer">' + (logs.length > 0 ? logs.map(l => '<div class="log-line">' + this.esc(l) + '</div>').join('') : '<div class="log-empty">No logs yet</div>') + '</div></div></div></div></div>';
     container.innerHTML = html;
-    document.getElementById('training-back-btn')?.addEventListener('click', () => { this.state.trainingView = 'list'; this.state.trainingDetailId = null; this.state.trainingLossData = []; this.renderTraining(); });
-    document.getElementById('training-cancel-job-btn')?.addEventListener('click', async () => {
-      if (!confirm('Cancel this training job?')) return;
-      const resp = await fetch('/api/training/jobs/' + jobId, { method: 'DELETE' });
-      if (resp.ok) { this.renderTraining(); } else { const err = await resp.json().catch(() => ({})); alert(err.error || 'Failed to cancel job'); }
-    });
-    const logViewer = document.getElementById('training-log-viewer');
-    if (logViewer) logViewer.scrollTop = logViewer.scrollHeight;
+    var self = this;
+    var bb = document.getElementById('training-back-btn'); if (bb) bb.addEventListener('click', function() { self.state.trainingView = 'list'; self.state.trainingDetailId = null; self.state.trainingLossData = []; self.renderTraining(); });
+    var cjb = document.getElementById('training-cancel-job-btn'); if (cjb) cjb.addEventListener('click', async function() { if (!confirm('Cancel this training job?')) return; var resp = await fetch('/api/training/jobs/' + jobId, { method: 'DELETE' }); if (resp.ok) self.renderTraining(); else { var err = await resp.json().catch(function() { return {}; }); self.toast(err.error || 'Failed to cancel job', 'error'); } });
+    var lv = document.getElementById('training-log-viewer'); if (lv) lv.scrollTop = lv.scrollHeight;
     if (this.state.trainingLossData.length > 1) this.drawLossChart();
   },
 
   drawLossChart() {
-    const canvas = document.getElementById('loss-chart');
-    if (!canvas) return;
-    const ctx = canvas.getContext('2d');
-    const dpr = window.devicePixelRatio || 1;
-    const rect = canvas.getBoundingClientRect();
+    var canvas = document.getElementById('loss-chart'); if (!canvas) return;
+    var ctx = canvas.getContext('2d'), dpr = window.devicePixelRatio || 1, rect = canvas.getBoundingClientRect();
     canvas.width = rect.width * dpr; canvas.height = rect.height * dpr; ctx.scale(dpr, dpr);
-    const w = rect.width, h = rect.height;
-    const pad = { top: 12, right: 16, bottom: 28, left: 48 };
-    const plotW = w - pad.left - pad.right, plotH = h - pad.top - pad.bottom;
-    const data = this.state.trainingLossData;
+    var w = rect.width, h = rect.height, pad = { top: 12, right: 16, bottom: 28, left: 48 };
+    var plotW = w - pad.left - pad.right, plotH = h - pad.top - pad.bottom, data = this.state.trainingLossData;
     if (data.length < 2) return;
-    const losses = data.map(d => d.loss);
-    const maxLoss = Math.max(...losses) * 1.05, minLoss = Math.min(...losses) * 0.95;
-    const maxProg = Math.max(...data.map(d => d.progress), 1);
-    const toX = (prog) => pad.left + (prog / maxProg) * plotW;
-    const toY = (loss) => pad.top + ((maxLoss - loss) / (maxLoss - minLoss || 1)) * plotH;
-    ctx.clearRect(0, 0, w, h);
-    ctx.strokeStyle = 'rgba(45, 55, 72, 0.5)'; ctx.lineWidth = 1;
-    for (let i = 0; i <= 4; i++) {
-      const y = pad.top + (plotH / 4) * i;
-      ctx.beginPath(); ctx.moveTo(pad.left, y); ctx.lineTo(w - pad.right, y); ctx.stroke();
-      const val = maxLoss - ((maxLoss - minLoss) / 4) * i;
-      ctx.fillStyle = '#64748b'; ctx.font = '10px Inter, sans-serif'; ctx.textAlign = 'right'; ctx.fillText(val.toFixed(3), pad.left - 6, y + 3);
-    }
-    ctx.fillStyle = '#64748b'; ctx.font = '10px Inter, sans-serif'; ctx.textAlign = 'center';
-    ctx.fillText('0%', pad.left, h - 6); ctx.fillText(maxProg.toFixed(0) + '%', w - pad.right, h - 6);
+    var losses = data.map(d => d.loss), maxLoss = Math.max(...losses) * 1.05, minLoss = Math.min(...losses) * 0.95;
+    var maxProg = Math.max(...data.map(d => d.progress), 1);
+    var toX = (prog) => pad.left + (prog / maxProg) * plotW, toY = (loss) => pad.top + ((maxLoss - loss) / (maxLoss - minLoss || 1)) * plotH;
+    ctx.clearRect(0, 0, w, h); ctx.strokeStyle = 'rgba(45,55,72,0.5)'; ctx.lineWidth = 1;
+    for (var i = 0; i <= 4; i++) { var y = pad.top + (plotH / 4) * i; ctx.beginPath(); ctx.moveTo(pad.left, y); ctx.lineTo(w - pad.right, y); ctx.stroke(); var val = maxLoss - ((maxLoss - minLoss) / 4) * i; ctx.fillStyle = '#64748b'; ctx.font = '10px Inter,sans-serif'; ctx.textAlign = 'right'; ctx.fillText(val.toFixed(3), pad.left - 6, y + 3); }
+    ctx.fillStyle = '#64748b'; ctx.font = '10px Inter,sans-serif'; ctx.textAlign = 'center'; ctx.fillText('0%', pad.left, h - 6); ctx.fillText(maxProg.toFixed(0) + '%', w - pad.right, h - 6);
     ctx.strokeStyle = '#4a90d9'; ctx.lineWidth = 2; ctx.lineJoin = 'round'; ctx.lineCap = 'round'; ctx.beginPath();
-    data.forEach((d, i) => { const x = toX(d.progress), y = toY(d.loss); if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y); }); ctx.stroke();
-    const gradient = ctx.createLinearGradient(0, pad.top, 0, h - pad.bottom);
-    gradient.addColorStop(0, 'rgba(74, 144, 217, 0.15)'); gradient.addColorStop(1, 'rgba(74, 144, 217, 0)');
-    ctx.fillStyle = gradient; ctx.beginPath();
-    data.forEach((d, i) => { const x = toX(d.progress), y = toY(d.loss); if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y); });
+    data.forEach((d, i) => { var x = toX(d.progress), y = toY(d.loss); if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y); }); ctx.stroke();
+    var gradient = ctx.createLinearGradient(0, pad.top, 0, h - pad.bottom); gradient.addColorStop(0, 'rgba(74,144,217,0.15)'); gradient.addColorStop(1, 'rgba(74,144,217,0)');
+    ctx.fillStyle = gradient; ctx.beginPath(); data.forEach((d, i) => { var x = toX(d.progress), y = toY(d.loss); if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y); });
     ctx.lineTo(toX(data[data.length - 1].progress), h - pad.bottom); ctx.lineTo(toX(data[0].progress), h - pad.bottom); ctx.closePath(); ctx.fill();
-    const last = data[data.length - 1];
-    ctx.fillStyle = '#4a90d9'; ctx.beginPath(); ctx.arc(toX(last.progress), toY(last.loss), 4, 0, Math.PI * 2); ctx.fill();
-    ctx.strokeStyle = '#0a0e17'; ctx.lineWidth = 2; ctx.stroke();
+    var last = data[data.length - 1]; ctx.fillStyle = '#4a90d9'; ctx.beginPath(); ctx.arc(toX(last.progress), toY(last.loss), 4, 0, Math.PI * 2); ctx.fill(); ctx.strokeStyle = '#0a0e17'; ctx.lineWidth = 2; ctx.stroke();
   },
 
-  // --- Utilities ---
-  esc(str) { const div = document.createElement('div'); div.textContent = str || ''; return div.innerHTML; },
+  esc(str) { var div = document.createElement('div'); div.textContent = str || ''; return div.innerHTML; },
   formatUptime(seconds) { if (seconds < 60) return seconds + 's'; if (seconds < 3600) return Math.floor(seconds / 60) + 'm'; return Math.floor(seconds / 3600) + 'h ' + Math.floor((seconds % 3600) / 60) + 'm'; },
   formatMarkdown(text) { if (!text) return ''; return text.replace(/```(\w*)\n([\s\S]*?)```/g, '<pre><code>$2</code></pre>').replace(/`([^`]+)`/g, '<code>$1</code>').replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>').replace(/\n/g, '<br>'); },
   skeletonCards(n) { return Array(n).fill('<div class="card"><div class="skeleton" style="height:48px;margin-bottom:8px"></div><div class="skeleton" style="height:14px;width:60%"></div></div>').join(''); },
 };
 
-document.addEventListener('DOMContentLoaded', () => AINode.init());
+document.addEventListener('DOMContentLoaded', function() { AINode.init(); });

--- a/ainode/web/static/js/app.js
+++ b/ainode/web/static/js/app.js
@@ -12,6 +12,17 @@ const AINode = {
     trainingView: 'list',
     trainingDetailId: null,
     trainingLossData: [],
+    // Models management
+    modelsCatalog: [],
+    modelsRecommended: [],
+    modelsGpuMemory: null,
+    modelsFilter: 'all',
+    modelsSearch: '',
+    modelsSort: 'recommended',
+    modelsExpanded: null,
+    modelsDownloading: {},
+    modelsDeleteTarget: null,
+    modelsBound: false,
   },
 
   // --- Initialization ---
@@ -92,47 +103,97 @@ const AINode = {
       <div class="card"><div class="stat-value">${totalMem || (s.gpu?.memory_gb || 0)} GB</div><div class="stat-label">Total Memory</div></div>
       <div class="card"><div class="stat-value">${modelsLoaded}</div><div class="stat-label">Models Loaded</div></div>
     `;
-    this.renderNodes(nodes, s);
+    this.renderTopology(nodes, s);
     this.renderClusterHealth(s);
   },
 
-  renderNodes(nodes, status) {
-    const container = document.getElementById('dashboard-nodes');
-    if (!container) return;
+  _topologyInitialized: false,
+
+  renderTopology(nodes, status) {
+    // Build node list — fallback to local node from status
     if (nodes.length === 0 && status) {
       nodes = [{
         node_id: status.node_id || 'local',
         node_name: status.node_name || 'This Node',
         gpu_name: status.gpu?.name || 'Unknown GPU',
         gpu_memory_gb: status.gpu?.memory_gb || 0,
+        gpu_memory_used_pct: status.gpu?.memory_used_pct || 0,
+        gpu_utilization_pct: status.gpu?.utilization_pct || null,
         unified_memory: status.gpu?.unified_memory || false,
         model: status.model || 'none',
         status: status.engine_ready ? 'online' : 'starting',
         is_leader: true,
+        uptime_seconds: status.uptime_seconds || null,
       }];
     }
-    container.innerHTML = nodes.map(node => {
-      const statusClass = node.status === 'online' ? 'status-online' : node.status === 'starting' ? 'status-starting' : 'status-offline';
-      const leaderClass = node.is_leader ? 'is-leader' : '';
-      const memLabel = node.unified_memory ? 'unified' : 'VRAM';
-      const memPct = node.gpu_memory_used_pct || 0;
-      const barClass = memPct > 90 ? 'red' : memPct > 70 ? 'yellow' : 'green';
-      return `
-        <div class="node-card ${leaderClass}">
-          <div style="display:flex; justify-content:space-between; align-items:start; margin-bottom:12px">
-            <div>
-              <div class="node-name">${this.esc(node.node_name || node.node_id)}</div>
-              <div class="node-id">${this.esc(node.node_id)}</div>
-            </div>
-            <div class="status ${statusClass}"><span class="status-dot"></span>${node.status || 'unknown'}</div>
-          </div>
-          <div class="node-gpu">${this.esc(node.gpu_name || 'Unknown')} &middot; ${node.gpu_memory_gb || '?'} GB ${memLabel}</div>
-          <div class="node-model">${this.esc(node.model || 'no model')}</div>
-          <div class="progress-bar"><div class="progress-fill ${barClass}" style="width:${memPct}%"></div></div>
-          <div style="font-size:11px; color:var(--text-muted); margin-top:4px">Memory: ${memPct}% used</div>
+
+    // Initialize topology canvas once
+    if (!this._topologyInitialized) {
+      const canvas = document.getElementById('topology-canvas');
+      if (canvas && typeof Topology !== 'undefined') {
+        Topology.init(canvas, (nodeData) => this.showTopologyDetail(nodeData));
+        this._topologyInitialized = true;
+      }
+    }
+
+    // Update topology data
+    if (typeof Topology !== 'undefined') {
+      Topology.update(nodes);
+    }
+  },
+
+  showTopologyDetail(nodeData) {
+    const panel = document.getElementById('topology-detail');
+    if (!panel) return;
+    if (!nodeData) {
+      panel.style.display = 'none';
+      return;
+    }
+    const d = nodeData;
+    const statusClass = d.status === 'online' ? 'status-online' : d.status === 'starting' ? 'status-starting' : 'status-offline';
+    const memLabel = d.unified_memory ? 'unified' : 'VRAM';
+    const memPct = d.gpu_memory_used_pct || 0;
+    const gpuUtil = d.gpu_utilization_pct != null ? d.gpu_utilization_pct + '%' : 'N/A';
+    const uptime = d.uptime_seconds ? this.formatUptime(d.uptime_seconds) : 'N/A';
+    panel.style.display = 'block';
+    panel.innerHTML = `
+      <div class="topology-detail-header">
+        <div>
+          <div class="topology-detail-name">${this.esc(d.node_name || d.node_id)}${d.is_leader ? ' <span style="color:var(--accent);font-size:12px;font-weight:600">LEADER</span>' : ''}</div>
+          <div class="topology-detail-id">${this.esc(d.node_id)}</div>
         </div>
-      `;
-    }).join('');
+        <div style="display:flex;align-items:center;gap:12px">
+          <div class="status ${statusClass}"><span class="status-dot"></span>${d.status || 'unknown'}</div>
+          <button class="topology-detail-close" id="topology-detail-close">Close</button>
+        </div>
+      </div>
+      <div class="topology-detail-grid">
+        <div class="topology-detail-stat">
+          <div class="stat-value" style="color:var(--text-primary)">${this.esc(d.gpu_name || 'Unknown')}</div>
+          <div class="stat-label">GPU</div>
+        </div>
+        <div class="topology-detail-stat">
+          <div class="stat-value">${d.gpu_memory_gb || '?'} <span style="font-size:14px;color:var(--text-muted)">GB ${memLabel}</span></div>
+          <div class="stat-label">Memory</div>
+          <div class="progress-bar" style="margin-top:6px"><div class="progress-fill ${memPct > 90 ? 'red' : memPct > 70 ? 'yellow' : 'green'}" style="width:${memPct}%"></div></div>
+          <div style="font-size:11px;color:var(--text-muted);margin-top:2px">${memPct}% used</div>
+        </div>
+        <div class="topology-detail-stat">
+          <div class="stat-value">${gpuUtil}</div>
+          <div class="stat-label">GPU Utilization</div>
+        </div>
+        <div class="topology-detail-stat">
+          <div class="stat-value">${uptime}</div>
+          <div class="stat-label">Uptime</div>
+        </div>
+      </div>
+      <div style="margin-top:12px;font-family:var(--font-mono);font-size:13px;color:var(--accent)">
+        Model: ${this.esc(d.model || 'no model loaded')}
+      </div>
+    `;
+    document.getElementById('topology-detail-close')?.addEventListener('click', () => {
+      panel.style.display = 'none';
+    });
   },
 
   renderClusterHealth(status) {

--- a/ainode/web/static/js/app.js
+++ b/ainode/web/static/js/app.js
@@ -12,6 +12,9 @@ const AINode = {
     trainingView: 'list',
     trainingDetailId: null,
     trainingLossData: [],
+    // Metrics / monitoring
+    metrics: null,
+    metricsInterval: null,
   },
 
   // --- Initialization ---
@@ -20,6 +23,7 @@ const AINode = {
     this.bindChat();
     this.navigate(window.location.hash.slice(1) || 'dashboard');
     this.startPolling();
+    this.startMetricsPolling();
   },
 
   // --- Navigation ---
@@ -226,34 +230,287 @@ const AINode = {
   },
 
   // --- Models View ---
-  renderModels() {
+  async renderModels() {
     const container = document.getElementById('models-list');
     if (!container) return;
-    const s = this.state.status;
-    const loaded = s?.models_loaded || [];
-    const recommended = [
-      { id: 'meta-llama/Llama-3.2-3B-Instruct', size: '~6 GB', desc: 'Quick start, fast inference' },
-      { id: 'meta-llama/Llama-3.1-8B-Instruct', size: '~16 GB', desc: 'Recommended for most tasks' },
-      { id: 'meta-llama/Llama-3.1-70B-Instruct-AWQ', size: '~35 GB', desc: 'High quality, needs 40+ GB' },
-      { id: 'Qwen/Qwen2.5-72B-Instruct', size: '~40 GB', desc: 'Great for coding + multilingual' },
-      { id: 'deepseek-ai/DeepSeek-R1-Distill-Qwen-7B', size: '~14 GB', desc: 'Reasoning specialist' },
-      { id: 'mistralai/Mistral-7B-Instruct-v0.3', size: '~14 GB', desc: 'Fast, general purpose' },
-    ];
-    container.innerHTML = recommended.map(model => {
-      const isLoaded = loaded.includes(model.id);
-      return `
-        <div class="model-card">
-          <div class="model-info">
-            <div class="model-name">${this.esc(model.id)}</div>
-            <div class="model-meta">${model.size} &middot; ${model.desc}</div>
-          </div>
-          <div class="model-status">
-            ${isLoaded ? '<span class="model-badge loaded">Loaded</span>' : '<span class="model-badge available">Available</span>'}
-          </div>
-        </div>
-      `;
-    }).join('');
+
+    const [catalogData, recData] = await Promise.all([
+      this.fetchJSON('/api/models'),
+      this.fetchJSON('/api/models/recommended'),
+    ]);
+    this.state.modelsCatalog = catalogData?.models || [];
+    this.state.modelsRecommended = recData?.models?.map(m => m.id) || [];
+    this.state.modelsGpuMemory = recData?.gpu_memory_gb || null;
+
+    if (!this.state.modelsBound) {
+      this.bindModelsUI();
+      this.state.modelsBound = true;
+    }
+
+    this.renderModelsList();
   },
+
+  bindModelsUI() {
+    const searchInput = document.getElementById('models-search');
+    if (searchInput) {
+      searchInput.addEventListener('input', (e) => {
+        this.state.modelsSearch = e.target.value.toLowerCase();
+        this.renderModelsList();
+      });
+    }
+
+    document.querySelectorAll('#models-filters .filter-pill').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('#models-filters .filter-pill').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        this.state.modelsFilter = btn.dataset.filter;
+        this.renderModelsList();
+      });
+    });
+
+    const sortSelect = document.getElementById('models-sort');
+    if (sortSelect) {
+      sortSelect.addEventListener('change', (e) => {
+        this.state.modelsSort = e.target.value;
+        this.renderModelsList();
+      });
+    }
+
+    document.getElementById('model-delete-cancel')?.addEventListener('click', () => this.hideDeleteModal());
+    document.getElementById('model-delete-confirm')?.addEventListener('click', () => this.confirmDeleteModel());
+    document.getElementById('model-delete-modal')?.addEventListener('click', (e) => {
+      if (e.target.classList.contains('model-modal-overlay')) this.hideDeleteModal();
+    });
+  },
+
+  renderModelsList() {
+    const container = document.getElementById('models-list');
+    if (!container) return;
+
+    const s = this.state.status;
+    const activeModel = s?.model || '';
+    const loadedModels = s?.models_loaded || [];
+    const gpuMem = this.state.modelsGpuMemory;
+    const recommended = this.state.modelsRecommended;
+    let models = [...this.state.modelsCatalog];
+
+    const filter = this.state.modelsFilter;
+    if (filter === 'downloaded') models = models.filter(m => m.downloaded);
+    else if (filter === 'available') models = models.filter(m => !m.downloaded);
+    else if (filter === 'recommended') models = models.filter(m => recommended.includes(m.id));
+
+    const q = this.state.modelsSearch;
+    if (q) {
+      models = models.filter(m =>
+        m.name.toLowerCase().includes(q) ||
+        m.description.toLowerCase().includes(q) ||
+        m.id.toLowerCase().includes(q) ||
+        m.hf_repo.toLowerCase().includes(q)
+      );
+    }
+
+    const sort = this.state.modelsSort;
+    if (sort === 'name') models.sort((a, b) => a.name.localeCompare(b.name));
+    else if (sort === 'size') models.sort((a, b) => a.size_gb - b.size_gb);
+    else {
+      models.sort((a, b) => {
+        const aActive = this.isModelActive(a, activeModel, loadedModels) ? -2 : 0;
+        const bActive = this.isModelActive(b, activeModel, loadedModels) ? -2 : 0;
+        const aDl = a.downloaded ? -1 : 0;
+        const bDl = b.downloaded ? -1 : 0;
+        const aRec = recommended.includes(a.id) ? -1 : 0;
+        const bRec = recommended.includes(b.id) ? -1 : 0;
+        return (aActive + aDl + aRec) - (bActive + bDl + bRec) || a.size_gb - b.size_gb;
+      });
+    }
+
+    const diskEl = document.getElementById('models-disk-space');
+    if (diskEl) {
+      const totalDisk = this.state.modelsCatalog.reduce((sum, m) => sum + (m.local_size_gb || 0), 0);
+      const dlCount = this.state.modelsCatalog.filter(m => m.downloaded).length;
+      diskEl.innerHTML = dlCount > 0
+        ? '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg> ' +
+          '<span>' + dlCount + ' downloaded &middot; ' + totalDisk.toFixed(1) + ' GB used</span>'
+        : '<span>No models downloaded</span>';
+    }
+
+    if (models.length === 0) {
+      container.innerHTML = '<div class="models-empty"><p>No models match your search.</p></div>';
+      return;
+    }
+
+    container.innerHTML = models.map(model => this.renderModelCard(model, activeModel, loadedModels, gpuMem)).join('');
+
+    container.querySelectorAll('.model-card-enhanced').forEach(card => {
+      const modelId = card.dataset.modelId;
+      card.querySelector('.model-card-main')?.addEventListener('click', () => {
+        this.state.modelsExpanded = this.state.modelsExpanded === modelId ? null : modelId;
+        this.renderModelsList();
+      });
+      card.querySelector('.model-download-btn')?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this.downloadModel(modelId);
+      });
+      card.querySelector('.model-delete-btn')?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this.showDeleteModal(modelId);
+      });
+    });
+  },
+
+  isModelActive(model, activeModel, loadedModels) {
+    return loadedModels.includes(model.hf_repo) || activeModel === model.hf_repo || activeModel === model.id;
+  },
+
+  getGpuFit(model, gpuMem) {
+    if (gpuMem == null) return 'unknown';
+    if (model.min_memory_gb <= gpuMem * 0.8) return 'fits';
+    if (model.min_memory_gb <= gpuMem) return 'tight';
+    return 'no-fit';
+  },
+
+  renderModelCard(model, activeModel, loadedModels, gpuMem) {
+    const isActive = this.isModelActive(model, activeModel, loadedModels);
+    const isExpanded = this.state.modelsExpanded === model.id;
+    const isDownloading = !!this.state.modelsDownloading[model.id];
+    const downloadProgress = this.state.modelsDownloading[model.id]?.progress || 0;
+    const fit = this.getGpuFit(model, gpuMem);
+
+    const fitIcon = fit === 'fits'
+      ? '<span class="gpu-fit gpu-fit-yes" title="Fits your GPU"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" width="14" height="14"><polyline points="20 6 9 17 4 12"/></svg></span>'
+      : fit === 'tight'
+      ? '<span class="gpu-fit gpu-fit-warn" title="Tight fit for your GPU"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14"><path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg></span>'
+      : fit === 'no-fit'
+      ? '<span class="gpu-fit gpu-fit-no" title="Won\'t fit your GPU"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" width="14" height="14"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></span>'
+      : '';
+
+    let statusHTML = '';
+    if (isActive) {
+      statusHTML = '<span class="model-badge active">Active</span>';
+    } else if (isDownloading) {
+      statusHTML = '<span class="model-badge downloading">Downloading</span>';
+    } else if (model.downloaded) {
+      statusHTML = '<span class="model-badge loaded">Downloaded</span>';
+    } else {
+      statusHTML = '<span class="model-badge available">Available</span>';
+    }
+
+    let actionHTML = '';
+    if (isDownloading) {
+      actionHTML = '<div class="model-progress-wrap"><div class="progress-bar model-progress-bar"><div class="progress-fill accent model-progress-animated" style="width:' + downloadProgress + '%"></div></div><span class="model-progress-text">Downloading...</span></div>';
+    } else if (model.downloaded) {
+      actionHTML = '<button class="btn btn-ghost btn-sm model-delete-btn" title="Delete model"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg></button>';
+    } else {
+      actionHTML = '<button class="btn btn-primary btn-sm model-download-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg> Download</button>';
+    }
+
+    const quantBadge = model.quantization
+      ? '<span class="model-quant-badge">' + this.esc(model.quantization.toUpperCase()) + '</span>'
+      : '';
+
+    let expandedHTML = '';
+    if (isExpanded) {
+      expandedHTML = '<div class="model-detail">' +
+        '<div class="model-detail-grid">' +
+          '<div class="model-detail-item"><span class="model-detail-label">HuggingFace Repo</span><span class="model-detail-value mono">' + this.esc(model.hf_repo) + '</span></div>' +
+          '<div class="model-detail-item"><span class="model-detail-label">Model Size</span><span class="model-detail-value">' + model.size_gb + ' GB</span></div>' +
+          '<div class="model-detail-item"><span class="model-detail-label">Min GPU Memory</span><span class="model-detail-value">' + model.min_memory_gb + ' GB</span></div>' +
+          (model.quantization ? '<div class="model-detail-item"><span class="model-detail-label">Quantization</span><span class="model-detail-value">' + this.esc(model.quantization.toUpperCase()) + '</span></div>' : '') +
+          (model.downloaded && model.local_size_gb != null ? '<div class="model-detail-item"><span class="model-detail-label">Disk Usage</span><span class="model-detail-value">' + model.local_size_gb + ' GB</span></div>' : '') +
+          (gpuMem != null ? '<div class="model-detail-item"><span class="model-detail-label">Your GPU Memory</span><span class="model-detail-value">' + gpuMem + ' GB</span></div>' : '') +
+        '</div>' +
+      '</div>';
+    }
+
+    return '<div class="model-card-enhanced' + (isActive ? ' model-active' : '') + (isExpanded ? ' model-expanded' : '') + '" data-model-id="' + this.esc(model.id) + '">' +
+      '<div class="model-card-main">' +
+        '<div class="model-card-left">' +
+          fitIcon +
+          '<div class="model-info">' +
+            '<div class="model-name-row"><span class="model-name">' + this.esc(model.name) + '</span>' + quantBadge + (isActive ? '<span class="model-active-badge">ACTIVE</span>' : '') + '</div>' +
+            '<div class="model-meta">' + this.esc(model.description) + '</div>' +
+            '<div class="model-meta-stats">' + model.size_gb + ' GB &middot; Min ' + model.min_memory_gb + ' GB GPU' + (model.downloaded && model.local_size_gb != null ? ' &middot; ' + model.local_size_gb + ' GB on disk' : '') + '</div>' +
+          '</div>' +
+        '</div>' +
+        '<div class="model-card-right">' +
+          statusHTML +
+          actionHTML +
+        '</div>' +
+      '</div>' +
+      expandedHTML +
+    '</div>';
+  },
+
+  async downloadModel(modelId) {
+    if (this.state.modelsDownloading[modelId]) return;
+    this.state.modelsDownloading[modelId] = { progress: 0, status: 'downloading' };
+    this.renderModelsList();
+
+    try {
+      const resp = await fetch('/api/models/' + encodeURIComponent(modelId) + '/download', { method: 'POST' });
+      const result = await resp.json();
+      if (!resp.ok) {
+        delete this.state.modelsDownloading[modelId];
+        this.renderModelsList();
+        alert('Download failed: ' + (result.error || 'Unknown error'));
+        return;
+      }
+      this.pollDownload(modelId, result.job_id);
+    } catch (err) {
+      delete this.state.modelsDownloading[modelId];
+      this.renderModelsList();
+      alert('Download error: ' + err.message);
+    }
+  },
+
+  pollDownload(modelId, jobId) {
+    const poll = async () => {
+      if (!this.state.modelsDownloading[modelId]) return;
+      const info = await this.fetchJSON('/api/models/' + encodeURIComponent(modelId));
+      if (info?.downloaded) {
+        delete this.state.modelsDownloading[modelId];
+        this.renderModels();
+        return;
+      }
+      const dl = this.state.modelsDownloading[modelId];
+      if (dl && dl.progress < 90) dl.progress = Math.min(dl.progress + 5, 90);
+      this.renderModelsList();
+      setTimeout(poll, 3000);
+    };
+    setTimeout(poll, 2000);
+  },
+
+  showDeleteModal(modelId) {
+    const model = this.state.modelsCatalog.find(m => m.id === modelId);
+    this.state.modelsDeleteTarget = modelId;
+    const msg = document.getElementById('model-delete-msg');
+    if (msg && model) {
+      msg.textContent = 'Are you sure you want to delete "' + model.name + '"? This will free up ' + (model.local_size_gb || model.size_gb) + ' GB of disk space.';
+    }
+    document.getElementById('model-delete-modal').style.display = 'flex';
+  },
+
+  hideDeleteModal() {
+    this.state.modelsDeleteTarget = null;
+    document.getElementById('model-delete-modal').style.display = 'none';
+  },
+
+  async confirmDeleteModel() {
+    const modelId = this.state.modelsDeleteTarget;
+    if (!modelId) return;
+    this.hideDeleteModal();
+    try {
+      const resp = await fetch('/api/models/' + encodeURIComponent(modelId), { method: 'DELETE' });
+      if (!resp.ok) {
+        const err = await resp.json().catch(() => ({}));
+        alert('Delete failed: ' + (err.error || 'Unknown error'));
+      }
+    } catch (err) {
+      alert('Delete error: ' + err.message);
+    }
+    this.renderModels();
+  },
+
 
   // --- Training View ---
   trainingModels: [
@@ -522,6 +779,135 @@ const AINode = {
     const last = data[data.length - 1];
     ctx.fillStyle = '#4a90d9'; ctx.beginPath(); ctx.arc(toX(last.progress), toY(last.loss), 4, 0, Math.PI * 2); ctx.fill();
     ctx.strokeStyle = '#0a0e17'; ctx.lineWidth = 2; ctx.stroke();
+  },
+
+  // --- Metrics Polling ---
+  startMetricsPolling() {
+    this.fetchMetrics();
+    this.state.metricsInterval = setInterval(() => this.fetchMetrics(), 3000);
+  },
+
+  async fetchMetrics() {
+    const data = await this.fetchJSON('/api/metrics');
+    if (data) {
+      this.state.metrics = data;
+      if (this.state.currentView === 'dashboard') {
+        this.renderMonitoring();
+      }
+    }
+  },
+
+  // --- Monitoring Widgets ---
+  renderMonitoring() {
+    const container = document.getElementById('dashboard-monitoring');
+    if (!container) return;
+    const m = this.state.metrics;
+    if (!m) { container.innerHTML = ''; return; }
+
+    const gpu = m.gpu || {};
+    const req = m.requests || {};
+    const hasGPU = !gpu.error;
+
+    const utilPct = hasGPU ? (gpu.utilization_percent || 0) : 0;
+    const memUsedMB = hasGPU ? (gpu.memory_used_mb || 0) : 0;
+    const memTotalMB = hasGPU ? (gpu.memory_total_mb || 1) : 1;
+    const memPct = Math.round((memUsedMB / memTotalMB) * 100);
+    const memUsedGB = (memUsedMB / 1024).toFixed(1);
+    const memTotalGB = (memTotalMB / 1024).toFixed(0);
+    const tempC = hasGPU ? (gpu.temperature_c || 0) : 0;
+
+    const totalReqs = req.total || 0;
+    const errors = req.errors || 0;
+    const errorRate = totalReqs > 0 ? ((errors / totalReqs) * 100).toFixed(1) : '0.0';
+    const latency = req.latency_ms || { p50: 0, p95: 0, p99: 0 };
+    const tokSec = req.tokens_per_second || 0;
+    const totalTokens = req.tokens_generated || 0;
+    const uptime = m.uptime_seconds || 0;
+    const reqPerMin = uptime > 60 ? ((totalReqs / uptime) * 60).toFixed(1) : totalReqs.toFixed(1);
+    const activeModel = this.state.status?.model || 'none';
+    const isUnified = this.state.status?.gpu?.unified_memory || false;
+
+    container.innerHTML = `
+      <div class="card-header" style="margin-bottom:12px">
+        <div class="card-title">Monitoring</div>
+      </div>
+      <div class="monitoring-grid" style="margin-bottom:24px">
+        <div class="card monitoring-card">
+          <div class="card-header"><div class="card-title">GPU Utilization</div></div>
+          <div class="gauge-container">
+            ${this.renderArcGauge(utilPct, this.gaugeColor(utilPct), utilPct + '%')}
+          </div>
+        </div>
+        <div class="card monitoring-card">
+          <div class="card-header"><div class="card-title">${isUnified ? 'Unified Memory' : 'GPU Memory'}</div></div>
+          <div class="gauge-container">
+            ${this.renderArcGauge(memPct, this.gaugeColor(memPct), memUsedGB + ' / ' + memTotalGB + ' GB')}
+          </div>
+        </div>
+        <div class="card monitoring-card monitoring-right-panel">
+          <div class="temp-section">
+            <div class="card-header"><div class="card-title">Temperature</div></div>
+            <div class="temp-bar-wrap">
+              <div class="temp-value" style="color:${this.tempColor(tempC)}">${hasGPU ? tempC + '\u00B0C' : 'N/A'}</div>
+              <div class="temp-bar">
+                <div class="temp-bar-fill" style="width:${Math.min(tempC, 100)}%;background:${this.tempColor(tempC)};transition:width 0.6s ease"></div>
+              </div>
+              <div class="temp-labels"><span>0\u00B0C</span><span>50\u00B0C</span><span>100\u00B0C</span></div>
+            </div>
+          </div>
+          <div class="request-section">
+            <div class="card-header"><div class="card-title">Request Metrics</div></div>
+            <table class="table metrics-table">
+              <tr><td>Total Requests</td><td class="metric-val">${totalReqs.toLocaleString()}</td></tr>
+              <tr><td>Requests / min</td><td class="metric-val">${reqPerMin}</td></tr>
+              <tr><td>Error Rate</td><td class="metric-val${errors > 0 ? ' metric-err' : ''}">${errorRate}%</td></tr>
+              <tr><td>Latency p50/p95/p99</td><td class="metric-val">${latency.p50}/${latency.p95}/${latency.p99} ms</td></tr>
+              <tr><td>Active Model</td><td class="metric-val metric-model">${this.esc(activeModel)}</td></tr>
+            </table>
+          </div>
+          ${tokSec > 0 || totalTokens > 0 ? `
+          <div class="inference-section">
+            <div class="card-header"><div class="card-title">Inference</div></div>
+            <div class="inference-stats">
+              <div class="inference-stat"><span class="inference-num">${tokSec.toFixed(1)}</span><span class="inference-label">tok/s</span></div>
+              <div class="inference-stat"><span class="inference-num">${totalTokens.toLocaleString()}</span><span class="inference-label">total tokens</span></div>
+            </div>
+          </div>` : ''}
+        </div>
+      </div>
+    `;
+  },
+
+  renderArcGauge(pct, color, label) {
+    const r = 70, stroke = 12, cx = 85, cy = 85;
+    const startAngle = 135, sweep = 270;
+    const filledAngle = startAngle + (sweep * (pct / 100));
+    const toRad = (deg) => (deg * Math.PI) / 180;
+    const arcX = (deg) => cx + r * Math.cos(toRad(deg));
+    const arcY = (deg) => cy + r * Math.sin(toRad(deg));
+    const bgStart = `${arcX(startAngle)},${arcY(startAngle)}`;
+    const bgEnd = `${arcX(startAngle + sweep)},${arcY(startAngle + sweep)}`;
+    const fillEnd = `${arcX(filledAngle)},${arcY(filledAngle)}`;
+    const fillSweepFlag = (filledAngle - startAngle) > 180 ? 1 : 0;
+    return `<svg class="arc-gauge" viewBox="0 0 170 140" xmlns="http://www.w3.org/2000/svg">
+      <path d="M${bgStart} A${r},${r} 0 1,1 ${bgEnd}" fill="none" stroke="var(--border)" stroke-width="${stroke}" stroke-linecap="round"/>
+      ${pct > 0 ? `<path class="arc-gauge-fill" d="M${bgStart} A${r},${r} 0 ${fillSweepFlag},1 ${fillEnd}" fill="none" stroke="${color}" stroke-width="${stroke}" stroke-linecap="round"/>` : ''}
+      <text x="${cx}" y="${cy - 2}" text-anchor="middle" class="gauge-pct">${pct}</text>
+      <text x="${cx}" y="${cy + 16}" text-anchor="middle" class="gauge-label">${label}</text>
+    </svg>`;
+  },
+
+  gaugeColor(pct) {
+    if (pct < 60) return 'var(--green)';
+    if (pct < 85) return 'var(--yellow)';
+    return 'var(--red)';
+  },
+
+  tempColor(temp) {
+    if (temp < 50) return 'var(--accent)';
+    if (temp < 70) return 'var(--green)';
+    if (temp < 85) return 'var(--yellow)';
+    return 'var(--red)';
   },
 
   // --- Utilities ---

--- a/ainode/web/static/js/topology.js
+++ b/ainode/web/static/js/topology.js
@@ -1,0 +1,685 @@
+/* AINode Topology — Interactive Force-Directed Node Graph */
+
+const Topology = (() => {
+  // --- Configuration ---
+  const CONFIG = {
+    nodeWidth: 220,
+    nodeHeight: 88,
+    nodeRadius: 14,
+    minHeight: 360,
+    padding: 60,
+    // Physics
+    repulsionStrength: 8000,
+    attractionStrength: 0.005,
+    centerGravity: 0.03,
+    damping: 0.88,
+    minVelocity: 0.01,
+    // Appearance
+    connectionWidth: 2,
+    pulseSpeed: 0.002,
+    hoverExpandHeight: 56,
+    // Colors (read from CSS vars at init)
+    colors: {},
+  };
+
+  // --- State ---
+  let canvas = null;
+  let ctx = null;
+  let width = 0;
+  let height = 0;
+  let dpr = 1;
+  let animFrameId = null;
+  let time = 0;
+  let selectedNodeId = null;
+  let hoveredNodeId = null;
+  let onSelectCallback = null;
+
+  // Graph data
+  let graphNodes = [];
+  let graphEdges = [];
+
+  // Mouse state
+  let mouse = { x: 0, y: 0, down: false };
+  let dragNode = null;
+  let dragOffset = { x: 0, y: 0 };
+
+  // --- Color Helpers ---
+  function readCSSColors() {
+    const style = getComputedStyle(document.documentElement);
+    const get = (v) => style.getPropertyValue(v).trim();
+    CONFIG.colors = {
+      bgPrimary: get('--bg-primary') || '#0a0e17',
+      bgCard: get('--bg-card') || '#1a2332',
+      bgCardHover: get('--bg-card-hover') || '#1e2a3d',
+      border: get('--border') || '#2d3748',
+      borderActive: get('--border-active') || '#4a90d9',
+      textPrimary: get('--text-primary') || '#e2e8f0',
+      textSecondary: get('--text-secondary') || '#94a3b8',
+      textMuted: get('--text-muted') || '#64748b',
+      accent: get('--accent') || '#4a90d9',
+      green: get('--green') || '#10b981',
+      yellow: get('--yellow') || '#f59e0b',
+      red: get('--red') || '#ef4444',
+      purple: get('--purple') || '#8b5cf6',
+    };
+  }
+
+  function hexToRgba(hex, alpha) {
+    hex = hex.replace('#', '');
+    if (hex.length === 3) hex = hex[0]+hex[0]+hex[1]+hex[1]+hex[2]+hex[2];
+    const r = parseInt(hex.substring(0,2), 16);
+    const g = parseInt(hex.substring(2,4), 16);
+    const b = parseInt(hex.substring(4,6), 16);
+    return `rgba(${r},${g},${b},${alpha})`;
+  }
+
+  // --- Initialization ---
+  function init(canvasEl, onSelect) {
+    canvas = canvasEl;
+    ctx = canvas.getContext('2d');
+    onSelectCallback = onSelect;
+    dpr = window.devicePixelRatio || 1;
+    readCSSColors();
+    resize();
+    bindEvents();
+    startLoop();
+  }
+
+  function destroy() {
+    if (animFrameId) cancelAnimationFrame(animFrameId);
+    animFrameId = null;
+    unbindEvents();
+  }
+
+  function resize() {
+    if (!canvas || !canvas.parentElement) return;
+    const rect = canvas.parentElement.getBoundingClientRect();
+    width = rect.width;
+    height = Math.max(rect.height, CONFIG.minHeight);
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    canvas.style.width = width + 'px';
+    canvas.style.height = height + 'px';
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  }
+
+  // --- Event Binding ---
+  let boundHandlers = {};
+
+  function bindEvents() {
+    boundHandlers.mouseMove = (e) => {
+      const rect = canvas.getBoundingClientRect();
+      mouse.x = e.clientX - rect.left;
+      mouse.y = e.clientY - rect.top;
+      if (dragNode) {
+        dragNode.x = mouse.x - dragOffset.x;
+        dragNode.y = mouse.y - dragOffset.y;
+        dragNode.vx = 0;
+        dragNode.vy = 0;
+        dragNode.pinned = true;
+      }
+      updateHover();
+    };
+    boundHandlers.mouseDown = (e) => {
+      mouse.down = true;
+      const node = getNodeAt(mouse.x, mouse.y);
+      if (node) {
+        dragNode = node;
+        dragOffset.x = mouse.x - node.x;
+        dragOffset.y = mouse.y - node.y;
+        canvas.style.cursor = 'grabbing';
+      }
+    };
+    boundHandlers.mouseUp = () => {
+      if (dragNode) {
+        // If barely moved, treat as click
+        const dx = mouse.x - (dragNode.x + dragOffset.x);
+        const dy = mouse.y - (dragNode.y + dragOffset.y);
+        if (Math.abs(dx) < 3 && Math.abs(dy) < 3) {
+          selectNode(dragNode.id);
+        }
+        dragNode.pinned = false;
+        dragNode = null;
+        canvas.style.cursor = 'default';
+      }
+      mouse.down = false;
+    };
+    boundHandlers.resize = () => {
+      resize();
+      // Re-center nodes if needed
+      graphNodes.forEach(n => {
+        n.x = Math.min(Math.max(n.x, CONFIG.padding), width - CONFIG.padding);
+        n.y = Math.min(Math.max(n.y, CONFIG.padding), height - CONFIG.padding);
+      });
+    };
+    boundHandlers.click = (e) => {
+      const node = getNodeAt(mouse.x, mouse.y);
+      if (!node && !dragNode) {
+        selectNode(null);
+      }
+    };
+
+    canvas.addEventListener('mousemove', boundHandlers.mouseMove);
+    canvas.addEventListener('mousedown', boundHandlers.mouseDown);
+    canvas.addEventListener('mouseup', boundHandlers.mouseUp);
+    canvas.addEventListener('mouseleave', () => {
+      hoveredNodeId = null;
+      if (dragNode) { dragNode.pinned = false; dragNode = null; }
+      mouse.down = false;
+      canvas.style.cursor = 'default';
+    });
+    canvas.addEventListener('click', boundHandlers.click);
+    window.addEventListener('resize', boundHandlers.resize);
+  }
+
+  function unbindEvents() {
+    if (!canvas) return;
+    canvas.removeEventListener('mousemove', boundHandlers.mouseMove);
+    canvas.removeEventListener('mousedown', boundHandlers.mouseDown);
+    canvas.removeEventListener('mouseup', boundHandlers.mouseUp);
+    canvas.removeEventListener('click', boundHandlers.click);
+    window.removeEventListener('resize', boundHandlers.resize);
+  }
+
+  function updateHover() {
+    const node = getNodeAt(mouse.x, mouse.y);
+    const newHovered = node ? node.id : null;
+    if (newHovered !== hoveredNodeId) {
+      hoveredNodeId = newHovered;
+      canvas.style.cursor = newHovered ? 'grab' : 'default';
+      if (dragNode) canvas.style.cursor = 'grabbing';
+    }
+  }
+
+  function getNodeAt(mx, my) {
+    // Reverse order so topmost (last drawn) is checked first
+    for (let i = graphNodes.length - 1; i >= 0; i--) {
+      const n = graphNodes[i];
+      const nw = CONFIG.nodeWidth;
+      const nh = getNodeHeight(n);
+      if (mx >= n.x - nw/2 && mx <= n.x + nw/2 &&
+          my >= n.y - nh/2 && my <= n.y + nh/2) {
+        return n;
+      }
+    }
+    return null;
+  }
+
+  function getNodeHeight(n) {
+    const base = CONFIG.nodeHeight;
+    if (hoveredNodeId === n.id) return base + CONFIG.hoverExpandHeight;
+    return base;
+  }
+
+  function selectNode(id) {
+    selectedNodeId = id;
+    if (onSelectCallback) {
+      const node = graphNodes.find(n => n.id === id);
+      onSelectCallback(node ? node.data : null);
+    }
+  }
+
+  // --- Data Update ---
+  function update(nodesData) {
+    if (!nodesData || !Array.isArray(nodesData)) return;
+
+    const existingMap = {};
+    graphNodes.forEach(n => { existingMap[n.id] = n; });
+
+    const newIds = new Set(nodesData.map(n => n.node_id || n.id || 'local'));
+    const updatedNodes = [];
+
+    nodesData.forEach((nd, i) => {
+      const id = nd.node_id || nd.id || 'local';
+      let gn = existingMap[id];
+      if (gn) {
+        // Update data, keep position
+        gn.data = nd;
+      } else {
+        // New node — place with initial position
+        gn = {
+          id,
+          data: nd,
+          x: width / 2 + (Math.random() - 0.5) * 100,
+          y: height / 2 + (Math.random() - 0.5) * 100,
+          vx: 0,
+          vy: 0,
+          pinned: false,
+          targetAlpha: 1,
+          alpha: 0, // fade in
+        };
+      }
+      updatedNodes.push(gn);
+    });
+
+    graphNodes = updatedNodes;
+
+    // Build edges: all-to-all mesh for discovered cluster
+    graphEdges = [];
+    for (let i = 0; i < graphNodes.length; i++) {
+      for (let j = i + 1; j < graphNodes.length; j++) {
+        const a = graphNodes[i];
+        const b = graphNodes[j];
+        const aOnline = a.data.status === 'online';
+        const bOnline = b.data.status === 'online';
+        graphEdges.push({
+          source: a,
+          target: b,
+          solid: aOnline && bOnline,
+          label: 'LAN',
+        });
+      }
+    }
+
+    // If single node, position at center
+    if (graphNodes.length === 1) {
+      const n = graphNodes[0];
+      if (!n.pinned) {
+        n.x = width / 2;
+        n.y = height / 2;
+      }
+    }
+    // For 2-4 nodes, arrange in a circle initially if new
+    else if (graphNodes.length <= 4) {
+      layoutCircle(false);
+    }
+  }
+
+  function layoutCircle(force) {
+    const cx = width / 2;
+    const cy = height / 2;
+    const radius = Math.min(width, height) * 0.25;
+    graphNodes.forEach((n, i) => {
+      if (force || (n.alpha < 0.1 && !n.pinned)) {
+        const angle = (i / graphNodes.length) * Math.PI * 2 - Math.PI / 2;
+        n.x = cx + Math.cos(angle) * radius;
+        n.y = cy + Math.sin(angle) * radius;
+      }
+    });
+  }
+
+  // --- Physics ---
+  function simulate() {
+    const N = graphNodes.length;
+    if (N === 0) return;
+    if (N === 1) {
+      // Single node: gently drift to center
+      const n = graphNodes[0];
+      if (!n.pinned) {
+        n.vx += (width / 2 - n.x) * 0.02;
+        n.vy += (height / 2 - n.y) * 0.02;
+        n.vx *= CONFIG.damping;
+        n.vy *= CONFIG.damping;
+        n.x += n.vx;
+        n.y += n.vy;
+      }
+      n.alpha += (n.targetAlpha - n.alpha) * 0.05;
+      return;
+    }
+
+    // Repulsion between all node pairs
+    for (let i = 0; i < N; i++) {
+      for (let j = i + 1; j < N; j++) {
+        const a = graphNodes[i];
+        const b = graphNodes[j];
+        let dx = b.x - a.x;
+        let dy = b.y - a.y;
+        let dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist < 1) dist = 1;
+        const force = CONFIG.repulsionStrength / (dist * dist);
+        const fx = (dx / dist) * force;
+        const fy = (dy / dist) * force;
+        if (!a.pinned) { a.vx -= fx; a.vy -= fy; }
+        if (!b.pinned) { b.vx += fx; b.vy += fy; }
+      }
+    }
+
+    // Attraction along edges
+    graphEdges.forEach(edge => {
+      const a = edge.source;
+      const b = edge.target;
+      let dx = b.x - a.x;
+      let dy = b.y - a.y;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      const idealDist = 280;
+      const force = (dist - idealDist) * CONFIG.attractionStrength;
+      const fx = (dx / (dist || 1)) * force;
+      const fy = (dy / (dist || 1)) * force;
+      if (!a.pinned) { a.vx += fx; a.vy += fy; }
+      if (!b.pinned) { b.vx -= fx; b.vy -= fy; }
+    });
+
+    // Center gravity
+    const cx = width / 2;
+    const cy = height / 2;
+    graphNodes.forEach(n => {
+      if (n.pinned) return;
+      n.vx += (cx - n.x) * CONFIG.centerGravity;
+      n.vy += (cy - n.y) * CONFIG.centerGravity;
+      // Damping
+      n.vx *= CONFIG.damping;
+      n.vy *= CONFIG.damping;
+      // Apply
+      n.x += n.vx;
+      n.y += n.vy;
+      // Bounds
+      const hw = CONFIG.nodeWidth / 2 + 10;
+      const hh = CONFIG.nodeHeight / 2 + 10;
+      n.x = Math.max(hw, Math.min(width - hw, n.x));
+      n.y = Math.max(hh, Math.min(height - hh, n.y));
+      // Fade in
+      n.alpha += (n.targetAlpha - n.alpha) * 0.05;
+    });
+  }
+
+  // --- Rendering ---
+  function draw() {
+    const c = CONFIG.colors;
+    ctx.clearRect(0, 0, width, height);
+
+    // Background subtle grid
+    drawGrid();
+
+    // Draw edges
+    graphEdges.forEach(edge => drawEdge(edge));
+
+    // Draw nodes (selected on top)
+    const sorted = [...graphNodes].sort((a, b) => {
+      if (a.id === selectedNodeId) return 1;
+      if (b.id === selectedNodeId) return -1;
+      return 0;
+    });
+    sorted.forEach(n => drawNode(n));
+
+    // Single node: pulsing ring and subtitle
+    if (graphNodes.length === 1) {
+      drawSingleNodeEffects(graphNodes[0]);
+    }
+  }
+
+  function drawGrid() {
+    const c = CONFIG.colors;
+    ctx.strokeStyle = hexToRgba(c.border, 0.15);
+    ctx.lineWidth = 1;
+    const gridSize = 40;
+    for (let x = gridSize; x < width; x += gridSize) {
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, height);
+      ctx.stroke();
+    }
+    for (let y = gridSize; y < height; y += gridSize) {
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(width, y);
+      ctx.stroke();
+    }
+  }
+
+  function drawEdge(edge) {
+    const c = CONFIG.colors;
+    const a = edge.source;
+    const b = edge.target;
+    const alpha = Math.min(a.alpha, b.alpha) * 0.6;
+    if (alpha < 0.01) return;
+
+    ctx.save();
+    ctx.globalAlpha = alpha;
+    ctx.strokeStyle = edge.solid ? hexToRgba(c.accent, 0.4) : hexToRgba(c.textMuted, 0.3);
+    ctx.lineWidth = CONFIG.connectionWidth;
+    if (!edge.solid) {
+      ctx.setLineDash([6, 4]);
+    }
+    ctx.beginPath();
+    ctx.moveTo(a.x, a.y);
+    ctx.lineTo(b.x, b.y);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // Connection label at midpoint
+    const mx = (a.x + b.x) / 2;
+    const my = (a.y + b.y) / 2;
+    ctx.font = '10px Inter, -apple-system, sans-serif';
+    ctx.fillStyle = hexToRgba(c.textMuted, 0.7);
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    // Background pill for label
+    const labelText = edge.label || 'LAN';
+    const tw = ctx.measureText(labelText).width + 10;
+    ctx.fillStyle = hexToRgba(c.bgPrimary, 0.85);
+    roundRect(ctx, mx - tw/2, my - 8, tw, 16, 4);
+    ctx.fill();
+    ctx.fillStyle = hexToRgba(c.textMuted, 0.7);
+    ctx.fillText(labelText, mx, my);
+
+    ctx.restore();
+  }
+
+  function drawNode(n) {
+    const c = CONFIG.colors;
+    const d = n.data;
+    const isHovered = hoveredNodeId === n.id;
+    const isSelected = selectedNodeId === n.id;
+    const isLeader = d.is_leader;
+    const nw = CONFIG.nodeWidth;
+    const nh = getNodeHeight(n);
+    const x = n.x - nw / 2;
+    const y = n.y - nh / 2;
+    const r = CONFIG.nodeRadius;
+
+    ctx.save();
+    ctx.globalAlpha = n.alpha;
+
+    // Glow for leader
+    if (isLeader) {
+      const glowPulse = 0.15 + Math.sin(time * 3) * 0.08;
+      ctx.shadowColor = c.accent;
+      ctx.shadowBlur = 20 + Math.sin(time * 3) * 5;
+      ctx.fillStyle = hexToRgba(c.accent, glowPulse);
+      roundRect(ctx, x - 3, y - 3, nw + 6, nh + 6, r + 2);
+      ctx.fill();
+      ctx.shadowBlur = 0;
+    }
+
+    // Selected glow
+    if (isSelected) {
+      ctx.shadowColor = c.accent;
+      ctx.shadowBlur = 16;
+    }
+
+    // Node background
+    ctx.fillStyle = isHovered ? c.bgCardHover : c.bgCard;
+    roundRect(ctx, x, y, nw, nh, r);
+    ctx.fill();
+
+    // Border
+    ctx.strokeStyle = isLeader ? c.accent : isSelected ? c.borderActive : c.border;
+    ctx.lineWidth = isLeader || isSelected ? 2 : 1;
+    roundRect(ctx, x, y, nw, nh, r);
+    ctx.stroke();
+    ctx.shadowBlur = 0;
+
+    // Status indicator dot with pulse
+    const statusColor = d.status === 'online' ? c.green : d.status === 'starting' ? c.yellow : c.red;
+    const dotX = x + nw - 16;
+    const dotY = y + 16;
+    // Pulse ring for online
+    if (d.status === 'online') {
+      const pulseAlpha = 0.3 + Math.sin(time * 4) * 0.2;
+      const pulseR = 6 + Math.sin(time * 4) * 3;
+      ctx.fillStyle = hexToRgba(statusColor, pulseAlpha);
+      ctx.beginPath();
+      ctx.arc(dotX, dotY, pulseR, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    // Solid dot
+    ctx.fillStyle = statusColor;
+    ctx.beginPath();
+    ctx.arc(dotX, dotY, 4, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Leader crown indicator
+    if (isLeader) {
+      ctx.fillStyle = c.accent;
+      ctx.font = 'bold 9px Inter, -apple-system, sans-serif';
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'top';
+      // Crown icon as text
+      const crownX = x + 10;
+      const crownY = y + 6;
+      ctx.fillStyle = hexToRgba(c.accent, 0.8);
+      ctx.font = '11px Inter, -apple-system, sans-serif';
+      ctx.fillText('\u2605', crownX, crownY); // star
+      ctx.fillStyle = c.accent;
+      ctx.font = 'bold 9px Inter, -apple-system, sans-serif';
+      ctx.fillText('LEADER', crownX + 14, crownY + 1);
+    }
+
+    // Node name
+    const nameY = isLeader ? y + 22 : y + 14;
+    ctx.fillStyle = c.textPrimary;
+    ctx.font = 'bold 13px Inter, -apple-system, sans-serif';
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    const name = truncate(d.node_name || d.node_id || 'Node', 22);
+    ctx.fillText(name, x + 12, nameY);
+
+    // GPU name
+    ctx.fillStyle = c.textSecondary;
+    ctx.font = '11px Inter, -apple-system, sans-serif';
+    const gpuText = truncate(d.gpu_name || 'Unknown GPU', 28);
+    ctx.fillText(gpuText, x + 12, nameY + 18);
+
+    // Memory + model line
+    const memText = (d.gpu_memory_gb || '?') + ' GB';
+    const modelText = truncate(d.model || 'no model', 18);
+    ctx.fillStyle = c.textMuted;
+    ctx.font = '10px JetBrains Mono, Fira Code, monospace';
+    ctx.fillText(memText + '  |  ' + modelText, x + 12, nameY + 34);
+
+    // Hover expanded info
+    if (isHovered) {
+      const expandY = nameY + 52;
+      ctx.fillStyle = hexToRgba(c.border, 0.5);
+      ctx.fillRect(x + 12, expandY - 4, nw - 24, 1);
+
+      ctx.font = '10px Inter, -apple-system, sans-serif';
+      ctx.fillStyle = c.textSecondary;
+      const gpuUtil = d.gpu_utilization_pct != null ? d.gpu_utilization_pct + '%' : 'N/A';
+      const memUsed = d.gpu_memory_used_pct != null ? d.gpu_memory_used_pct + '%' : 'N/A';
+      const memLabel = d.unified_memory ? 'unified' : 'VRAM';
+      const uptime = d.uptime_seconds ? formatUptime(d.uptime_seconds) : 'N/A';
+      ctx.fillText('GPU: ' + gpuUtil + '   Mem: ' + memUsed + ' ' + memLabel, x + 12, expandY + 4);
+      ctx.fillText('Uptime: ' + uptime + '   Status: ' + (d.status || 'unknown'), x + 12, expandY + 20);
+
+      // Memory bar
+      const barX = x + 12;
+      const barY = expandY + 36;
+      const barW = nw - 24;
+      const barH = 4;
+      const pct = d.gpu_memory_used_pct || 0;
+      ctx.fillStyle = hexToRgba(c.bgPrimary, 0.8);
+      roundRect(ctx, barX, barY, barW, barH, 2);
+      ctx.fill();
+      const barColor = pct > 90 ? c.red : pct > 70 ? c.yellow : c.green;
+      ctx.fillStyle = barColor;
+      roundRect(ctx, barX, barY, barW * (pct / 100), barH, 2);
+      ctx.fill();
+    }
+
+    ctx.restore();
+  }
+
+  function drawSingleNodeEffects(n) {
+    const c = CONFIG.colors;
+    ctx.save();
+    ctx.globalAlpha = n.alpha;
+
+    // Pulsing ring
+    const pulsePhase = (time * 1.5) % (Math.PI * 2);
+    const ringRadius = CONFIG.nodeWidth * 0.75 + Math.sin(pulsePhase) * 10;
+    const ringAlpha = 0.1 + Math.sin(pulsePhase) * 0.05;
+    ctx.strokeStyle = hexToRgba(c.accent, ringAlpha);
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(n.x, n.y, ringRadius, 0, Math.PI * 2);
+    ctx.stroke();
+
+    // Second ring offset
+    const ring2Radius = CONFIG.nodeWidth * 0.95 + Math.cos(pulsePhase * 0.7) * 15;
+    const ring2Alpha = 0.06 + Math.cos(pulsePhase * 0.7) * 0.03;
+    ctx.strokeStyle = hexToRgba(c.accent, ring2Alpha);
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.arc(n.x, n.y, ring2Radius, 0, Math.PI * 2);
+    ctx.stroke();
+
+    // "Waiting for peers..." subtitle
+    ctx.font = '12px Inter, -apple-system, sans-serif';
+    ctx.fillStyle = hexToRgba(c.textMuted, 0.5 + Math.sin(time * 2) * 0.2);
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    ctx.fillText('Waiting for peers...', n.x, n.y + CONFIG.nodeHeight / 2 + 20);
+
+    // Scanning dots
+    for (let i = 0; i < 3; i++) {
+      const dotAngle = time * 0.8 + (i * Math.PI * 2 / 3);
+      const dotR = CONFIG.nodeWidth * 0.85;
+      const dx = n.x + Math.cos(dotAngle) * dotR;
+      const dy = n.y + Math.sin(dotAngle) * dotR;
+      const dotAlpha = 0.15 + Math.sin(time * 3 + i) * 0.1;
+      ctx.fillStyle = hexToRgba(c.accent, dotAlpha);
+      ctx.beginPath();
+      ctx.arc(dx, dy, 3, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    ctx.restore();
+  }
+
+  // --- Utilities ---
+  function roundRect(ctx, x, y, w, h, r) {
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.lineTo(x + w - r, y);
+    ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+    ctx.lineTo(x + w, y + h - r);
+    ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+    ctx.lineTo(x + r, y + h);
+    ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+    ctx.lineTo(x, y + r);
+    ctx.quadraticCurveTo(x, y, x + r, y);
+    ctx.closePath();
+  }
+
+  function truncate(str, max) {
+    if (!str) return '';
+    return str.length > max ? str.slice(0, max - 1) + '\u2026' : str;
+  }
+
+  function formatUptime(seconds) {
+    if (seconds < 60) return seconds + 's';
+    if (seconds < 3600) return Math.floor(seconds / 60) + 'm';
+    return Math.floor(seconds / 3600) + 'h ' + Math.floor((seconds % 3600) / 60) + 'm';
+  }
+
+  // --- Animation Loop ---
+  function startLoop() {
+    function frame(ts) {
+      time = ts * CONFIG.pulseSpeed;
+      simulate();
+      draw();
+      animFrameId = requestAnimationFrame(frame);
+    }
+    animFrameId = requestAnimationFrame(frame);
+  }
+
+  // --- Public API ---
+  return {
+    init,
+    destroy,
+    update,
+    resize,
+    getSelectedNodeId: () => selectedNodeId,
+  };
+})();

--- a/ainode/web/templates/index.html
+++ b/ainode/web/templates/index.html
@@ -70,10 +70,13 @@
         </div>
 
         <div class="card-header" style="margin-bottom:12px">
-          <div class="card-title">Nodes</div>
+          <div class="card-title">Cluster Topology</div>
         </div>
-        <div id="dashboard-nodes" class="grid-3" style="margin-bottom:24px">
-          <!-- Filled by JS -->
+        <div id="topology-container" class="topology-container" style="margin-bottom:24px">
+          <canvas id="topology-canvas"></canvas>
+        </div>
+        <div id="topology-detail" class="topology-detail" style="display:none; margin-bottom:24px">
+          <!-- Filled by JS on node click -->
         </div>
 
         <div id="dashboard-health">
@@ -135,6 +138,7 @@
     </main>
   </div>
 
+  <script src="/static/js/topology.js"></script>
   <script src="/static/js/app.js"></script>
 </body>
 </html>

--- a/ainode/web/templates/index.html
+++ b/ainode/web/templates/index.html
@@ -66,43 +66,70 @@
         </div>
 
         <div id="dashboard-stats" class="grid-4" style="margin-bottom:24px">
-          <!-- Filled by JS -->
         </div>
 
         <div class="card-header" style="margin-bottom:12px">
           <div class="card-title">Nodes</div>
         </div>
         <div id="dashboard-nodes" class="grid-3" style="margin-bottom:24px">
-          <!-- Filled by JS -->
         </div>
 
         <div id="dashboard-health">
-          <!-- Filled by JS -->
         </div>
       </div>
 
       <!-- Chat View -->
       <div id="view-chat" class="view" style="display:none">
-        <div class="page-header">
-          <div class="page-title">Chat</div>
-          <div class="page-desc">Talk to your local models</div>
-        </div>
-
-        <div class="chat-container">
-          <select id="chat-model" class="chat-model-select">
-            <option>Loading models...</option>
-          </select>
-
-          <div id="chat-messages" class="chat-messages">
-            <div style="text-align:center; color:var(--text-muted); padding:60px 0">
-              Send a message to get started
+        <div class="chat-layout">
+          <!-- Conversation History Sidebar -->
+          <div id="chat-history-panel" class="chat-history-panel">
+            <div class="chat-history-header">
+              <button id="chat-new-btn" class="btn btn-primary btn-sm chat-new-btn">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                New Chat
+              </button>
+              <button id="chat-history-toggle" class="btn btn-ghost btn-icon" title="Toggle history">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><polyline points="15 18 9 12 15 6"/></svg>
+              </button>
+            </div>
+            <div id="chat-history-list" class="chat-history-list">
             </div>
           </div>
 
-          <div class="chat-input-area">
-            <div class="chat-input-wrapper">
-              <textarea id="chat-input" class="chat-input" placeholder="Type a message..." rows="1"></textarea>
-              <button id="chat-send" class="chat-send">Send</button>
+          <!-- Chat Main Area -->
+          <div class="chat-main">
+            <div class="page-header" style="display:flex;align-items:center;gap:12px">
+              <button id="chat-history-open" class="btn btn-ghost btn-icon chat-history-open-btn" title="Show history" style="display:none">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><polyline points="9 18 15 12 9 6"/></svg>
+              </button>
+              <div>
+                <div class="page-title">Chat</div>
+                <div class="page-desc">Talk to your local models</div>
+              </div>
+            </div>
+
+            <div class="chat-container">
+              <select id="chat-model" class="chat-model-select">
+                <option>Loading models...</option>
+              </select>
+
+              <div id="chat-messages" class="chat-messages">
+              </div>
+
+              <div id="chat-metrics-bar" class="chat-metrics-bar" style="display:none">
+                <span id="chat-metric-ttft">TTFT: --</span>
+                <span class="chat-metric-sep">|</span>
+                <span id="chat-metric-tps">-- tok/s</span>
+                <span class="chat-metric-sep">|</span>
+                <span id="chat-metric-tokens">0 tokens</span>
+              </div>
+
+              <div class="chat-input-area">
+                <div class="chat-input-wrapper">
+                  <textarea id="chat-input" class="chat-input" placeholder="Type a message..." rows="1"></textarea>
+                  <button id="chat-send" class="chat-send">Send</button>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -116,7 +143,6 @@
         </div>
 
         <div id="models-list">
-          <!-- Filled by JS -->
         </div>
       </div>
 
@@ -128,12 +154,14 @@
         </div>
 
         <div id="training-content">
-          <!-- Filled by JS -->
         </div>
       </div>
 
     </main>
   </div>
+
+  <!-- Toast Notifications -->
+  <div id="toast-container" class="toast-container"></div>
 
   <script src="/static/js/app.js"></script>
 </body>

--- a/ainode/web/templates/index.html
+++ b/ainode/web/templates/index.html
@@ -69,6 +69,10 @@
           <!-- Filled by JS -->
         </div>
 
+        <div id="dashboard-monitoring">
+          <!-- Filled by JS: GPU gauge, Memory ring, Temp + Request stats -->
+        </div>
+
         <div class="card-header" style="margin-bottom:12px">
           <div class="card-title">Nodes</div>
         </div>
@@ -110,13 +114,48 @@
 
       <!-- Models View -->
       <div id="view-models" class="view" style="display:none">
-        <div class="page-header">
-          <div class="page-title">Models</div>
-          <div class="page-desc">Browse and manage available models</div>
+        <div class="page-header" style="display:flex;justify-content:space-between;align-items:flex-start">
+          <div>
+            <div class="page-title">Models</div>
+            <div class="page-desc">Browse and manage available models</div>
+          </div>
+          <div id="models-disk-space" class="models-disk-space"></div>
+        </div>
+
+        <div class="models-toolbar">
+          <div class="models-search-wrap">
+            <svg class="models-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+            <input type="text" id="models-search" class="models-search" placeholder="Search models by name or description...">
+          </div>
+          <div class="models-filters" id="models-filters">
+            <button class="filter-pill active" data-filter="all">All</button>
+            <button class="filter-pill" data-filter="downloaded">Downloaded</button>
+            <button class="filter-pill" data-filter="available">Available</button>
+            <button class="filter-pill" data-filter="recommended">Recommended for GPU</button>
+          </div>
+          <div class="models-sort">
+            <label class="models-sort-label">Sort:</label>
+            <select id="models-sort" class="form-select models-sort-select">
+              <option value="recommended">Recommended</option>
+              <option value="name">Name</option>
+              <option value="size">Size</option>
+            </select>
+          </div>
         </div>
 
         <div id="models-list">
           <!-- Filled by JS -->
+        </div>
+
+        <div id="model-delete-modal" class="model-modal-overlay" style="display:none">
+          <div class="model-modal">
+            <h3>Delete Model</h3>
+            <p id="model-delete-msg">Are you sure you want to delete this model? This will free up disk space but you will need to re-download it later.</p>
+            <div class="model-modal-actions">
+              <button class="btn btn-ghost" id="model-delete-cancel">Cancel</button>
+              <button class="btn btn-danger" id="model-delete-confirm">Delete Model</button>
+            </div>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Gap analysis against EXO identified 10 feature gaps. This PR closes the top 7.

### PRs included
- **#15 topology-graph**: Interactive canvas force-directed node topology with physics, hover, glow, drag, leader crown (685 lines)
- **#16 models-enhance**: Search/filter/sort, download progress, GPU fit indicators, expandable details, delete modal (370 lines CSS)
- **#17 dashboard-enhance**: SVG arc gauges for GPU util + memory, temperature bar, request metrics panel, inference stats (149 lines CSS)
- **#18 chat-enhance**: Stop generation, TTFT/TPS metrics, conversation history (localStorage), toast notifications, copy button, suggested prompts

### EXO gap closure
| Gap | Status |
|-----|--------|
| Interactive topology graph | **CLOSED** — canvas force-directed with physics |
| Real-time inference metrics (TTFT/TPS) | **CLOSED** — live metrics bar during streaming |
| Model download progress UI | **CLOSED** — progress bar, search, filter, GPU fit |
| Stop generation button | **CLOSED** — AbortController-based cancel |
| Conversation history | **CLOSED** — localStorage-backed sidebar |
| Toast notifications | **CLOSED** — 4 types, auto-dismiss |
| GPU utilization gauges | **CLOSED** — SVG arc gauges, temperature bar |

### Remaining gaps (lower priority)
- SSE events endpoint (using polling, works fine)
- Connection type visualization (only matters with 2+ nodes)
- HuggingFace search from dashboard (search within catalog, not HF API)

## Test plan
- [x] `pytest tests/` → 238/238 passing
- [x] `ainode --version` → `ainode 0.1.0`
- [ ] Browser visual test on running instance (deferred to hardware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)