### PR TITLE
v0.1.0 final: wiring fixes, security hardening, slop cleanup

### DIFF
--- a/ainode/api/server.py
+++ b/ainode/api/server.py
@@ -103,7 +103,9 @@ async def cors_middleware(request: web.Request, handler):
         except web.HTTPException as exc:
             resp = exc
 
-    resp.headers["Access-Control-Allow-Origin"] = "*"
+    origin = request.headers.get("Origin", "")
+    allowed = origin if origin.startswith(("http://localhost", "http://127.0.0.1")) else ""
+    resp.headers["Access-Control-Allow-Origin"] = allowed
     resp.headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, DELETE, OPTIONS"
     resp.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
     return resp

--- a/ainode/auth/middleware.py
+++ b/ainode/auth/middleware.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 import secrets
 from dataclasses import dataclass, field, asdict
@@ -10,24 +12,19 @@ from aiohttp import web
 
 from ainode.core.config import AINODE_HOME
 
+
+def _hash_key(key: str) -> str:
+    return hashlib.sha256(key.encode()).hexdigest()
+
+
 AUTH_FILE = AINODE_HOME / "auth.json"
 
-# Paths that never require authentication
-SKIP_PATHS: set[str] = {
-    "/",
-    "/onboarding",
-    "/api/health",
-}
-SKIP_PREFIXES: tuple[str, ...] = (
-    "/static/",
-    "/api/onboarding/",
-)
+SKIP_PATHS: set[str] = {"/", "/onboarding", "/api/health"}
+SKIP_PREFIXES: tuple[str, ...] = ("/static/", "/api/onboarding/")
 
 
 @dataclass
 class AuthConfig:
-    """Persisted auth state."""
-
     enabled: bool = False
     api_keys: list[dict] = field(default_factory=list)
     # Each key entry: {"id": "<short-id>", "key": "<hex>"}
@@ -45,19 +42,15 @@ class AuthConfig:
             return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
         return cls()
 
-    # -- key management -------------------------------------------------------
-
     def generate_key(self) -> dict:
-        """Create a new API key, append it, save, and return the entry."""
-        key = secrets.token_hex(16)  # 32-char hex string
-        key_id = key[:8]
-        entry = {"id": key_id, "key": key}
-        self.api_keys.append(entry)
+        key = secrets.token_hex(16)
+        key_id = secrets.token_hex(4)
+        key_hash = _hash_key(key)
+        self.api_keys.append({"id": key_id, "key_hash": key_hash})
         self.save()
-        return entry
+        return {"id": key_id, "key": key}
 
     def revoke_key(self, key_id: str) -> bool:
-        """Remove a key by its id. Returns True if found and removed."""
         before = len(self.api_keys)
         self.api_keys = [k for k in self.api_keys if k["id"] != key_id]
         if len(self.api_keys) != before:
@@ -65,34 +58,34 @@ class AuthConfig:
             return True
         return False
 
-    def valid_keys(self) -> set[str]:
-        """Return the set of currently valid raw key strings."""
-        return {k["key"] for k in self.api_keys}
+    def validate_token(self, token: str) -> bool:
+        token_hash = _hash_key(token)
+        for entry in self.api_keys:
+            stored = entry.get("key_hash") or entry.get("key", "")
+            if hmac.compare_digest(token_hash, stored):
+                return True
+        return False
 
     def enable(self) -> dict:
-        """Enable auth. Generates a default key if none exist. Returns the key entry."""
         self.enabled = True
         if not self.api_keys:
-            entry = self.generate_key()  # also saves
+            entry = self.generate_key()
         else:
             entry = self.api_keys[0]
             self.save()
         return entry
 
     def disable(self) -> None:
-        """Disable auth (keys are kept but not enforced)."""
         self.enabled = False
         self.save()
 
 
 def _should_skip(request: web.Request) -> bool:
-    """Return True if this request should bypass auth checks."""
     path = request.path
     if path in SKIP_PATHS:
         return True
     if path.startswith(SKIP_PREFIXES):
         return True
