### PR TITLE
Add model sharding for distributed inference

### DIFF
--- a/ainode/api/server.py
+++ b/ainode/api/server.py
@@ -26,6 +26,7 @@ from ainode.discovery.broadcast import (
     NodeAnnouncement,
 )
 from ainode.discovery.cluster import ClusterState
+from ainode.engine.sharding_routes import register_sharding_routes
 
 from ainode import __version__
 
@@ -94,6 +95,9 @@ def create_app(
 
     # --- Training routes -----------------------------------------------------
     setup_training_routes(app, manager)
+
+    # --- Sharding routes ----------------------------------------------------
+    register_sharding_routes(app)
 
     app.router.add_static("/static", get_static_path(), name="static")
 

--- a/ainode/engine/ray_setup.py
+++ b/ainode/engine/ray_setup.py
@@ -1,0 +1,207 @@
+"""Ray cluster helpers for multi-node distributed inference."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+RAY_DEFAULT_PORT = 6379
+RAY_DASHBOARD_PORT = 8265
+
+
+@dataclass
+class RayStatus:
+    """Snapshot of Ray cluster health."""
+    running: bool
+    is_head: bool
+    head_address: Optional[str]
+    num_nodes: int
+    total_cpus: float
+    total_gpus: float
+    error: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "running": self.running,
+            "is_head": self.is_head,
+            "head_address": self.head_address,
+            "num_nodes": self.num_nodes,
+            "total_cpus": self.total_cpus,
+            "total_gpus": self.total_gpus,
+            "error": self.error,
+        }
+
+
+def _ray_executable() -> str:
+    """Return path to ray CLI, or raise if not installed."""
+    ray_path = shutil.which("ray")
+    if not ray_path:
+        raise RuntimeError(
+            "Ray is not installed. Install with: pip install 'ray[default]'"
+        )
+    return ray_path
+
+
+def start_ray_head(
+    port: int = RAY_DEFAULT_PORT,
+    dashboard_port: int = RAY_DASHBOARD_PORT,
+    num_gpus: Optional[int] = None,
+) -> str:
+    """Start a Ray head node on this machine.
+
+    Returns the address string (e.g. '192.168.1.10:6379') for workers to join.
+    """
+    ray_bin = _ray_executable()
+    cmd = [
+        ray_bin, "start", "--head",
+        "--port", str(port),
+        "--dashboard-port", str(dashboard_port),
+    ]
+    if num_gpus is not None:
+        cmd.extend(["--num-gpus", str(num_gpus)])
+
+    logger.info("Starting Ray head node: %s", " ".join(cmd))
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to start Ray head: {result.stderr.strip()}")
+
+    # Parse the address from output
+    for line in result.stdout.splitlines():
+        if "ray start --address=" in line:
+            parts = line.split("ray start --address=")
+            if len(parts) > 1:
+                addr = parts[1].strip().strip("'\"")
+                logger.info("Ray head started at %s", addr)
+                return addr
+
+    # Fallback: construct address
+    address = f"127.0.0.1:{port}"
+    logger.info("Ray head started (fallback address: %s)", address)
+    return address
+
+
+def join_ray_cluster(
+    head_address: str,
+    num_gpus: Optional[int] = None,
+) -> bool:
+    """Join this node to an existing Ray cluster as a worker.
+
+    Parameters
+    ----------
+    head_address : str
+        The head node address, e.g. '192.168.1.10:6379'.
+    num_gpus : int | None
+        Number of GPUs to expose to Ray on this worker.
+
+    Returns True on success.
+    """
+    ray_bin = _ray_executable()
+    cmd = [ray_bin, "start", f"--address={head_address}"]
+    if num_gpus is not None:
+        cmd.extend(["--num-gpus", str(num_gpus)])
+
+    logger.info("Joining Ray cluster at %s: %s", head_address, " ".join(cmd))
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to join Ray cluster: {result.stderr.strip()}")
+
+    logger.info("Successfully joined Ray cluster at %s", head_address)
+    return True
+
+
+def get_ray_status() -> RayStatus:
+    """Check Ray cluster health and return a status snapshot."""
+    ray_bin_path = shutil.which("ray")
+    if not ray_bin_path:
+        return RayStatus(
+            running=False, is_head=False, head_address=None,
+            num_nodes=0, total_cpus=0, total_gpus=0,
+            error="Ray not installed",
+        )
+
+    try:
+        result = subprocess.run(
+            [ray_bin_path, "status"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        return RayStatus(
+            running=False, is_head=False, head_address=None,
+            num_nodes=0, total_cpus=0, total_gpus=0,
+            error="Ray status check timed out",
+        )
+
+    if result.returncode != 0:
+        return RayStatus(
+            running=False, is_head=False, head_address=None,
+            num_nodes=0, total_cpus=0, total_gpus=0,
+            error=result.stderr.strip() or "Ray not running",
+        )
+
+    # Parse output for basic info
+    stdout = result.stdout
+    num_nodes = 0
+    total_cpus = 0.0
+    total_gpus = 0.0
+
+    for line in stdout.splitlines():
+        line_stripped = line.strip()
+        if "node" in line_stripped.lower() and "alive" in line_stripped.lower():
+            parts = line_stripped.split()
+            for p in parts:
+                if p.isdigit():
+                    num_nodes = int(p)
+                    break
+        if "CPU" in line_stripped:
+            for token in line_stripped.split():
+                try:
+                    total_cpus = float(token)
+                    break
+                except ValueError:
+                    continue
+        if "GPU" in line_stripped:
+            for token in line_stripped.split():
+                try:
+                    total_gpus = float(token)
+                    break
+                except ValueError:
+                    continue
+
+    return RayStatus(
+        running=True,
+        is_head=True,
+        head_address=None,
+        num_nodes=max(num_nodes, 1),
+        total_cpus=total_cpus,
+        total_gpus=total_gpus,
+    )
+
+
+def stop_ray() -> bool:
+    """Gracefully shut down Ray on this node.
+
+    Returns True on success.
+    """
+    ray_bin_path = shutil.which("ray")
+    if not ray_bin_path:
+        return True  # Nothing to stop
+
+    logger.info("Stopping Ray...")
+    try:
+        result = subprocess.run(
+            [ray_bin_path, "stop"],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode == 0:
+            logger.info("Ray stopped successfully")
+            return True
+        logger.warning("Ray stop returned non-zero: %s", result.stderr.strip())
+        return False
+    except subprocess.TimeoutExpired:
+        logger.error("Ray stop timed out")
+        return False

--- a/ainode/engine/sharding.py
+++ b/ainode/engine/sharding.py
@@ -1,0 +1,277 @@
+"""Model sharding coordinator — plans and manages distributed inference across cluster nodes."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, List, Optional
+
+from ainode.discovery.cluster import ClusterNode, ClusterState
+
+logger = logging.getLogger(__name__)
+
+# Approximate model sizes in GB (weights only, at fp16).
+# This is a rough heuristic — real memory usage includes KV cache, activations, etc.
+KNOWN_MODEL_SIZES: Dict[str, float] = {
+    "meta-llama/Llama-3.2-3B-Instruct": 6.0,
+    "meta-llama/Llama-3.1-8B-Instruct": 16.0,
+    "meta-llama/Llama-3.1-70B-Instruct": 140.0,
+    "meta-llama/Llama-3.1-70B-Instruct-AWQ": 35.0,
+    "meta-llama/Llama-3.3-70B-Instruct": 140.0,
+    "meta-llama/Llama-3.1-405B-Instruct": 810.0,
+    "Qwen/Qwen2.5-72B-Instruct": 145.0,
+    "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B": 14.0,
+    "mistralai/Mistral-7B-Instruct-v0.3": 14.0,
+    "microsoft/Phi-3-mini-4k-instruct": 7.5,
+    "meta-llama/CodeLlama-34b-Instruct-hf": 63.0,
+}
+
+# Overhead factor: vLLM needs extra memory for KV cache, CUDA context, etc.
+MEMORY_OVERHEAD_FACTOR = 1.20
+
+
+class ShardingStrategy(str, Enum):
+    """How to distribute model layers across devices."""
+    TENSOR_PARALLEL = "tensor_parallel"
+    PIPELINE_PARALLEL = "pipeline_parallel"
+    AUTO = "auto"
+
+
+@dataclass
+class ShardInfo:
+    """Describes what a single node is responsible for in a sharded deployment."""
+    node_id: str
+    host: str
+    api_port: int
+    role: str  # "head" or "worker"
+    layers: Optional[str] = None  # e.g. "0-39" for pipeline parallel
+    estimated_memory_gb: float = 0.0
+
+
+@dataclass
+class ShardingConfig:
+    """Complete sharding plan for a model across the cluster."""
+    model: str
+    strategy: ShardingStrategy
+    tensor_parallel_size: int = 1
+    pipeline_parallel_size: int = 1
+    nodes: List[str] = field(default_factory=list)  # node endpoint addresses
+    shard_map: Dict[str, ShardInfo] = field(default_factory=dict)
+    total_memory_required_gb: float = 0.0
+    ray_head_address: Optional[str] = None
+
+    @property
+    def is_distributed(self) -> bool:
+        """True if model spans multiple nodes (requires Ray)."""
+        return len(self.nodes) > 1
+
+    @property
+    def world_size(self) -> int:
+        return self.tensor_parallel_size * self.pipeline_parallel_size
+
+    def to_dict(self) -> dict:
+        return {
+            "model": self.model,
+            "strategy": self.strategy.value,
+            "tensor_parallel_size": self.tensor_parallel_size,
+            "pipeline_parallel_size": self.pipeline_parallel_size,
+            "nodes": self.nodes,
+            "shard_map": {k: _shard_to_dict(v) for k, v in self.shard_map.items()},
+            "total_memory_required_gb": round(self.total_memory_required_gb, 1),
+            "is_distributed": self.is_distributed,
+            "world_size": self.world_size,
+            "ray_head_address": self.ray_head_address,
+        }
+
+
+def _shard_to_dict(s: ShardInfo) -> dict:
+    return {
+        "node_id": s.node_id,
+        "host": s.host,
+        "api_port": s.api_port,
+        "role": s.role,
+        "layers": s.layers,
+        "estimated_memory_gb": round(s.estimated_memory_gb, 1),
+    }
+
+
+def estimate_model_size(model_id: str) -> float:
+    """Return estimated model memory in GB.
+
+    Uses the known sizes table, or falls back to a rough heuristic based on
+    common naming patterns (e.g. '70B' in the name).
+    """
+    if model_id in KNOWN_MODEL_SIZES:
+        return KNOWN_MODEL_SIZES[model_id]
+
+    # Heuristic: extract parameter count from model name
+    name_lower = model_id.lower()
+    for token in name_lower.replace("-", " ").replace("_", " ").split():
+        if token.endswith("b") and token[:-1].replace(".", "").isdigit():
+            params_b = float(token[:-1])
+            # ~2 bytes per param at fp16
+            return params_b * 2.0
+
+    # Default fallback: assume 14 GB (7B model at fp16)
+    return 14.0
+
+
+class ShardingPlanner:
+    """Plans optimal sharding strategy for a model given the cluster state."""
+
+    def __init__(self, memory_utilization: float = 0.85):
+        self.memory_utilization = memory_utilization
+
+    def estimate_memory_per_node(
+        self, model_size_gb: float, num_nodes: int, strategy: ShardingStrategy
+    ) -> float:
+        """Estimate how much memory each node needs for the given sharding plan."""
+        if num_nodes <= 0:
+            return model_size_gb * MEMORY_OVERHEAD_FACTOR
+
+        if strategy == ShardingStrategy.TENSOR_PARALLEL:
+            # Tensor parallel splits weights evenly but each node also stores
+            # some shared buffers — overhead is higher.
+            per_node = (model_size_gb / num_nodes) * 1.10
+        elif strategy == ShardingStrategy.PIPELINE_PARALLEL:
+            # Pipeline parallel splits layers across nodes.
+            per_node = model_size_gb / num_nodes
+        else:
+            # Auto: assume pipeline for multi-node (lower overhead)
+            per_node = model_size_gb / num_nodes
+
+        return per_node * MEMORY_OVERHEAD_FACTOR
+
+    def can_fit_model(self, model_id: str, cluster_state: ClusterState) -> bool:
+        """Check if the cluster has enough total memory to run the model."""
+        model_size = estimate_model_size(model_id)
+        required = model_size * MEMORY_OVERHEAD_FACTOR
+        nodes = cluster_state.get_nodes(include_offline=False)
+        if not nodes:
+            return False
+        total_available = sum(
+            n.gpu_memory_gb * self.memory_utilization for n in nodes
+        )
+        return total_available >= required
+
+    def get_shard_assignment(self, config: ShardingConfig) -> Dict[str, ShardInfo]:
+        """Return the shard_map — already populated during plan_sharding."""
+        return dict(config.shard_map)
+
+    def plan_sharding(
+        self, model_id: str, cluster_state: ClusterState, strategy: ShardingStrategy = ShardingStrategy.AUTO
+    ) -> ShardingConfig:
+        """Given a model and available cluster nodes, determine optimal sharding.
+
+        Strategy:
+        - If model fits on a single node, don't shard.
+        - If model needs multiple nodes, use pipeline parallel (simpler over network).
+        - tensor_parallel is used only within a single node with multiple GPUs.
+        """
+        model_size = estimate_model_size(model_id)
+        required = model_size * MEMORY_OVERHEAD_FACTOR
+        nodes = cluster_state.get_nodes(include_offline=False)
+
+        if not nodes:
+            raise ValueError("No online nodes in cluster")
+
+        # Sort nodes by available memory (largest first)
+        nodes_sorted = sorted(nodes, key=lambda n: n.gpu_memory_gb, reverse=True)
+
+        # Check if a single node can handle it
+        best_node = nodes_sorted[0]
+        best_usable = best_node.gpu_memory_gb * self.memory_utilization
+
+        if best_usable >= required:
+            # Single node — no sharding needed
+            shard = ShardInfo(
+                node_id=best_node.node_id,
+                host="localhost",
+                api_port=best_node.api_port,
+                role="head",
+                layers="all",
+                estimated_memory_gb=required,
+            )
+            return ShardingConfig(
+                model=model_id,
+                strategy=ShardingStrategy.TENSOR_PARALLEL,
+                tensor_parallel_size=1,
+                pipeline_parallel_size=1,
+                nodes=[f"localhost:{best_node.api_port}"],
+                shard_map={best_node.node_id: shard},
+                total_memory_required_gb=required,
+            )
+
+        # Need multiple nodes — find minimum set that has enough memory
+        selected_nodes: List[ClusterNode] = []
+        accumulated = 0.0
+        for node in nodes_sorted:
+            selected_nodes.append(node)
+            accumulated += node.gpu_memory_gb * self.memory_utilization
+            if accumulated >= required:
+                break
+
+        if accumulated < required:
+            raise ValueError(
+                f"Cluster lacks memory for {model_id}: need {required:.1f} GB, "
+                f"have {accumulated:.1f} GB usable across {len(nodes_sorted)} nodes"
+            )
+
+        num_nodes = len(selected_nodes)
+
+        # Determine actual strategy
+        if strategy == ShardingStrategy.AUTO:
+            effective_strategy = ShardingStrategy.PIPELINE_PARALLEL
+        else:
+            effective_strategy = strategy
+
+        # Calculate per-node memory
+        per_node_mem = self.estimate_memory_per_node(model_size, num_nodes, effective_strategy)
+
+        # Build shard assignments
+        shard_map: Dict[str, ShardInfo] = {}
+        node_endpoints: List[str] = []
+
+        # Estimate total layers based on model size heuristic
+        estimated_layers = max(int(model_size / 2.0), 1)
+        layers_per_node = estimated_layers / num_nodes
+
+        for i, node in enumerate(selected_nodes):
+            role = "head" if i == 0 else "worker"
+            start_layer = int(i * layers_per_node)
+            end_layer = int((i + 1) * layers_per_node) - 1 if i < num_nodes - 1 else estimated_layers - 1
+            endpoint = f"{node.node_id}:{node.api_port}"
+            node_endpoints.append(endpoint)
+
+            shard_map[node.node_id] = ShardInfo(
+                node_id=node.node_id,
+                host=node.node_id,
+                api_port=node.api_port,
+                role=role,
+                layers=f"{start_layer}-{end_layer}",
+                estimated_memory_gb=per_node_mem,
+            )
+
+        tp_size = 1
+        pp_size = num_nodes
+
+        if effective_strategy == ShardingStrategy.TENSOR_PARALLEL:
+            tp_size = num_nodes
+            pp_size = 1
+
+        config = ShardingConfig(
+            model=model_id,
+            strategy=effective_strategy,
+            tensor_parallel_size=tp_size,
+            pipeline_parallel_size=pp_size,
+            nodes=node_endpoints,
+            shard_map=shard_map,
+            total_memory_required_gb=required,
+        )
+
+        logger.info(
+            "Sharding plan: %s across %d nodes (%s), TP=%d PP=%d",
+            model_id, num_nodes, effective_strategy.value, tp_size, pp_size,
+        )
+        return config

--- a/ainode/engine/sharding_routes.py
+++ b/ainode/engine/sharding_routes.py
@@ -1,0 +1,146 @@
+"""API routes for model sharding — plan, launch, and monitor distributed inference."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Optional
+
+from aiohttp import web
+
+from ainode.discovery.cluster import ClusterState
+from ainode.engine.sharding import ShardingPlanner, ShardingStrategy, ShardingConfig
+from ainode.engine.ray_setup import get_ray_status, start_ray_head, join_ray_cluster, stop_ray
+
+logger = logging.getLogger(__name__)
+
+# Module-level state for active sharding session
+_active_sharding: Optional[ShardingConfig] = None
+
+
+def register_sharding_routes(app: web.Application) -> None:
+    """Register sharding API endpoints on the aiohttp app."""
+    app.router.add_get("/api/sharding/plan", handle_sharding_plan)
+    app.router.add_post("/api/sharding/launch", handle_sharding_launch)
+    app.router.add_get("/api/sharding/status", handle_sharding_status)
+
+
+async def handle_sharding_plan(request: web.Request) -> web.Response:
+    """GET /api/sharding/plan?model=X — preview sharding plan for a model.
+
+    Query params:
+        model (required): HuggingFace model ID
+        strategy (optional): tensor_parallel, pipeline_parallel, auto (default: auto)
+    """
+    model = request.query.get("model")
+    if not model:
+        return web.json_response({"error": "model parameter required"}, status=400)
+
+    strategy_str = request.query.get("strategy", "auto")
+    try:
+        strategy = ShardingStrategy(strategy_str)
+    except ValueError:
+        return web.json_response(
+            {"error": f"Invalid strategy: {strategy_str}. Use: auto, tensor_parallel, pipeline_parallel"},
+            status=400,
+        )
+
+    cluster: ClusterState = request.app["cluster_state"]
+    planner = ShardingPlanner()
+
+    try:
+        config = planner.plan_sharding(model, cluster, strategy)
+    except ValueError as exc:
+        return web.json_response({"error": str(exc)}, status=422)
+
+    return web.json_response({
+        "plan": config.to_dict(),
+        "can_fit": planner.can_fit_model(model, cluster),
+        "cluster_nodes": len(cluster.get_nodes(include_offline=False)),
+    })
+
+
+async def handle_sharding_launch(request: web.Request) -> web.Response:
+    """POST /api/sharding/launch — launch a model with sharding across the cluster.
+
+    JSON body:
+        model (required): HuggingFace model ID
+        strategy (optional): auto | tensor_parallel | pipeline_parallel
+    """
+    global _active_sharding
+
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        return web.json_response({"error": "Invalid JSON"}, status=400)
+
+    model = body.get("model")
+    if not model:
+        return web.json_response({"error": "model field required"}, status=400)
+
+    strategy_str = body.get("strategy", "auto")
+    try:
+        strategy = ShardingStrategy(strategy_str)
+    except ValueError:
+        return web.json_response({"error": f"Invalid strategy: {strategy_str}"}, status=400)
+
+    cluster: ClusterState = request.app["cluster_state"]
+    engine = request.app.get("engine")
+
+    if engine is None:
+        return web.json_response({"error": "Engine not initialized"}, status=503)
+
+    planner = ShardingPlanner()
+
+    try:
+        config = planner.plan_sharding(model, cluster, strategy)
+    except ValueError as exc:
+        return web.json_response({"error": str(exc)}, status=422)
+
+    # If distributed, set up Ray cluster
+    if config.is_distributed:
+        try:
+            head_addr = start_ray_head()
+            config.ray_head_address = head_addr
+            logger.info("Ray head started at %s, workers should join", head_addr)
+        except RuntimeError as exc:
+            return web.json_response(
+                {"error": f"Failed to start Ray cluster: {exc}"}, status=500
+            )
+
+    # Stop existing engine if running
+    if engine.is_running():
+        engine.stop()
+
+    # Launch with sharding config
+    success = engine.launch_distributed(config)
+    if not success:
+        return web.json_response({"error": "Failed to launch distributed engine"}, status=500)
+
+    _active_sharding = config
+
+    return web.json_response({
+        "status": "launching",
+        "plan": config.to_dict(),
+    })
+
+
+async def handle_sharding_status(request: web.Request) -> web.Response:
+    """GET /api/sharding/status — current sharding state and Ray cluster health."""
+    ray_status = get_ray_status()
+    engine = request.app.get("engine")
+
+    engine_running = False
+    engine_ready = False
+    if engine is not None:
+        engine_running = engine.is_running()
+        engine_ready = getattr(engine, "ready", False)
+
+    result = {
+        "active_sharding": _active_sharding.to_dict() if _active_sharding else None,
+        "engine_running": engine_running,
+        "engine_ready": engine_ready,
+        "ray": ray_status.to_dict(),
+    }
+
+    return web.json_response(result)

--- a/ainode/engine/vllm_engine.py
+++ b/ainode/engine/vllm_engine.py
@@ -1,5 +1,6 @@
 """vLLM engine wrapper — manages the vLLM inference server lifecycle."""
 
+import logging
 import subprocess
 import signal
 import os
@@ -10,6 +11,8 @@ from pathlib import Path
 from typing import Optional, Callable
 from ainode.core.config import NodeConfig, LOGS_DIR
 from ainode.core.gpu import detect_gpu
+
+logger = logging.getLogger(__name__)
 
 
 class VLLMEngine:
@@ -112,7 +115,7 @@ class VLLMEngine:
         """Check if vLLM is healthy and responding.
 
         Works both when this instance owns the process and when checking
-        an externally-running vLLM server (e.g. from `ainode status`).
+        an externally-running vLLM server (e.g. from ``ainode status``).
         """
         import urllib.request
         import json
@@ -160,3 +163,76 @@ class VLLMEngine:
     @property
     def log_path(self) -> Optional[Path]:
         return self._log_file
+
+    # --- Distributed / Sharded Inference ---
+
+    def build_distributed_cmd(self, sharding_config) -> list[str]:
+        """Generate vLLM launch args for distributed inference."""
+        from ainode.engine.sharding import ShardingConfig
+
+        cmd = self.build_cmd()
+
+        if not isinstance(sharding_config, ShardingConfig):
+            return cmd
+
+        tp = sharding_config.tensor_parallel_size
+        pp = sharding_config.pipeline_parallel_size
+
+        if tp > 1:
+            cmd.extend(["--tensor-parallel-size", str(tp)])
+        if pp > 1:
+            cmd.extend(["--pipeline-parallel-size", str(pp)])
+
+        if sharding_config.model and sharding_config.model != self.config.model:
+            try:
+                model_idx = cmd.index("--model")
+                cmd[model_idx + 1] = sharding_config.model
+            except (ValueError, IndexError):
+                pass
+
+        return cmd
+
+    def launch_distributed(self, sharding_config) -> bool:
+        """Launch vLLM with distributed sharding via Ray."""
+        from ainode.engine.sharding import ShardingConfig
+
+        if self.process and self.process.poll() is None:
+            logger.warning("Engine already running, stop it first")
+            return False
+
+        if not isinstance(sharding_config, ShardingConfig):
+            logger.error("Invalid sharding config")
+            return False
+
+        cmd = self.build_distributed_cmd(sharding_config)
+        env = os.environ.copy()
+
+        if sharding_config.is_distributed:
+            if sharding_config.ray_head_address:
+                env["RAY_ADDRESS"] = sharding_config.ray_head_address
+            logger.info(
+                "Launching distributed vLLM: TP=%d PP=%d across %d nodes",
+                sharding_config.tensor_parallel_size,
+                sharding_config.pipeline_parallel_size,
+                len(sharding_config.nodes),
+            )
+        else:
+            env["CUDA_VISIBLE_DEVICES"] = os.environ.get("CUDA_VISIBLE_DEVICES", "0")
+            logger.info("Launching single-node vLLM with TP=%d", sharding_config.tensor_parallel_size)
+
+        LOGS_DIR.mkdir(parents=True, exist_ok=True)
+        self._log_file = LOGS_DIR / "vllm.log"
+
+        self.process = subprocess.Popen(
+            cmd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            bufsize=1,
+            universal_newlines=True,
+        )
+
+        self._log_thread = threading.Thread(target=self._stream_logs, daemon=True)
+        self._log_thread.start()
+
+        return self.process.poll() is None

--- a/ainode/web/static/js/app.js
+++ b/ainode/web/static/js/app.js
@@ -17,6 +17,7 @@ const AINode = {
     abortController: null,
     historyVisible: true,
     streamMetrics: { ttft: null, tps: 0, tokenCount: 0, startTime: 0, firstTokenTime: 0 },
+    shardingStatus: null,
   },
 
   init() {
@@ -138,9 +139,10 @@ const AINode = {
   async fetchJSON(url) { try { const resp = await fetch(url); if (!resp.ok) return null; return await resp.json(); } catch(e) { return null; } },
 
   async refresh() {
-    const [status, nodes] = await Promise.all([this.fetchJSON('/api/status'), this.fetchJSON('/api/nodes')]);
+    const [status, nodes, sharding] = await Promise.all([this.fetchJSON('/api/status'), this.fetchJSON('/api/nodes'), this.fetchJSON('/api/sharding/status')]);
     this.state.status = status;
     this.state.nodes = nodes?.nodes || [];
+    this.state.shardingStatus = sharding;
     switch (this.state.currentView) {
       case 'dashboard': this.renderDashboard(); break;
       case 'chat': this.renderChatHeader(); break;
@@ -177,6 +179,15 @@ const AINode = {
         model: s.model || 'none',
         status: s.engine_ready ? 'online' : 'starting'
       }];
+      // Annotate topology nodes with sharding info
+      var shardInfo = this.state.shardingStatus && this.state.shardingStatus.active_sharding;
+      if (shardInfo && shardInfo.shard_map) {
+        topoNodes = topoNodes.map(function(n) {
+          var shard = shardInfo.shard_map[n.node_id];
+          if (shard) { n.shard_role = shard.role; n.shard_layers = shard.layers; n.shard_memory_gb = shard.estimated_memory_gb; n.sharded_model = shardInfo.model; }
+          return n;
+        });
+      }
       this.topology.update(topoNodes);
     }
 
@@ -378,13 +389,22 @@ const AINode = {
       sortSelect + '</div>' +
       '<div style="display:flex;gap:8px;margin-bottom:16px">' + filterPills + '</div>';
 
+    var totalClusterMem = nodes.reduce(function(s, n) { return s + (n.gpu_memory_gb || 0); }, 0);
+    var clusterNodeCount = nodes.length;
+
     html += models.map(function(model) {
       var isLoaded = loaded.includes(model.id);
       var fits = gpuMem >= model.sizeGb;
       var fitBadge = gpuMem > 0 ? (fits ? '<span class="model-badge" style="background:rgba(34,197,94,0.15);color:#22c55e">Fits GPU</span>' : '<span class="model-badge" style="background:rgba(239,68,68,0.15);color:#ef4444">Too large</span>') : '';
       var downloadBtn = !isLoaded ? '<button class="btn btn-sm btn-primary models-download-btn" data-model-id="' + self.esc(model.id) + '">Download</button>' : '';
       var statusBadge = isLoaded ? '<span class="model-badge loaded">Loaded</span>' : '<span class="model-badge available">Available</span>';
-      return '<div class="model-card" data-model-id="' + self.esc(model.id) + '"><div class="model-info"><div class="model-name">' + self.esc(model.id) + '</div><div class="model-meta">' + model.size + ' &middot; ' + self.esc(model.desc) + '</div></div><div class="model-status" style="display:flex;gap:8px;align-items:center">' + fitBadge + statusBadge + downloadBtn + '</div></div>';
+      var shardBtn = '';
+      if (!fits && clusterNodeCount > 1 && totalClusterMem >= model.sizeGb) {
+        shardBtn = '<button class="btn btn-sm models-shard-btn" data-model-id="' + self.esc(model.id) + '" style="background:rgba(139,92,246,0.15);color:#8b5cf6;border:1px solid rgba(139,92,246,0.3)">Shard Across Cluster</button>';
+      } else if (!fits && clusterNodeCount > 1) {
+        shardBtn = '<span class="model-badge" style="background:rgba(139,92,246,0.1);color:#8b5cf6;font-size:11px">Needs more nodes</span>';
+      }
+      return '<div class="model-card" data-model-id="' + self.esc(model.id) + '"><div class="model-info"><div class="model-name">' + self.esc(model.id) + '</div><div class="model-meta">' + model.size + ' &middot; ' + self.esc(model.desc) + '</div></div><div class="model-status" style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">' + fitBadge + statusBadge + shardBtn + downloadBtn + '</div></div>';
     }).join('');
 
     if (models.length === 0) {
@@ -432,10 +452,33 @@ const AINode = {
       });
     });
 
+    // Bind shard buttons
+    container.querySelectorAll('.models-shard-btn').forEach(function(btn) {
+      btn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        var modelId = btn.dataset.modelId;
+        btn.disabled = true; btn.textContent = 'Planning...';
+        fetch('/api/sharding/plan?model=' + encodeURIComponent(modelId)).then(function(r) { return r.json(); }).then(function(data) {
+          if (data.error) { self.toast(data.error, 'error'); btn.disabled = false; btn.textContent = 'Shard Across Cluster'; return; }
+          var plan = data.plan, sm = plan.shard_map || {};
+          var h = '<div style="padding:12px;border:1px solid rgba(139,92,246,0.3);border-radius:8px;margin-top:8px;background:rgba(139,92,246,0.05)">';
+          h += '<div style="font-weight:600;margin-bottom:8px;color:#8b5cf6">Sharding Plan: ' + plan.strategy + '</div>';
+          h += '<div style="font-size:12px;color:var(--text-muted);margin-bottom:8px">World size: ' + plan.world_size + ' | TP: ' + plan.tensor_parallel_size + ' | PP: ' + plan.pipeline_parallel_size + ' | Memory: ' + plan.total_memory_required_gb + ' GB</div>';
+          Object.keys(sm).forEach(function(nid) { var s = sm[nid]; var rc = s.role === 'head' ? '#22c55e' : '#4a90d9'; h += '<div style="display:flex;justify-content:space-between;padding:6px 8px;margin:4px 0;background:rgba(255,255,255,0.03);border-radius:4px;font-size:12px"><span><span style="color:' + rc + ';font-weight:600">' + s.role.toUpperCase() + '</span> ' + self.esc(nid) + '</span><span style="color:var(--text-muted)">Layers ' + (s.layers || 'all') + ' | ~' + s.estimated_memory_gb + ' GB</span></div>'; });
+          h += '<div style="margin-top:10px;display:flex;gap:8px"><button class="btn btn-sm btn-primary shard-launch-btn" data-model-id="' + self.esc(modelId) + '">Launch Sharded</button><button class="btn btn-sm btn-ghost shard-cancel-btn">Cancel</button></div></div>';
+          var card = btn.closest('.model-card'), ep = card.querySelector('.shard-preview'); if (ep) ep.remove();
+          var pe = document.createElement('div'); pe.className = 'shard-preview'; pe.innerHTML = h; card.appendChild(pe);
+          btn.disabled = false; btn.textContent = 'Shard Across Cluster';
+          pe.querySelector('.shard-launch-btn').addEventListener('click', function(ev) { ev.stopPropagation(); var lb = ev.target; lb.disabled = true; lb.textContent = 'Launching...'; fetch('/api/sharding/launch', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ model: modelId }) }).then(function(r) { return r.json(); }).then(function(res) { if (res.error) { self.toast(res.error, 'error'); lb.disabled = false; lb.textContent = 'Launch Sharded'; } else { self.toast('Sharded model launching: ' + modelId, 'success'); self.refresh(); } }).catch(function(err) { self.toast('Error: ' + err.message, 'error'); lb.disabled = false; lb.textContent = 'Launch Sharded'; }); });
+          pe.querySelector('.shard-cancel-btn').addEventListener('click', function(ev) { ev.stopPropagation(); pe.remove(); });
+        }).catch(function(err) { self.toast('Error: ' + err.message, 'error'); btn.disabled = false; btn.textContent = 'Shard Across Cluster'; });
+      });
+    });
+
     // Bind expandable model details
     container.querySelectorAll('.model-card').forEach(function(card) {
       card.addEventListener('click', function(e) {
-        if (e.target.closest('.models-download-btn')) return;
+        if (e.target.closest('.models-download-btn') || e.target.closest('.models-shard-btn') || e.target.closest('.shard-preview')) return;
         var existing = card.querySelector('.model-details-expanded');
         if (existing) { existing.remove(); return; }
         var mid = card.dataset.modelId;

--- a/ainode/web/static/js/topology.js
+++ b/ainode/web/static/js/topology.js
@@ -206,9 +206,10 @@ const Topology = (() => {
   }
 
   function getNodeHeight(n) {
-    const base = CONFIG.nodeHeight;
-    if (hoveredNodeId === n.id) return base + CONFIG.hoverExpandHeight;
-    return base;
+    let h = CONFIG.nodeHeight;
+    if (n.data && n.data.shard_role) h += 22;
+    if (hoveredNodeId === n.id) h += CONFIG.hoverExpandHeight + (n.data && n.data.sharded_model ? 16 : 0);
+    return h;
   }
 
   function selectNode(id) {
@@ -262,11 +263,12 @@ const Topology = (() => {
         const b = graphNodes[j];
         const aOnline = a.data.status === 'online';
         const bOnline = b.data.status === 'online';
+        const bothSharded = !!(a.data.shard_role && b.data.shard_role);
         graphEdges.push({
           source: a,
           target: b,
           solid: aOnline && bOnline,
-          label: 'LAN',
+          label: bothSharded ? 'SHARD' : 'LAN',
         });
       }
     }
@@ -557,9 +559,23 @@ const Topology = (() => {
     ctx.font = '10px JetBrains Mono, Fira Code, monospace';
     ctx.fillText(memText + '  |  ' + modelText, x + 12, nameY + 34);
 
+    // Shard role badge (visible without hover)
+    if (d.shard_role) {
+      const badgeY = nameY + 50;
+      const badgeColor = d.shard_role === 'head' ? c.green : c.purple;
+      ctx.fillStyle = hexToRgba(badgeColor, 0.15);
+      roundRect(ctx, x + 10, badgeY - 2, nw - 20, 18, 4);
+      ctx.fill();
+      ctx.font = 'bold 9px Inter, -apple-system, sans-serif';
+      ctx.fillStyle = badgeColor;
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'top';
+      ctx.fillText(d.shard_role.toUpperCase() + ' | Layers ' + (d.shard_layers || 'all') + ' | ~' + (d.shard_memory_gb || '?') + ' GB', x + 14, badgeY + 1);
+    }
+
     // Hover expanded info
     if (isHovered) {
-      const expandY = nameY + 52;
+      const expandY = d.shard_role ? nameY + 72 : nameY + 52;
       ctx.fillStyle = hexToRgba(c.border, 0.5);
       ctx.fillRect(x + 12, expandY - 4, nw - 24, 1);
 

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -1,0 +1,217 @@
+"""Tests for ainode.engine.sharding — ShardingPlanner, memory estimation, shard assignment."""
+
+import pytest
+
+from ainode.discovery.broadcast import NodeStatus
+from ainode.discovery.cluster import ClusterState, ClusterNode
+from ainode.engine.sharding import (
+    ShardingPlanner,
+    ShardingStrategy,
+    estimate_model_size,
+    MEMORY_OVERHEAD_FACTOR,
+)
+
+
+def _make_node(node_id, gpu_memory_gb, model=""):
+    """Helper to create a ClusterNode for testing."""
+    return ClusterNode(
+        node_id=node_id,
+        node_name="node-" + node_id,
+        gpu_name="NVIDIA GB10",
+        gpu_memory_gb=gpu_memory_gb,
+        unified_memory=True,
+        model=model,
+        status=NodeStatus.ONLINE,
+        api_port=8000,
+        web_port=3000,
+        last_seen=0.0,
+    )
+
+
+def _make_cluster(*nodes):
+    """Helper to create a ClusterState from a list of nodes."""
+    cluster = ClusterState()
+    for node in nodes:
+        cluster.add_node(node)
+    return cluster
+
+
+class TestEstimateModelSize:
+    def test_known_model(self):
+        assert estimate_model_size("meta-llama/Llama-3.1-70B-Instruct") == 140.0
+
+    def test_known_model_awq(self):
+        assert estimate_model_size("meta-llama/Llama-3.1-70B-Instruct-AWQ") == 35.0
+
+    def test_unknown_model_with_param_count(self):
+        size = estimate_model_size("some-org/CustomModel-13B-Chat")
+        assert size == 26.0
+
+    def test_unknown_model_with_decimal_param_count(self):
+        size = estimate_model_size("org/Model-1.5B")
+        assert size == 3.0
+
+    def test_completely_unknown_model(self):
+        size = estimate_model_size("org/mystery-model")
+        assert size == 14.0
+
+
+class TestShardingPlannerMemoryEstimation:
+    def setup_method(self):
+        self.planner = ShardingPlanner()
+
+    def test_single_node_memory(self):
+        mem = self.planner.estimate_memory_per_node(100.0, 1, ShardingStrategy.PIPELINE_PARALLEL)
+        assert mem == 100.0 * MEMORY_OVERHEAD_FACTOR
+
+    def test_two_node_pipeline(self):
+        mem = self.planner.estimate_memory_per_node(100.0, 2, ShardingStrategy.PIPELINE_PARALLEL)
+        assert mem == 50.0 * MEMORY_OVERHEAD_FACTOR
+
+    def test_four_node_pipeline(self):
+        mem = self.planner.estimate_memory_per_node(200.0, 4, ShardingStrategy.PIPELINE_PARALLEL)
+        assert mem == 50.0 * MEMORY_OVERHEAD_FACTOR
+
+    def test_tensor_parallel_has_higher_overhead(self):
+        mem_tp = self.planner.estimate_memory_per_node(100.0, 2, ShardingStrategy.TENSOR_PARALLEL)
+        mem_pp = self.planner.estimate_memory_per_node(100.0, 2, ShardingStrategy.PIPELINE_PARALLEL)
+        assert mem_tp > mem_pp
+
+    def test_zero_nodes_returns_full_overhead(self):
+        mem = self.planner.estimate_memory_per_node(100.0, 0, ShardingStrategy.AUTO)
+        assert mem == 100.0 * MEMORY_OVERHEAD_FACTOR
+
+
+class TestCanFitModel:
+    def setup_method(self):
+        self.planner = ShardingPlanner()
+
+    def test_single_large_node_fits(self):
+        cluster = _make_cluster(_make_node("a", 256.0))
+        assert self.planner.can_fit_model("meta-llama/Llama-3.1-70B-Instruct", cluster) is True
+
+    def test_single_small_node_does_not_fit(self):
+        cluster = _make_cluster(_make_node("a", 24.0))
+        assert self.planner.can_fit_model("meta-llama/Llama-3.1-70B-Instruct", cluster) is False
+
+    def test_two_nodes_combined_fit(self):
+        cluster = _make_cluster(_make_node("a", 128.0), _make_node("b", 128.0))
+        assert self.planner.can_fit_model("meta-llama/Llama-3.1-70B-Instruct", cluster) is True
+
+    def test_empty_cluster(self):
+        cluster = ClusterState()
+        assert self.planner.can_fit_model("meta-llama/Llama-3.2-3B-Instruct", cluster) is False
+
+    def test_small_model_fits_small_node(self):
+        cluster = _make_cluster(_make_node("a", 16.0))
+        assert self.planner.can_fit_model("meta-llama/Llama-3.2-3B-Instruct", cluster) is True
+
+
+class TestPlanSharding:
+    def setup_method(self):
+        self.planner = ShardingPlanner()
+
+    def test_single_node_no_sharding(self):
+        cluster = _make_cluster(_make_node("a", 256.0))
+        config = self.planner.plan_sharding("meta-llama/Llama-3.1-70B-Instruct", cluster)
+
+        assert config.is_distributed is False
+        assert config.tensor_parallel_size == 1
+        assert config.pipeline_parallel_size == 1
+        assert len(config.shard_map) == 1
+        assert "a" in config.shard_map
+        assert config.shard_map["a"].role == "head"
+
+    def test_two_node_sharding(self):
+        cluster = _make_cluster(_make_node("a", 128.0), _make_node("b", 128.0))
+        config = self.planner.plan_sharding("meta-llama/Llama-3.1-70B-Instruct", cluster)
+
+        assert config.is_distributed is True
+        assert config.pipeline_parallel_size == 2
+        assert config.tensor_parallel_size == 1
+        assert config.strategy == ShardingStrategy.PIPELINE_PARALLEL
+        assert len(config.shard_map) == 2
+        roles = set()
+        for s in config.shard_map.values():
+            roles.add(s.role)
+        assert roles == {"head", "worker"}
+
+    def test_four_node_large_model(self):
+        """405B model needs multiple large nodes (e.g. 4x DGX Spark with 300GB each)."""
+        cluster = _make_cluster(
+            _make_node("a", 300.0),
+            _make_node("b", 300.0),
+            _make_node("c", 300.0),
+            _make_node("d", 300.0),
+        )
+        config = self.planner.plan_sharding("meta-llama/Llama-3.1-405B-Instruct", cluster)
+
+        assert config.is_distributed is True
+        assert config.pipeline_parallel_size >= 2
+        assert len(config.shard_map) >= 2
+
+    def test_auto_strategy_selects_pipeline(self):
+        cluster = _make_cluster(_make_node("a", 128.0), _make_node("b", 128.0))
+        config = self.planner.plan_sharding(
+            "meta-llama/Llama-3.1-70B-Instruct", cluster, ShardingStrategy.AUTO
+        )
+        assert config.strategy == ShardingStrategy.PIPELINE_PARALLEL
+
+    def test_explicit_tensor_parallel(self):
+        cluster = _make_cluster(_make_node("a", 128.0), _make_node("b", 128.0))
+        config = self.planner.plan_sharding(
+            "meta-llama/Llama-3.1-70B-Instruct", cluster, ShardingStrategy.TENSOR_PARALLEL
+        )
+        assert config.strategy == ShardingStrategy.TENSOR_PARALLEL
+        assert config.tensor_parallel_size == 2
+        assert config.pipeline_parallel_size == 1
+
+    def test_insufficient_memory_raises(self):
+        cluster = _make_cluster(_make_node("a", 32.0))
+        with pytest.raises(ValueError, match="lacks memory"):
+            self.planner.plan_sharding("meta-llama/Llama-3.1-70B-Instruct", cluster)
+
+    def test_no_nodes_raises(self):
+        cluster = ClusterState()
+        with pytest.raises(ValueError, match="No online nodes"):
+            self.planner.plan_sharding("meta-llama/Llama-3.2-3B-Instruct", cluster)
+
+    def test_selects_fewest_nodes_needed(self):
+        cluster = _make_cluster(
+            _make_node("big", 256.0),
+            _make_node("medium", 128.0),
+            _make_node("small", 64.0),
+        )
+        config = self.planner.plan_sharding("meta-llama/Llama-3.1-70B-Instruct", cluster)
+        assert len(config.shard_map) == 1
+        assert "big" in config.shard_map
+
+
+class TestShardAssignment:
+    def test_shard_layers_are_assigned(self):
+        planner = ShardingPlanner()
+        cluster = _make_cluster(_make_node("a", 128.0), _make_node("b", 128.0))
+        config = planner.plan_sharding("meta-llama/Llama-3.1-70B-Instruct", cluster)
+        assignment = planner.get_shard_assignment(config)
+
+        for node_id, shard in assignment.items():
+            assert shard.layers is not None
+            assert shard.estimated_memory_gb > 0
+
+
+class TestShardingConfigSerialization:
+    def test_to_dict(self):
+        planner = ShardingPlanner()
+        cluster = _make_cluster(_make_node("a", 128.0), _make_node("b", 128.0))
+        config = planner.plan_sharding("meta-llama/Llama-3.1-70B-Instruct", cluster)
+        d = config.to_dict()
+
+        assert d["model"] == "meta-llama/Llama-3.1-70B-Instruct"
+        assert d["strategy"] in ("tensor_parallel", "pipeline_parallel")
+        assert d["is_distributed"] is True
+        assert d["world_size"] >= 2
+        assert isinstance(d["shard_map"], dict)
+        for node_id, shard in d["shard_map"].items():
+            assert "role" in shard
+            assert "layers" in shard
+            assert "estimated_memory_gb" in shard


### PR DESCRIPTION
## Summary
- **ShardingPlanner** (`ainode/engine/sharding.py`): Plans optimal model distribution across cluster nodes. Auto-selects pipeline parallel for multi-node (simpler over network), estimates memory per node, finds minimum node set to fit a model. Includes known model size table and heuristic fallback.
- **Ray cluster helpers** (`ainode/engine/ray_setup.py`): Start/join/stop Ray head and worker nodes for multi-node distributed inference via subprocess calls.
- **VLLMEngine distributed launch** (`ainode/engine/vllm_engine.py`): `build_distributed_cmd()` and `launch_distributed()` methods generate vLLM args with `--tensor-parallel-size` and `--pipeline-parallel-size`, set Ray environment for multi-node.
- **Sharding API** (`ainode/engine/sharding_routes.py`): `GET /api/sharding/plan`, `POST /api/sharding/launch`, `GET /api/sharding/status` endpoints for planning, launching, and monitoring sharded deployments.
- **Dashboard UI** (`app.js`, `topology.js`): "Shard Across Cluster" button on models too large for a single node, sharding preview with per-node layer/memory assignment, topology view shows shard role badges and SHARD edge labels.
- **25 tests** (`tests/test_sharding.py`): Full coverage of planner logic, memory estimation, shard assignment, strategy selection, and serialization.

## Test plan
- [x] `pytest tests/test_sharding.py` — 25 tests pass
- [x] `pytest tests/` — all 291 tests pass
- [ ] Manual: verify sharding plan API with multi-node cluster
- [ ] Manual: verify dashboard shows shard button when cluster has 2+ nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)