-    # GET requests to onboarding pages
     if request.method == "GET" and path.startswith("/api/onboarding"):
         return True
     return False
@@ -100,30 +93,21 @@ def _should_skip(request: web.Request) -> bool:
 
 @web.middleware
 async def auth_middleware(request: web.Request, handler):
-    """Check Bearer token when auth is enabled."""
     auth_cfg: AuthConfig | None = request.app.get("auth_config")
-
-    # If auth is not configured or disabled, pass through
     if auth_cfg is None or not auth_cfg.enabled:
         return await handler(request)
-
-    # Skip exempt paths
     if _should_skip(request):
         return await handler(request)
-
-    # Check Authorization header
     auth_header = request.headers.get("Authorization", "")
     if not auth_header.startswith("Bearer "):
         return web.json_response(
             {"error": {"message": "Missing or invalid Authorization header", "type": "auth_error"}},
             status=401,
         )
-
-    token = auth_header[7:]  # strip "Bearer "
-    if token not in auth_cfg.valid_keys():
+    token = auth_header[7:]
+    if not auth_cfg.validate_token(token):
         return web.json_response(
             {"error": {"message": "Invalid API key", "type": "auth_error"}},
             status=401,
         )
-
     return await handler(request)

--- a/ainode/core/gpu.py
+++ b/ainode/core/gpu.py
@@ -16,8 +16,14 @@ class GPUInfo:
     unified_memory: bool = False  # DGX Spark / GB10
 
 
-def detect_gpu() -> Optional[GPUInfo]:
+_gpu_cache: Optional[GPUInfo] = None
+
+
+def detect_gpu(use_cache: bool = True) -> Optional[GPUInfo]:
     """Detect NVIDIA GPU and return its capabilities."""
+    global _gpu_cache
+    if use_cache and _gpu_cache is not None:
+        return _gpu_cache
     try:
         import pynvml
         pynvml.nvmlInit()
@@ -50,7 +56,7 @@ def detect_gpu() -> Optional[GPUInfo]:
 
         pynvml.nvmlShutdown()
 
-        return GPUInfo(
+        result = GPUInfo(
             name=name,
             memory_total_mb=memory_total,
             memory_free_mb=memory_free,
@@ -59,6 +65,8 @@ def detect_gpu() -> Optional[GPUInfo]:
             compute_capability=f"{major}.{minor}",
             unified_memory=unified,
         )
+        _gpu_cache = result
+        return result
     except Exception:
         return None
 

--- a/ainode/engine/vllm_engine.py
+++ b/ainode/engine/vllm_engine.py
@@ -29,11 +29,13 @@ class VLLMEngine:
         cmd = [
             sys.executable, "-m", "vllm.entrypoints.openai.api_server",
             "--model", self.config.model,
-            "--host", self.config.host,
+            "--host", "127.0.0.1",
             "--port", str(self.config.api_port),
             "--gpu-memory-utilization", str(self.config.gpu_memory_utilization),
-            "--trust-remote-code",
-        ]
+            ]
+
+        if self.config.trust_remote_code:
+            cmd.append("--trust-remote-code")
 
         if self.config.max_model_len:
             cmd.extend(["--max-model-len", str(self.config.max_model_len)])
@@ -84,7 +86,7 @@ class VLLMEngine:
         if not self.process or not self.process.stdout:
             return
 
-        with open(self._log_file, "w") as log_f:
+        with open(self._log_file, "a") as log_f:
             for line in self.process.stdout:
                 log_f.write(line)
                 log_f.flush()

--- a/ainode/models/api_routes.py
+++ b/ainode/models/api_routes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 import uuid
 from typing import Optional
 
@@ -62,7 +63,10 @@ async def handle_download_model(request: web.Request) -> web.Response:
 
     job_id = str(uuid.uuid4())
     jobs: dict = request.app["download_jobs"]
-    jobs[job_id] = {"model_id": model_id, "status": "downloading", "error": None}
+    jobs[job_id] = {"model_id": model_id, "status": "downloading", "error": None, "finished_at": None}
+
+    # Clean up old completed/failed jobs
+    _cleanup_old_jobs(jobs)
 
     loop = asyncio.get_event_loop()
     loop.create_task(_run_download(manager, model_id, job_id, jobs))
@@ -117,6 +121,15 @@ async def handle_recommended(request: web.Request) -> web.Response:
 
 # -- Background download task -------------------------------------------------
 
+_DOWNLOAD_JOB_MAX_AGE = 3600
+
+def _cleanup_old_jobs(jobs: dict) -> None:
+    now = time.time()
+    to_remove = [jid for jid, info in jobs.items() if info.get("finished_at") is not None and (now - info["finished_at"]) > _DOWNLOAD_JOB_MAX_AGE]
+    for jid in to_remove:
+        del jobs[jid]
+
+
 async def _run_download(
     manager: ModelManager,
     model_id: str,
@@ -131,3 +144,5 @@ async def _run_download(
     except Exception as exc:
         jobs[job_id]["status"] = "failed"
         jobs[job_id]["error"] = str(exc)
+    finally:
+        jobs[job_id]["finished_at"] = time.time()

--- a/ainode/onboarding/api_routes.py
+++ b/ainode/onboarding/api_routes.py
@@ -67,11 +67,17 @@ async def handle_onboarding_complete(request: web.Request) -> web.Response:
 
     config: NodeConfig = request.app["config"]
 
-    node_name = body.get("node_name", "").strip()
+    node_name = body.get("node_name", "").strip()[:64]
+    email = body.get("email", "").strip()[:254]
+    model = body.get("model", "").strip()[:256]
+
+    if node_name and not node_name.replace("-", "").replace("_", "").replace(" ", "").isalnum():
+        return web.json_response({"error": "node_name contains invalid characters"}, status=400)
+
     if node_name:
         config.node_name = node_name
 
-    model = body.get("model", "").strip()
+    if model:
     if model:
         config.model = model
         # Set quantization for AWQ models
@@ -80,7 +86,6 @@ async def handle_onboarding_complete(request: web.Request) -> web.Response:
         else:
             config.quantization = None
 
-    email = body.get("email", "").strip()
     if email:
         config.email = email
 

--- a/ainode/onboarding/api_routes.py
+++ b/ainode/onboarding/api_routes.py
@@ -78,7 +78,6 @@ async def handle_onboarding_complete(request: web.Request) -> web.Response:
         config.node_name = node_name
 
     if model:
-    if model:
         config.model = model
         # Set quantization for AWQ models
         if "awq" in model.lower():

--- a/ainode/training/engine.py
+++ b/ainode/training/engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import collections
 import json
 import os
 import signal
@@ -59,6 +60,14 @@ class TrainingConfig:
 
         if not self.dataset_path or not self.dataset_path.strip():
             errors.append("dataset_path is required")
+        else:
+            ds = self.dataset_path.strip()
+            if ".." in ds:
+                errors.append("dataset_path must not contain '..'")
+            elif ds.startswith("/"):
+                datasets_dir = str(AINODE_HOME / "datasets")
+                if not ds.startswith(datasets_dir):
+                    errors.append(f"dataset_path absolute paths must be under {datasets_dir}")
 
         if self.method not in ("lora", "full"):
             errors.append(f"method must be 'lora' or 'full', got '{self.method}'")
@@ -80,6 +89,15 @@ class TrainingConfig:
 
         if self.max_seq_length < 1:
             errors.append("max_seq_length must be >= 1")
+
+        if self.output_dir is not None:
+            out = self.output_dir.strip()
+            if ".." in out:
+                errors.append("output_dir must not contain '..'")
+            elif out.startswith("/"):
+                allowed_prefix = str(AINODE_HOME / "training")
+                if not out.startswith(allowed_prefix):
+                    errors.append(f"output_dir absolute paths must be under {allowed_prefix}")
 
         return errors
 
@@ -104,7 +122,7 @@ class TrainingJob:
         self.current_loss: Optional[float] = None
         self.start_time: Optional[float] = None
         self.end_time: Optional[float] = None
-        self.logs: list[str] = []
+        self.logs: collections.deque[str] = collections.deque(maxlen=5000)
         self._process: Optional[subprocess.Popen] = None
         self._monitor_task: Optional[asyncio.Task] = None
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -83,16 +83,22 @@ async def test_index_serves_html(client):
 # ---- CORS ------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_cors_headers(client):
-    resp = await client.get("/api/health")
-    assert resp.headers.get("Access-Control-Allow-Origin") == "*"
+async def test_cors_headers_localhost(client):
+    resp = await client.get("/api/health", headers={"Origin": "http://localhost:3000"})
+    assert resp.headers.get("Access-Control-Allow-Origin") == "http://localhost:3000"
+
+
+@pytest.mark.asyncio
+async def test_cors_headers_rejected(client):
+    resp = await client.get("/api/health", headers={"Origin": "http://evil.com"})
+    assert resp.headers.get("Access-Control-Allow-Origin") == ""
 
 
 @pytest.mark.asyncio
 async def test_cors_preflight(client):
-    resp = await client.options("/api/health")
+    resp = await client.options("/api/health", headers={"Origin": "http://127.0.0.1:3000"})
     assert resp.status == 204
-    assert resp.headers.get("Access-Control-Allow-Origin") == "*"
+    assert resp.headers.get("Access-Control-Allow-Origin") == "http://127.0.0.1:3000"
     assert "POST" in resp.headers.get("Access-Control-Allow-Methods", "")
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -87,19 +87,20 @@ class TestAuthConfig:
     def test_generate_key(self, auth_config):
         entry = auth_config.generate_key()
         assert len(entry["key"]) == 32
-        assert entry["id"] == entry["key"][:8]
+        assert len(entry["id"]) == 8
         assert len(auth_config.api_keys) == 1
+        assert "key_hash" in auth_config.api_keys[0]
 
     def test_enable_generates_key(self, auth_config):
         entry = auth_config.enable()
         assert auth_config.enabled is True
         assert len(auth_config.api_keys) == 1
-        assert entry["key"] in auth_config.valid_keys()
+        assert auth_config.validate_token(entry["key"])
 
     def test_enable_reuses_existing_key(self, auth_config):
         first = auth_config.generate_key()
         entry = auth_config.enable()
-        assert entry["key"] == first["key"]
+        assert entry["id"] == auth_config.api_keys[0]["id"]
         assert len(auth_config.api_keys) == 1
 
     def test_disable(self, auth_config):
@@ -119,12 +120,12 @@ class TestAuthConfig:
 
     def test_save_and_load(self, auth_config, tmp_auth_file):
         auth_config.enable()
-        key = auth_config.api_keys[0]["key"]
+        key_hash = auth_config.api_keys[0]["key_hash"]
 
         # Load from disk
         loaded = AuthConfig.load()
         assert loaded.enabled is True
-        assert loaded.api_keys[0]["key"] == key
+        assert loaded.api_keys[0]["key_hash"] == key_hash
 
     def test_load_missing_file(self, tmp_auth_file):
         cfg = AuthConfig.load()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -24,7 +24,9 @@ def test_build_cmd_defaults():
     assert "meta-llama/Llama-3.2-3B-Instruct" in cmd
     assert "--port" in cmd
     assert "8000" in cmd
-    assert "--trust-remote-code" in cmd
+    assert "--trust-remote-code" not in cmd
+    assert "--host" in cmd
+    assert "127.0.0.1" in cmd
 
 
 def test_build_cmd_with_quantization():

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -20,12 +20,12 @@ class TestTrainingConfig:
     def test_valid_config(self):
         config = TrainingConfig(
             base_model="meta-llama/Llama-3.2-3B-Instruct",
-            dataset_path="/data/train.jsonl",
+            dataset_path="user/my-dataset",
         )
         assert config.validate() == []
 
     def test_missing_base_model(self):
-        config = TrainingConfig(base_model="", dataset_path="/data/train.jsonl")
+        config = TrainingConfig(base_model="", dataset_path="user/my-dataset")
         errors = config.validate()
         assert any("base_model" in e for e in errors)
 
@@ -36,49 +36,49 @@ class TestTrainingConfig:
 
     def test_invalid_method(self):
         config = TrainingConfig(
-            base_model="model", dataset_path="/data", method="qlora"
+            base_model="model", dataset_path="user/dataset", method="qlora"
         )
         errors = config.validate()
         assert any("method" in e for e in errors)
 
     def test_invalid_num_epochs(self):
         config = TrainingConfig(
-            base_model="model", dataset_path="/data", num_epochs=0
+            base_model="model", dataset_path="user/dataset", num_epochs=0
         )
         errors = config.validate()
         assert any("num_epochs" in e for e in errors)
 
     def test_invalid_batch_size(self):
         config = TrainingConfig(
-            base_model="model", dataset_path="/data", batch_size=-1
+            base_model="model", dataset_path="user/dataset", batch_size=-1
         )
         errors = config.validate()
         assert any("batch_size" in e for e in errors)
 
     def test_invalid_learning_rate(self):
         config = TrainingConfig(
-            base_model="model", dataset_path="/data", learning_rate=0
+            base_model="model", dataset_path="user/dataset", learning_rate=0
         )
         errors = config.validate()
         assert any("learning_rate" in e for e in errors)
 
     def test_invalid_lora_rank(self):
         config = TrainingConfig(
-            base_model="model", dataset_path="/data", lora_rank=0
+            base_model="model", dataset_path="user/dataset", lora_rank=0
         )
         errors = config.validate()
         assert any("lora_rank" in e for e in errors)
 
     def test_invalid_lora_alpha(self):
         config = TrainingConfig(
-            base_model="model", dataset_path="/data", lora_alpha=0
+            base_model="model", dataset_path="user/dataset", lora_alpha=0
         )
         errors = config.validate()
         assert any("lora_alpha" in e for e in errors)
 
     def test_invalid_max_seq_length(self):
         config = TrainingConfig(
-            base_model="model", dataset_path="/data", max_seq_length=0
+            base_model="model", dataset_path="user/dataset", max_seq_length=0
         )
         errors = config.validate()
         assert any("max_seq_length" in e for e in errors)
@@ -94,7 +94,7 @@ class TestTrainingConfig:
         assert len(errors) >= 3
 
     def test_defaults(self):
-        config = TrainingConfig(base_model="m", dataset_path="/d")
+        config = TrainingConfig(base_model="m", dataset_path="user/d")
         assert config.method == "lora"
         assert config.num_epochs == 3
         assert config.batch_size == 4
@@ -104,10 +104,10 @@ class TestTrainingConfig:
         assert config.max_seq_length == 2048
 
     def test_to_dict(self):
-        config = TrainingConfig(base_model="m", dataset_path="/d")
+        config = TrainingConfig(base_model="m", dataset_path="user/d")
         d = config.to_dict()
         assert d["base_model"] == "m"
-        assert d["dataset_path"] == "/d"
+        assert d["dataset_path"] == "user/d"
         assert isinstance(d, dict)
 
     def test_from_dict(self):
@@ -138,7 +138,7 @@ class TestTrainingConfig:
 
 class TestTrainingJob:
     def test_initial_state(self):
-        config = TrainingConfig(base_model="m", dataset_path="/d")
+        config = TrainingConfig(base_model="m", dataset_path="user/d")
         job = TrainingJob(config)
         assert job.status == JobStatus.PENDING
         assert job.progress == 0.0
@@ -149,12 +149,12 @@ class TestTrainingJob:
         assert len(job.job_id) == 12
 
     def test_custom_job_id(self):
-        config = TrainingConfig(base_model="m", dataset_path="/d")
+        config = TrainingConfig(base_model="m", dataset_path="user/d")
         job = TrainingJob(config, job_id="custom123")
         assert job.job_id == "custom123"
 
     def test_get_status(self):
-        config = TrainingConfig(base_model="m", dataset_path="/d")
+        config = TrainingConfig(base_model="m", dataset_path="user/d")
         job = TrainingJob(config)
         status = job.get_status()
         assert status["job_id"] == job.job_id
@@ -164,7 +164,7 @@ class TestTrainingJob:
 
     def test_output_dir_default(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
-        config = TrainingConfig(base_model="m", dataset_path="/d")
+        config = TrainingConfig(base_model="m", dataset_path="user/d")
         job = TrainingJob(config)
         assert "output" in job.config.output_dir
         assert job.job_id in job.config.output_dir
@@ -172,7 +172,7 @@ class TestTrainingJob:
     def test_output_dir_custom(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
         config = TrainingConfig(
-            base_model="m", dataset_path="/d", output_dir="/custom/out"
+            base_model="m", dataset_path="user/d", output_dir="/custom/out"
         )
         job = TrainingJob(config)
         assert job.config.output_dir == "/custom/out"
@@ -180,7 +180,7 @@ class TestTrainingJob:
     @pytest.mark.asyncio
     async def test_cancel_pending_job(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
-        config = TrainingConfig(base_model="m", dataset_path="/d")
+        config = TrainingConfig(base_model="m", dataset_path="user/d")
         job = TrainingJob(config)
         assert job.status == JobStatus.PENDING
         await job.stop()
@@ -189,7 +189,7 @@ class TestTrainingJob:
 
     def test_parse_progress(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
-        config = TrainingConfig(base_model="m", dataset_path="/d")
+        config = TrainingConfig(base_model="m", dataset_path="user/d")
         job = TrainingJob(config)
         line = 'AINODE_PROGRESS:{"epoch":2,"loss":0.45,"progress":66.7}'
         job._parse_progress(line)
@@ -199,14 +199,14 @@ class TestTrainingJob:
 
     def test_parse_progress_invalid_json(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
-        config = TrainingConfig(base_model="m", dataset_path="/d")
+        config = TrainingConfig(base_model="m", dataset_path="user/d")
         job = TrainingJob(config)
         job._parse_progress("AINODE_PROGRESS:{invalid}")
         assert job.current_epoch == 0  # Unchanged
 
     def test_parse_progress_no_marker(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
-        config = TrainingConfig(base_model="m", dataset_path="/d")
+        config = TrainingConfig(base_model="m", dataset_path="user/d")
         job = TrainingJob(config)
         job._parse_progress("some random log line")
         assert job.current_epoch == 0  # Unchanged
@@ -218,7 +218,7 @@ class TestTrainingJob:
 
 
 class TestTrainingManager:
-    def _make_config(self, model="m", dataset="/d"):
+    def _make_config(self, model="m", dataset="user/d"):
         return TrainingConfig(base_model=model, dataset_path=dataset)
 
     def test_submit_job(self):


### PR DESCRIPTION
## Summary

Final quality pass after comprehensive 5-agent audit. Closes all critical issues found.

### Wiring Fixes (PR #21)
- API server now launches alongside vLLM engine in cmd_start
- Metrics, training, and cluster routes wired into server.py
- Topology graph and monitoring gauges integrated into dashboard JS
- Enhanced models view with search/filter/download restored

### Security Hardening (PR #24)
- CORS restricted to localhost origins only
- Training paths validated against traversal attacks
- API keys stored as SHA-256 hashes with constant-time comparison
- Key IDs generated independently (no longer leak key material)
- vLLM binds to 127.0.0.1 (auth bypass via direct port eliminated)
- trust-remote-code now opt-in, not default

### Reliability (PR #24)
- Bounded collections for latencies, logs, download jobs
- GPU detection cached (no more NVML init per request)
- Log file append mode (no longer truncated on restart)
- systemd unit allows HuggingFace cache writes
- Input validation on onboarding endpoints

### Slop Cleanup (PR #20)
- Removed 131 lines of noise (dead code, restating docstrings, banner comments)
- Fixed unused imports, empty f-strings, duplicated version

## Test plan
- [x] `pytest tests/` → 239/239 passing
- [x] `ainode --version` → `ainode 0.1.0`
- [x] `pip install -e .` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)