### PR TITLE
feat: Models redesign + Unload fan-out + BUG A + fp8 KV + start-clean + dashboard truth

### DIFF
--- a/ainode/__init__.py
+++ b/ainode/__init__.py
@@ -1,5 +1,5 @@
 """AINode — Turn any NVIDIA GPU into a local AI platform."""
 
-__version__ = "0.4.37"
+__version__ = "0.4.43"
 __author__ = "Argentos AI"
 __url__ = "https://ainode.dev"

--- a/ainode/api/server.py
+++ b/ainode/api/server.py
@@ -272,13 +272,18 @@ async def _on_startup(app: web.Application) -> None:
 
     # Always-on: re-load the persisted solo instance set so a `systemctl restart
     # ainode` brings every previously-loaded model back with no manual step.
-    try:
-        from ainode.models.api_routes import replay_instances_on_startup
-        app["_instance_replay_task"] = asyncio.get_event_loop().create_task(
-            replay_instances_on_startup(app)
-        )
-    except Exception:
-        logger.exception("Failed to schedule instance replay")
+    # Skipped when the operator requested a clean boot (closet #310, set in the
+    # CLI start path) so a restart can actually free the node.
+    if getattr(config, "_skip_replay", False):
+        logger.info("start-clean: skipping persisted-instance replay")
+    else:
+        try:
+            from ainode.models.api_routes import replay_instances_on_startup
+            app["_instance_replay_task"] = asyncio.get_event_loop().create_task(
+                replay_instances_on_startup(app)
+            )
+        except Exception:
+            logger.exception("Failed to schedule instance replay")
 
     if config.cluster_enabled:
         # Start broadcast sender

--- a/ainode/api/server.py
+++ b/ainode/api/server.py
@@ -366,6 +366,13 @@ async def _cluster_sync_loop(app: web.Application) -> None:
                 }
                 dmode = updates["distributed_mode"]
                 engine_ready = bool(engine is not None and getattr(engine, "ready", False))
+                # Re-broadcast the live primary model every cycle. Without this the
+                # announcement's `model` field is frozen at its startup value, so
+                # /api/nodes (reads n.model) goes stale while /v1/models (reads
+                # n.instances) stays fresh — and unloads never clear, leaving
+                # phantom-READY panels + ghost routing until restart (BUG A).
+                # Members serve via the head's sharded engine, not their own model.
+                updates["model"] = "" if dmode == "member" else (config.model or "")
                 if dmode == "member":
                     updates["status"] = "member-ready"
                 elif engine is not None:

--- a/ainode/api/server.py
+++ b/ainode/api/server.py
@@ -344,6 +344,27 @@ async def _on_startup(app: web.Application) -> None:
             )
 
 
+async def _engine_serving(backend, loop) -> bool:
+    """True iff the engine's OpenAI API actually answers right now.
+
+    The latched `ready` flag never flips False when an engine crashes or is
+    killed out-of-band, so a dead engine reads READY forever (phantom-READY →
+    ghost routing → 502s). An active localhost probe is the truthful signal —
+    and it correctly reads False while a model is still loading (api not up
+    yet), so we never advertise a not-yet-serving OR already-dead engine.
+
+    health_check() uses a blocking 5s-timeout urlopen, so run it in the default
+    executor to keep the event loop free (a hung engine must not stall sync).
+    """
+    if backend is None:
+        return False
+    try:
+        hc = await loop.run_in_executor(None, backend.health_check)
+        return bool(hc.get("api_responding"))
+    except Exception:
+        return False
+
+
 async def _cluster_sync_loop(app: web.Application) -> None:
     """Periodically sync the listener registry into ClusterState."""
     try:
@@ -365,23 +386,33 @@ async def _cluster_sync_loop(app: web.Application) -> None:
                     "distributed_mode": getattr(config, "distributed_mode", "solo") or "solo",
                 }
                 dmode = updates["distributed_mode"]
-                engine_ready = bool(engine is not None and getattr(engine, "ready", False))
-                # Re-broadcast the live primary model every cycle. Without this the
-                # announcement's `model` field is frozen at its startup value, so
-                # /api/nodes (reads n.model) goes stale while /v1/models (reads
-                # n.instances) stays fresh — and unloads never clear, leaving
-                # phantom-READY panels + ghost routing until restart (BUG A).
-                # Members serve via the head's sharded engine, not their own model.
-                updates["model"] = "" if dmode == "member" else (config.model or "")
+                loop = asyncio.get_event_loop()
+                # Liveness: the latched `ready` flag never flips False when an engine
+                # crashes or is killed out-of-band, so a dead engine reads READY forever
+                # (phantom-READY → ghost routing → 502s, BUG A FIX 2). Probe the engine's
+                # own API instead (see _engine_serving) — also reads False while loading,
+                # so we never advertise a not-yet-serving OR already-dead engine.
+                # ponytail: one localhost probe per instance per 5s cycle; a transient
+                # blip drops the model for one cycle and self-heals on the next probe.
+                engine_serving = await _engine_serving(engine, loop)
+                engine_proc_alive = bool(engine is not None and engine.is_running())
+                # Re-broadcast the live primary model every cycle, gated on real
+                # liveness — fixes both the stale `model` field (BUG A) and the
+                # phantom-READY-after-crash case (FIX 2). Members serve via the head's
+                # sharded engine, not their own model.
+                updates["model"] = "" if (dmode == "member" or not engine_serving) else (config.model or "")
                 if dmode == "member":
                     updates["status"] = "member-ready"
                 elif engine is not None:
-                    updates["status"] = "serving" if engine_ready else "starting"
+                    updates["status"] = (
+                        "serving" if engine_serving
+                        else ("starting" if engine_proc_alive else "stopped")
+                    )
 
                 # Advertise distributed instance metadata once the head's
                 # sharded engine is serving — the UI uses this to render
                 # "DISTRIBUTED TP=N across X nodes".
-                if dmode == "head" and engine_ready:
+                if dmode == "head" and engine_serving:
                     peer_ips = list(getattr(config, "peer_ips", []) or [])
                     if peer_ips:
                         updates["distributed_instance_id"] = f"{config.node_id or 'head'}:{config.model}"
@@ -394,10 +425,16 @@ async def _cluster_sync_loop(app: web.Application) -> None:
                     updates["distributed_peers"] = []
                 manager = app.get("instances")
                 if manager is not None and not manager.is_empty():
-                    updates["instances"] = [r.to_dict() for r in manager.records()]
+                    # Only advertise instances whose engine actually answers — a dead
+                    # stacked instance drops out of the broadcast within one cycle.
+                    live_records = []
+                    for inst in manager.instances():
+                        if await _engine_serving(inst.backend, loop):
+                            live_records.append(inst.record)
+                    updates["instances"] = [r.to_dict() for r in live_records]
                 else:
                     updates["instances"] = (
-                        _head_instances(config) if (dmode == "head" and engine_ready) else []
+                        _head_instances(config) if (dmode == "head" and engine_serving) else []
                     )
                 if sender:
                     sender.update_announcement(**updates)

--- a/ainode/api/server.py
+++ b/ainode/api/server.py
@@ -543,6 +543,23 @@ async def handle_status(request: web.Request) -> web.Response:
 
     gpu: Optional[GPUInfo] = detect_gpu()
     gpu_info = asdict(gpu) if gpu else None
+    # detect_gpu() caches and reports free==total on GB10 unified memory, so the
+    # dashboard showed 0% used. Overlay the collector's live psutil reading — the
+    # same source /api/nodes uses — so the two endpoints agree.
+    if gpu_info is not None:
+        collector = request.app.get("metrics_collector")
+        if collector is not None:
+            try:
+                m = collector.get_gpu_metrics() or {}
+                if not m.get("error"):
+                    total_mb = m.get("memory_total_mb") or gpu_info.get("memory_total_mb")
+                    used_mb = m.get("memory_used_mb")
+                    if total_mb:
+                        gpu_info["memory_total_mb"] = round(total_mb)
+                        if used_mb is not None:
+                            gpu_info["memory_free_mb"] = max(0, round(total_mb - used_mb))
+            except Exception:
+                pass
 
     engine_ready = False
     models_loaded: list[str] = []
@@ -581,7 +598,11 @@ async def handle_status(request: web.Request) -> web.Response:
         "engine_ready": engine_ready,
         # Coarse engine load phase for the UI launching card (3c):
         # idle | starting | loading_weights | distributed_init | profiling | ready
-        "load_phase": (getattr(engine, "load_phase", "idle") if engine is not None else "idle"),
+        # Truthful phase: the live /v1/models probe above is the reliable
+        # readiness signal — the engine's _ready latch can miss the vLLM startup
+        # log marker and stay False on a model that is actually serving. Report
+        # 'ready' when the probe says serving; else the engine's coarse phase.
+        "load_phase": ("ready" if engine_ready else (getattr(engine, "load_phase", "idle") if engine is not None else "idle")),
         "uptime": round(time.time() - start_time, 1),
         "version": __version__,
         "powered_by": "argentos.ai",

--- a/ainode/cli/main.py
+++ b/ainode/cli/main.py
@@ -140,6 +140,32 @@ def cmd_start(args):
         config.node_id = str(uuid.uuid4())[:8]
         config.save()
 
+    # Start-clean (closet #310): one-shot operator knob to skip replaying
+    # persisted models this boot, so `restart` actually frees a node (replay
+    # otherwise reloads config.model + the stacked manifest). Non-destructive —
+    # on-disk config is untouched, so a normal restart resumes serving.
+    from ainode.models.api_routes import consume_start_clean
+    if consume_start_clean():
+        if config.model:
+            console.print("  [yellow]Start-clean — not replaying persisted model(s) this boot.[/yellow]\n")
+        config.model = None
+        config._skip_replay = True
+        # Actually free the node: a vLLM engine container is a sibling spawned via
+        # docker.sock, so the ainode restart does NOT stop it — and with no boot
+        # engine to reclaim it, it would keep holding memory. Sweep them here.
+        try:
+            import subprocess
+            ps = subprocess.run(
+                ["docker", "ps", "-aq", "--filter", "name=ainode-vllm-node-solo"],
+                capture_output=True, text=True, timeout=20)
+            ids = [i for i in ps.stdout.split() if i]
+            if ids:
+                subprocess.run(["docker", "rm", "-f", *ids],
+                               capture_output=True, text=True, timeout=60)
+                console.print(f"  [dim]Start-clean — freed {len(ids)} engine container(s).[/dim]\n")
+        except Exception:
+            pass
+
     # Detect GPU
     gpu = detect_gpu()
     if gpu:

--- a/ainode/core/config.py
+++ b/ainode/core/config.py
@@ -43,6 +43,10 @@ class NodeConfig:
     # for GB10 (still fits a 70B / per-node MoE share); push it higher per-load
     # (gpu_memory_utilization in the load body) for big-MoE long-context runs.
     gpu_memory_utilization: float = 0.5
+    # KV-cache precision. fp8 is the GB10 design default — required for long
+    # context (32k+) or vLLM OOMs sizing the cache at bf16 (see engine/AGENTS.md).
+    # Set "" / "auto" to let vLLM choose if a model/quant ever rejects fp8.
+    kv_cache_dtype: str = "fp8"
     quantization: Optional[str] = None  # awq, gptq, fp8, None
     trust_remote_code: bool = False
 

--- a/ainode/engine/backends/nvidia.py
+++ b/ainode/engine/backends/nvidia.py
@@ -379,7 +379,7 @@ class NvidiaBackend(EngineBackend):
             "process_alive": self.is_running(),
             "api_responding": False,
             "models_loaded": [],
-            "load_phase": self._load_phase,
+            "load_phase": self.load_phase,
         }
         try:
             url = f"http://127.0.0.1:{self.config.api_port}/v1/models"
@@ -401,8 +401,13 @@ class NvidiaBackend(EngineBackend):
 
     @property
     def load_phase(self) -> str:
-        """Coarse engine load phase for the UI launching card (3c)."""
-        return self._load_phase
+        """Coarse engine load phase for the UI launching card (3c).
+
+        Derive 'ready' from the readiness latch: wait_ready() can set _ready via
+        the API-poll path before _stream_logs sees the startup log line, which
+        left _load_phase stuck at 'starting' on a model that is actually serving.
+        """
+        return "ready" if self._ready else self._load_phase
 
     @property
     def api_url(self) -> str:

--- a/ainode/engine/backends/nvidia.py
+++ b/ainode/engine/backends/nvidia.py
@@ -856,6 +856,11 @@ class NvidiaBackend(EngineBackend):
             # throughput needs a working non-FlashInfer backend first.
             "--enforce-eager",
         ]
+        # fp8 KV cache — the GB10 design default (engine/AGENTS.md): required for
+        # long context or vLLM OOMs sizing the cache at bf16. Config-driven so a
+        # model/quant that rejects fp8 can fall back via kv_cache_dtype="".
+        if getattr(self.config, "kv_cache_dtype", ""):
+            args.extend(["--kv-cache-dtype", self.config.kv_cache_dtype])
         if tp_size > 1:
             args.extend(["--tensor-parallel-size", str(tp_size)])
             args.extend(["--distributed-executor-backend", "ray"])

--- a/ainode/models/api_routes.py
+++ b/ainode/models/api_routes.py
@@ -76,6 +76,32 @@ def _manifest_path() -> Path:
     return Path(AINODE_HOME) / "instances.json"
 
 
+def consume_start_clean() -> bool:
+    """One-shot 'start clean' signal: skip replaying persisted models this boot.
+
+    A node restart otherwise reloads config.model (boot engine) + the stacked
+    manifest, so 'restart to free a node' just reloads. This lets an operator
+    start a node idle. Triggered by:
+      - env AINODE_START_CLEAN truthy (persists across restarts), or
+      - a sentinel file <AINODE_HOME>/.start-clean — a single-use
+        `touch ~/.ainode/.start-clean && systemctl restart ainode` knob,
+        consumed (deleted) here so the next restart serves normally.
+    Non-destructive: the on-disk config + manifest are left intact.
+    """
+    import os
+    from ainode.core.config import AINODE_HOME
+    env = str(os.environ.get("AINODE_START_CLEAN", "")).strip().lower() in ("1", "true", "yes", "on")
+    sentinel_present = False
+    try:
+        sentinel = Path(AINODE_HOME) / ".start-clean"
+        if sentinel.exists():
+            sentinel_present = True
+            sentinel.unlink()
+    except Exception:
+        pass
+    return env or sentinel_present
+
+
 def save_instance_manifest(app) -> None:
     """Write the current solo instance set (model + gpu_memory_utilization)."""
     manager = app.get("instances")

--- a/ainode/models/api_routes.py
+++ b/ainode/models/api_routes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import aiohttp
 import json
 import logging
 import time
@@ -478,37 +479,65 @@ async def handle_model_unload(request: web.Request) -> web.Response:
                 "errors": errors,
             })
 
-    if engine is not None:
+    # Was THIS node actually serving the requested model? (back-compat: no model
+    # given → stop whatever is local.) Only then is a local "stopped" truthful —
+    # the old code returned stopped:true even when engine was None or serving a
+    # different model, which is why the dashboard's Unload button silently no-op'd.
+    served_here = engine is not None and (not model or getattr(config, "model", None) == model)
+    if served_here:
         try:
             if engine.is_running():
                 engine.stop()
-            # Both a live stop and an already-dead engine mean not-serving.
-            stopped = True
         except Exception as exc:
             errors.append(f"engine.stop(): {exc}")
-            stopped = True
-        # Always force the latch down so a phantom doesn't re-advertise.
         try:
-            engine._ready = False
+            engine._ready = False  # force the latch down so a phantom doesn't re-advertise
         except Exception:
             pass
-    else:
-        stopped = True
-
-    try:
-        config.model = None
-        if getattr(config, "distributed_mode", "") == "head":
-            config.distributed_mode = "solo"
         try:
+            config.model = None
+            if getattr(config, "distributed_mode", "") == "head":
+                config.distributed_mode = "solo"
             config.save()
         except Exception as exc:
-            errors.append(f"config.save: {exc}")
-    except Exception as exc:
-        errors.append(f"config clear: {exc}")
+            errors.append(f"config clear: {exc}")
+        return web.json_response({"stopped": True, "model": model, "scope": "local", "errors": errors})
+
+    # Not serving here. `fanout=0` marks a fan-out child — stop, don't recurse
+    # (prevents an unload broadcast storm). Otherwise the model lives on another
+    # node: fan the unload out to online peers (each peer's local unload is
+    # idempotent) so the head can unload a remote-node instance.
+    if request.query.get("fanout") == "0":
+        return web.json_response({"stopped": False, "model": model, "scope": "local-miss", "errors": errors})
+
+    cluster = request.app.get("cluster_state")
+    session = request.app.get("client_session")
+    remote_stopped = False
+    peers_reached = 0
+    if cluster is not None and session is not None and model:
+        for node in cluster.members():
+            if node.node_id == config.node_id:
+                continue
+            host = node.fabric_ip or node.node_name
+            if not host:
+                continue
+            url = f"http://{host}:{node.web_port}/api/models/unload?fanout=0"
+            try:
+                async with session.post(url, json={"model": model},
+                                        timeout=aiohttp.ClientTimeout(total=30)) as r:
+                    peers_reached += 1
+                    jr = await r.json()
+                    if jr.get("stopped"):
+                        remote_stopped = True
+                        errors.extend(jr.get("errors") or [])
+            except Exception as exc:
+                errors.append(f"peer {node.node_id}: {exc}")
 
     return web.json_response({
-        "stopped": stopped,
-        "model": body.get("model"),
+        "stopped": remote_stopped,
+        "model": model,
+        "scope": "remote-fanout",
+        "peers_reached": peers_reached,
         "errors": errors,
     })
 

--- a/ainode/models/registry.py
+++ b/ainode/models/registry.py
@@ -8,6 +8,7 @@ fallback for offline/error situations.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import shutil
@@ -15,6 +16,27 @@ import time
 from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+# Bytes-per-element for the dtypes HF reports in safetensors metadata. Lets us
+# compute real download size for quantized models (NVFP4 weights land as U8).
+_DTYPE_BYTES = {
+    "F64": 8, "I64": 8, "U64": 8,
+    "F32": 4, "I32": 4, "U32": 4,
+    "BF16": 2, "F16": 2, "I16": 2, "U16": 2,
+    "F8_E4M3": 1, "F8_E5M2": 1, "I8": 1, "U8": 1, "BOOL": 1,
+    "F4": 0.5, "FP4": 0.5,
+}
+
+
+def _safetensors_size_gb(safetensors) -> float:
+    """Real on-disk size (decimal GB) from HF safetensors dtype breakdown."""
+    params = getattr(safetensors, "parameters", None)
+    if not params:
+        return 0.0
+    total_bytes = sum(_DTYPE_BYTES.get(dt, 2) * n for dt, n in params.items())
+    return round(total_bytes / 1e9, 1)
 
 
 def _download_max_workers() -> int:
@@ -48,6 +70,9 @@ class ModelInfo:
     # actually served it on this hardware (drives the picker default + a ✓ badge).
     proven_tp: int = 0
     verified: bool = False
+    # True for our hand-picked CURATED_CLUSTER_MODELS — drives the "Catalog"
+    # (known-good to grab) list, separate from on-disk / HF-sweep entries.
+    curated: bool = False
     created_at: str = ""
     downloads: int = 0
     likes: int = 0
@@ -180,6 +205,16 @@ CURATED_CLUSTER_MODELS: dict[str, ModelInfo] = {
         proven_tp=1, verified=True,
         context_length=262144, license="Apache 2.0", recommended=True, format="awq",
     ),
+    "llama-3.1-8b-nvfp4": ModelInfo(
+        id="llama-3.1-8b-nvfp4",
+        name="Llama 3.1 8B Instruct (NVFP4)",
+        hf_repo="nvidia/Llama-3.1-8B-Instruct-NVFP4",
+        size_gb=6.0,
+        description="Dense 8B, Blackwell-native NVFP4 — ~18 tok/s single-stream on one GB10 (dense is bandwidth-bound). Solid general-purpose chat model, light enough to stack.",
+        quantization="NVFP4", min_memory_gb=8, family="llama", params_b=8.0,
+        proven_tp=1, verified=True,
+        context_length=131072, license="Llama 3.1", recommended=True, format="nvfp4",
+    ),
     # --- Community daily-driver MoE picks (DGX Spark forum + r/LocalLLaMA, 2026) ---
     "nemotron-cascade-2-30b-a3b-nvfp4": ModelInfo(
         id="nemotron-cascade-2-30b-a3b-nvfp4",
@@ -261,6 +296,16 @@ CURATED_CLUSTER_MODELS: dict[str, ModelInfo] = {
         proven_tp=4, verified=False,
         context_length=131072, license="GLM",
     ),
+    "glm-5.2-reap-504b-nvfp4": ModelInfo(
+        id="glm-5.2-reap-504b-nvfp4",
+        name="GLM-5.2 NVFP4 REAP-504B",
+        hf_repo="madeby561/GLM-5.2-NVFP4-REAP-504B",
+        size_gb=309.0,
+        description="REAP-pruned GLM-5.2 MoE, NVFP4 for GB10. ~309 GB on disk — needs the cluster's pooled memory (TP=4). DeepSeek Sparse Attention. NOT yet load-tested on GB10.",
+        quantization="NVFP4", min_memory_gb=360, family="glm", params_b=504.0,
+        proven_tp=4, verified=False,
+        context_length=131072, license="MIT", recommended=False, format="nvfp4",
+    ),
 }
 
 
@@ -323,7 +368,7 @@ class CatalogAggregator:
             seen_ids: set[str] = set()
             for q in queries:
                 try:
-                    iterator = api.list_models(direction=-1, **q)
+                    iterator = api.list_models(**q)  # `direction` dropped in hub >=1.x
                 except Exception:
                     continue
                 for m in iterator:
@@ -772,6 +817,7 @@ class ModelManager:
             # Skip any whose hf_repo a live entry already covers (don't clobber).
             existing_repos = {m.hf_repo.lower() for m in merged.values()}
             for cid, info in CURATED_CLUSTER_MODELS.items():
+                info.curated = True  # mark our hand-picked known-good set
                 if cid not in merged and info.hf_repo.lower() not in existing_repos:
                     merged[cid] = info
             self._catalog_cache = merged
@@ -1047,28 +1093,37 @@ class ModelManager:
         try:
             from huggingface_hub import HfApi
             api = HfApi()
+            # huggingface_hub >=1.x dropped `direction`/`task`; use pipeline_tag.
+            # expand=safetensors pulls the dtype breakdown so we can show real size.
             models = api.list_models(
                 search=query,
-                filter="text-generation",
+                pipeline_tag="text-generation",
                 limit=limit,
                 sort="downloads",
-                direction=-1,
+                expand=["safetensors"],
             )
-            catalog_ids = set(self.get_catalog_map().keys())
+            catalog_repos = {info.hf_repo.lower() for info in self.get_catalog()}
             results = []
             for m in models:
                 repo = m.id
+                repo_l = repo.lower()
                 slug = repo.replace("/", "--").lower()
-                size_gb = 0.0
-                if hasattr(m, "safetensors") and m.safetensors:
-                    total_params = m.safetensors.get("total", 0)
-                    size_gb = (total_params * 2) / (1024 ** 3)
-                card_data = getattr(m, "cardData", None)
-                license_str = ""
-                if isinstance(card_data, dict):
-                    lic = card_data.get("license", "")
-                    if isinstance(lic, str):
-                        license_str = lic
+                size_gb = _safetensors_size_gb(getattr(m, "safetensors", None))
+                sf = getattr(m, "safetensors", None)
+                total_params = getattr(sf, "total", 0) if sf else 0
+                # Quant/engine from repo name — drives the badge AND the
+                # "can it run on vLLM/GB10" filter (MLX=Apple, GGUF=llama.cpp).
+                quant = ""
+                for tag, label in (
+                    ("nvfp4", "NVFP4"), ("mxfp4", "MXFP4"), ("w4afp8", "W4AFP8"),
+                    ("w4a16", "W4A16"), ("awq", "AWQ"), ("gptq", "GPTQ"),
+                    ("int4", "INT4"), ("int8", "INT8"), ("fp8", "FP8"),
+                    ("gguf", "GGUF"), ("mlx", "MLX"), ("bf16", "BF16"), ("fp16", "FP16"),
+                ):
+                    if tag in repo_l:
+                        quant = label
+                        break
+                vllm_ok = not ("mlx" in repo_l or "gguf" in repo_l or "ggml" in repo_l)
                 results.append({
                     "id": slug,
                     "name": repo.split("/")[-1],
@@ -1076,16 +1131,48 @@ class ModelManager:
                     "size_gb": round(size_gb, 1),
                     "description": (m.pipeline_tag or "text-generation") + " model",
                     "family": repo.split("/")[0].lower(),
-                    "params_b": round((size_gb / 2), 2) if size_gb > 0 else 0,
+                    "params_b": round(total_params / 1e9, 1) if total_params else 0,
                     "context_length": 0,
-                    "license": license_str,
+                    "license": "",
                     "recommended": False,
+                    "quant": quant,
+                    "vllm_ok": vllm_ok,
                     "downloads": getattr(m, "downloads", 0),
                     "likes": getattr(m, "likes", 0),
-                    "in_catalog": slug in catalog_ids,
+                    "in_catalog": repo_l in catalog_repos,
                 })
+            # Always surface curated matches for the query — HF's download-sorted
+            # page often ranks our vetted pick past the limit, so inject it.
+            ql = query.lower()
+            have = {r["hf_repo"].lower() for r in results}
+            for info in self.get_catalog():
+                if not getattr(info, "curated", False):
+                    continue
+                hay = (info.hf_repo + " " + info.name + " " + (info.family or "")).lower()
+                if ql in hay and info.hf_repo.lower() not in have:
+                    results.append({
+                        "id": info.hf_repo.replace("/", "--").lower(),
+                        "name": info.name,
+                        "hf_repo": info.hf_repo,
+                        "size_gb": info.size_gb,
+                        "description": info.description,
+                        "family": info.family,
+                        "params_b": info.params_b,
+                        "context_length": info.context_length,
+                        "license": info.license,
+                        "recommended": info.recommended,
+                        "quant": (info.quantization or info.format or "").upper(),
+                        "vllm_ok": True,
+                        "proven_tp": info.proven_tp,
+                        "downloads": 0,
+                        "likes": 0,
+                        "in_catalog": True,
+                    })
+            # Vetted (in-catalog) pick first, then most-downloaded.
+            results.sort(key=lambda r: (not r["in_catalog"], -(r["downloads"] or 0)))
             return results
-        except Exception:
+        except Exception as e:
+            logger.warning("HuggingFace search failed for %r: %s", query, e)
             return []
 
     def _find_catalog_by_dir(self, dirname: str) -> Optional[ModelInfo]:

--- a/ainode/web/static/css/style.css
+++ b/ainode/web/static/css/style.css
@@ -1042,6 +1042,12 @@ h4.chat-h { font-size: 14px; color: var(--nvidia-green); }
   background: rgba(118, 185, 0, 0.06);
   letter-spacing: 0.2px;
 }
+
+.launch-hint.warn {
+  border-left-color: #d9a441;
+  background: rgba(217, 164, 65, 0.08);
+  color: #e3c07a;
+}
 .launch-hint.warn {
   color: #ffb84d;
   border-left-color: #ffb84d;
@@ -1777,20 +1783,21 @@ h4.chat-h { font-size: 14px; color: var(--nvidia-green); }
 /* Node selector dots */
 .node-selector {
   display: flex;
-  gap: 10px;
+  flex-wrap: wrap;
+  gap: 8px;
   margin: 8px 0 8px 0;
 }
 
 .node-dot {
-  min-width: 40px;
-  height: 40px;
-  border-radius: 18px;
-  padding: 0 12px;
+  flex: 0 0 auto;
+  height: 34px;
+  border-radius: 17px;
+  padding: 0 14px;
   white-space: nowrap;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 14px;
+  font-size: 12.5px;
   font-weight: 700;
   font-family: var(--font-mono);
   cursor: pointer;
@@ -2235,6 +2242,115 @@ select {
   color: var(--text-muted);
   font-family: var(--font-mono);
   letter-spacing: 0.5px;
+}
+
+/* Two-list layout: Installed (what you have) + Catalog (what you can grab). */
+.downloads-section {
+  margin-top: 4px;
+}
+
+.downloads-section-title {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 18px 32px 10px;
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-primary);
+}
+
+.downloads-section-count {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 700;
+  color: #0a0a0a;
+  background: var(--nvidia-green);
+  border-radius: 10px;
+  padding: 1px 9px;
+}
+
+.downloads-section-sub {
+  font-size: 11px;
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--text-muted);
+}
+
+/* Dimmed: shown only via "Show all", can't run on this cluster. */
+.download-card.dimmed {
+  opacity: 0.4;
+}
+
+.hf-toggle-row {
+  display: flex;
+  justify-content: center;
+  padding: 4px 32px 28px;
+}
+
+/* Browse HF / Back / Show-all — neutral outline matching the Details button. */
+#browse-hf-btn,
+#hf-show-all,
+.hf-back-btn {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-hover);
+  font-weight: 600;
+  padding: 8px 16px;
+  border-radius: var(--radius);
+  letter-spacing: 0.3px;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+#browse-hf-btn:hover,
+#hf-show-all:hover,
+.hf-back-btn:hover {
+  background: var(--bg-card-hover);
+  color: var(--nvidia-green);
+  border-color: var(--nvidia-green-dim);
+}
+
+.hf-back-btn {
+  align-self: flex-start;
+}
+
+/* Delete — danger outline, consistent with the red DELETE in the instances panel. */
+.downloads-delete-btn {
+  background: transparent !important;
+  color: var(--red) !important;
+  border: 1px solid rgba(255, 51, 51, 0.4) !important;
+  font-weight: 600 !important;
+}
+
+.downloads-delete-btn:hover {
+  background: var(--red-glow) !important;
+  border-color: var(--red) !important;
+  box-shadow: 0 0 12px var(--red-glow) !important;
+}
+
+/* Browse HF lives alone on its row, pushed right under the page title. */
+.downloads-actions-row {
+  justify-content: flex-end;
+  padding-top: 16px;
+  padding-bottom: 0;
+}
+
+/* Curated-but-not-yet-load-tested — amber, distinct from the green verified ✓. */
+.fit-badge.untested {
+  color: #d9a441;
+  border-color: rgba(217, 164, 65, 0.45);
+  background: rgba(217, 164, 65, 0.08);
+}
+
+/* Multi-node placement (TP=2/4) — purple, matching the Shard button. */
+.fit-badge.cluster {
+  color: #b794f6;
+  border-color: rgba(139, 92, 246, 0.45);
+  background: rgba(139, 92, 246, 0.08);
 }
 
 .downloads-toolbar {

--- a/ainode/web/static/js/app.js
+++ b/ainode/web/static/js/app.js
@@ -677,7 +677,10 @@ const AINode = {
         tp_size: di.tensor_parallel_size,
         nodes: di.member_names || [di.head_node_name || di.head_node_id].concat(di.peer_node_ids || di.peer_ips || []),
         status: live ? 'READY' : 'STARTING',
-        badge: 'DISTRIBUTED · TP=' + di.tensor_parallel_size,
+        // A single-node serve is SOLO even when the head advertises a
+        // distributed_instance (it's configured with peers) — only badge
+        // DISTRIBUTED when there's real cross-node tensor parallelism.
+        badge: (di.tensor_parallel_size > 1) ? ('DISTRIBUTED · TP=' + di.tensor_parallel_size) : 'SOLO · TP=1',
       });
     }
 

--- a/ainode/web/static/js/app.js
+++ b/ainode/web/static/js/app.js
@@ -27,7 +27,7 @@ const AINode = {
     abortController: null,
     shardingStatus: null,
     currentView: 'dashboard',
-    modelsFilter: 'all',
+    modelsFilter: 'catalog',
     modelsSearch: '',
     modelsSort: 'recommended',
     configSection: 'credentials',
@@ -757,7 +757,7 @@ const AINode = {
                 '<span style="display:inline-block;width:90px;height:5px;background:#1f2a1f;border-radius:3px;margin:0 8px;vertical-align:middle;overflow:hidden">' +
                 '<span style="display:block;height:100%;width:' + pi[1] + '%;background:#76c043;transition:width .4s"></span></span>';
             })()) +
-        '<button class="instance-delete" data-model="' + self.esc(inst.model) + '">DELETE</button>' +
+        '<button class="instance-delete" data-model="' + self.esc(inst.model) + '">UNLOAD</button>' +
         '</div>' +
         '</div>';
     }).join('');
@@ -859,18 +859,53 @@ const AINode = {
       updateLaunchHint();
     };
 
+    // Activate a specific set of node ids (head always stays on).
+    this._selectNodeIds = function (ids) {
+      var sel = document.getElementById('node-selector'); if (!sel) return;
+      var want = {}; (ids || []).forEach(function (id) { want[id] = true; });
+      sel.querySelectorAll('.node-dot').forEach(function (d) {
+        if (d.dataset.head) { d.classList.add('active'); return; }
+        d.classList.toggle('active', !!want[d.dataset.nodeId]);
+      });
+    };
+
+    // Fit-aware hint, recomputed on every refresh + node/strategy change so it
+    // survives polling. Reads the selected model's size and each node's free mem.
     function updateLaunchHint() {
       if (!launchHint) return;
       var active = nodeSelector ? nodeSelector.querySelectorAll('.node-dot.active') : [];
       var n = active.length || 1;
+      var names = Array.prototype.map.call(active, function (d) { return d.textContent.replace('★', '').trim(); }).join(' + ');
       var strategyPill = document.querySelector('#sharding-pills .pill.active');
       var strat = strategyPill ? strategyPill.dataset.value : 'tensor';
+      var stratLabel = strat.charAt(0).toUpperCase() + strat.slice(1);
       launchHint.className = 'launch-hint';
-      if (n <= 1) {
-        launchHint.textContent = 'Solo — runs on this node only (TP=1).';
+
+      var msel = document.getElementById('launch-model');
+      var opt = msel && msel.selectedIndex >= 0 ? msel.options[msel.selectedIndex] : null;
+      var size = opt ? parseFloat(opt.getAttribute('data-size-gb') || '0') : 0;
+      var minMem = opt ? parseFloat(opt.getAttribute('data-min-mem') || '0') : 0;
+      var req = (minMem && minMem > size) ? minMem : size * 1.2;
+      if (!opt || !opt.value || !req) {  // no model picked yet → plain text
+        launchHint.textContent = n <= 1 ? 'Solo — runs on this node only (TP=1).'
+          : stratLabel + ' · TP=' + n + ' across ' + names + '.';
+        return;
+      }
+
+      var byId = {};
+      (self.state.nodes || []).forEach(function (nd) { byId[nd.node_id] = nd; });
+      var freeOf = function (nd) { return nd ? Math.max(0, (nd.gpu_memory_gb || 0) * (1 - (nd.gpu_memory_used_pct || 0) / 100)) : 0; };
+      var perShard = req / n;
+      var frees = Array.prototype.map.call(active, function (d) { return freeOf(byId[d.dataset.nodeId]); });
+      var minFree = frees.length ? Math.min.apply(null, frees) : 0;
+      if (minFree < perShard) {
+        launchHint.className = 'launch-hint warn';
+        launchHint.textContent = '⚠ Needs ~' + Math.round(perShard) + ' GB/node but a selected node has only ~' +
+          Math.round(minFree) + ' GB free — unload a model to free space.';
+      } else if (n <= 1) {
+        launchHint.textContent = '✓ Runs solo on ' + (names || 'this node') + ' (TP=1) — ~' + Math.round(req) + ' GB.';
       } else {
-        var names = Array.prototype.map.call(active, function (d) { return d.textContent.replace(' ★', '').trim(); }).join(' + ');
-        launchHint.textContent = strat.toUpperCase() + ' · TP=' + n + ' across ' + names + '.';
+        launchHint.textContent = '✓ ' + stratLabel + ' · TP=' + n + ' across ' + names + ' (~' + Math.round(perShard) + ' GB/node).';
       }
     }
     // (dot click handlers bound inside _renderNodeDots)
@@ -887,6 +922,45 @@ const AINode = {
     if (launchBtn) {
       launchBtn.addEventListener('click', function () { self.launchInstance(); });
     }
+  },
+
+  // Auto-pick sharding + nodes for the selected model, aware of free memory on
+  // each node (a node already serving a model has ~85% reserved by vLLM, so it
+  // reads as nearly full). m: {proven_tp, size_gb, min_mem}.
+  recommendLaunch(m) {
+    var nodes = (this.state.nodes || []).filter(function (n) { return n.status !== 'offline'; });
+    var size = m.size_gb || 0;
+    if (!nodes.length || (!size && !m.min_mem)) return;
+    var freeOf = function (n) { return Math.max(0, (n.gpu_memory_gb || 0) * (1 - (n.gpu_memory_used_pct || 0) / 100)); };
+    var headId = this.state.status && this.state.status.node_id;
+    var head = nodes.find(function (n) { return n.node_id === headId; }) || nodes[0];
+    var peers = nodes.filter(function (n) { return n !== head; }).sort(function (a, b) {
+      var am = a.model ? 1 : 0, bm = b.model ? 1 : 0;
+      if (am !== bm) return am - bm;          // prefer idle nodes over busy ones
+      return freeOf(b) - freeOf(a);           // then the most free
+    });
+    var N = nodes.length;
+    var req = (m.min_mem && m.min_mem > size) ? m.min_mem : size * 1.2;
+
+    // Tensor is the proven strategy on this hardware.
+    var pills = document.getElementById('sharding-pills');
+    if (pills) pills.querySelectorAll('.pill').forEach(function (p) { p.classList.toggle('active', p.dataset.value === 'tensor'); });
+
+    // Smallest TP (>= proven_tp) where head + (tp-1) peers each hold req/tp.
+    var rec = null;
+    [1, 2, 4, 8].forEach(function (tp) {
+      if (rec || tp > N) return;
+      if (m.proven_tp && tp < m.proven_tp) return;
+      var perShard = req / tp;
+      if (freeOf(head) < perShard) return;
+      var okPeers = peers.filter(function (n) { return freeOf(n) >= perShard; });
+      if (okPeers.length >= tp - 1) rec = { tp: tp, peers: okPeers.slice(0, tp - 1) };
+    });
+
+    // Set node selection; the fit-aware updater renders the hint (and survives polling).
+    var ids = rec ? [head.node_id].concat(rec.peers.map(function (n) { return n.node_id; })) : [head.node_id];
+    if (this._selectNodeIds) this._selectNodeIds(ids);
+    if (this._launchHintUpdater) this._launchHintUpdater();
   },
 
   populateLaunchModels() {
@@ -945,15 +1019,21 @@ const AINode = {
           var glyph = isLoaded ? '● ' : (onDiskNow ? '○ ' : '');
           var verifiedMark = m.verified ? ' ✓' : '';
           var pt = m.proven_tp || 0;
-          return '<option value="' + self.esc(repo) + '" data-proven-tp="' + pt + '">'
+          return '<option value="' + self.esc(repo) + '" data-proven-tp="' + pt + '"'
+            + ' data-size-gb="' + (m.size_gb || 0) + '" data-min-mem="' + (m.min_memory_gb || 0) + '">'
             + glyph + self.esc(label) + sizeNote + verifiedMark + '</option>';
         }).join('');
       if (cv) select.value = cv;
-      // Picking a model with a proven TP pre-selects that many nodes in the picker.
+      // Picking a model auto-recommends sharding + nodes from its size and the
+      // free memory on each node.
       select.onchange = function () {
         var opt = select.options[select.selectedIndex];
-        var tp = opt ? parseInt(opt.getAttribute('data-proven-tp') || '0', 10) : 0;
-        if (tp > 0 && self._selectNodes) self._selectNodes(tp);
+        if (!opt || !opt.value) return;
+        self.recommendLaunch({
+          proven_tp: parseInt(opt.getAttribute('data-proven-tp') || '0', 10),
+          size_gb: parseFloat(opt.getAttribute('data-size-gb') || '0'),
+          min_mem: parseFloat(opt.getAttribute('data-min-mem') || '0'),
+        });
       };
     });
   },
@@ -2288,25 +2368,25 @@ const AINode = {
         '<div id="downloads-queue" class="downloads-queue"></div>' +
         '<div class="downloads-toolbar">' +
         '<input type="text" id="hf-search-input" class="search-input" placeholder="Search HuggingFace (e.g. llama, qwen, mistral, phi)..." value="' + this.esc(query) + '" autofocus>' +
-        '<div class="pill-group downloads-filters" id="downloads-filters">' + filterPills + '</div>' +
+        '<button id="hf-back-btn" class="btn-sm hf-back-btn">← Back to Catalog</button>' +
         '</div>' +
         '<div id="downloads-results"></div>';
       container.innerHTML = toolbarHtml;
-    } else {
-      var pillsEl = container.querySelector('#downloads-filters');
-      if (pillsEl) pillsEl.innerHTML = filterPills;
     }
 
     var resultsContainer = container.querySelector('#downloads-results');
     var countEl = container.querySelector('#hf-count');
 
-    // Rebind filter pills
-    container.querySelectorAll('.downloads-filter').forEach(function (btn) {
-      btn.addEventListener('click', function () {
-        self.state.modelsFilter = btn.dataset.filter;
+    // Back to the two-list catalog.
+    var backBtn = container.querySelector('#hf-back-btn');
+    if (backBtn && !backBtn.dataset.bound) {
+      backBtn.dataset.bound = '1';
+      backBtn.addEventListener('click', function () {
+        self.state.modelsSearch = '';
+        self.state.modelsFilter = 'catalog';
         self.renderDownloads();
       });
-    });
+    }
 
     // Bind search input (debounced)
     var input = container.querySelector('#hf-search-input');
@@ -2342,60 +2422,123 @@ const AINode = {
     fetch('/api/models/search?q=' + encodeURIComponent(query) + '&limit=50')
       .then(function (r) { return r.json(); })
       .then(function (data) {
-        var models = data.models || [];
-        if (countEl) countEl.textContent = models.length + ' results for "' + query + '"';
-        if (models.length === 0) {
-          if (resultsContainer) resultsContainer.innerHTML = '<div class="downloads-empty">No models found.</div>';
-          return;
-        }
-        var rows = models.map(function (m) {
-          var isLoaded = loaded.includes(m.hf_repo);
-          var isOnDisk = isLoaded || !!(self.state.downloadedModels && self.state.downloadedModels[m.hf_repo]);
-          var sizeStr = m.size_gb > 0 ? '~' + Math.round(m.size_gb) + ' GB' : 'size unknown';
-          var fits = gpuMem > 0 && m.size_gb > 0 && gpuMem >= m.size_gb;
-          var fitBadge = (gpuMem > 0 && m.size_gb > 0) ? (fits ?
-            '<span class="fit-badge fits">Fits GPU</span>' :
-            '<span class="fit-badge no-fit">Too large</span>') : '';
-          var catalogBadge = m.in_catalog ? '<span class="fit-badge rec">In Catalog</span>' : '';
-          var statusBadge = isLoaded ?
-            '<span class="model-badge loaded">Loaded</span>' :
-            isOnDisk ?
-            '<span class="model-badge loaded">Downloaded</span>' :
-            '<span class="model-badge available">Available</span>';
-          var downloadsStr = m.downloads ? self.formatNumber(m.downloads) + ' downloads' : '';
-          var likesStr = m.likes ? '❤ ' + self.formatNumber(m.likes) : '';
-          var statsLine = [downloadsStr, likesStr].filter(Boolean).join(' · ');
-          var detailsBtn = '<button class="btn-sm download-details-btn" data-info-repo="' + self.esc(m.hf_repo) + '">Details</button>';
-          var downloadBtn = isOnDisk ? '' :
-            '<button class="btn-sm downloads-download-btn" data-model-id="' + self.esc(m.hf_repo) + '">Download</button>';
-          return '<div class="download-card" data-model-id="' + self.esc(m.hf_repo) + '">' +
-            '<div class="download-card-main">' +
-            '<div class="download-card-info">' +
-            '<div class="download-card-header">' +
-            '<div class="download-card-name">' + self.esc(m.name) + '</div>' +
-            '<div class="download-card-badges">' + catalogBadge + fitBadge + statusBadge + '</div>' +
-            '</div>' +
-            '<div class="download-card-repo">' + self.esc(m.hf_repo) + '</div>' +
-            '<div class="download-card-desc">' + sizeStr + (statsLine ? ' &middot; ' + statsLine : '') + '</div>' +
-            '</div>' +
-            '<div class="download-card-actions">' + detailsBtn + downloadBtn + '</div>' +
-            '</div>' +
-            '</div>';
-        }).join('');
-        if (resultsContainer) {
-          resultsContainer.innerHTML = '<div class="downloads-grid">' + rows + '</div>';
-          self.bindRepoDownloadButtons(resultsContainer);
-        }
+        self._hfResults = data.models || [];
+        self._hfQuery = query;
+        self.state.hfShowAll = false;  // reset the reveal on each new search
+        self.renderHfResults();
       })
       .catch(function (err) {
-        if (resultsContainer) resultsContainer.innerHTML = '<div class="downloads-empty">Search failed: ' + err.message + '</div>';
+        var rc = document.getElementById('downloads-results');
+        if (rc) rc.innerHTML = '<div class="downloads-empty">Search failed: ' + err.message + '</div>';
       });
+  },
+
+  // Render cached HF results, hiding models that can't run here (incompatible
+  // engine or too large) unless "Show all" is toggled (then shown dimmed).
+  renderHfResults() {
+    var self = this;
+    var models = this._hfResults || [];
+    var query = this._hfQuery || '';
+    var loaded = (this.state.status && this.state.status.models_loaded) || [];
+    var resultsContainer = document.getElementById('downloads-results');
+    var countEl = document.getElementById('hf-count');
+    if (!resultsContainer) return;
+
+    var runnable = models.filter(function (m) { return self.hfRunnable(m); });
+    var hiddenCount = models.length - runnable.length;
+    var showAll = !!this.state.hfShowAll;
+    var shown = showAll ? models : runnable;
+
+    if (countEl) {
+      countEl.textContent = runnable.length + ' runnable for "' + query + '"' +
+        (hiddenCount ? ' · ' + hiddenCount + ' hidden' : '');
+    }
+
+    function card(m) {
+      var isLoaded = loaded.includes(m.hf_repo);
+      var isOnDisk = isLoaded || !!(self.state.downloadedModels && self.state.downloadedModels[m.hf_repo]);
+      var dimmed = !self.hfRunnable(m);
+      var sizeStr = m.size_gb > 0 ? '~' + Math.round(m.size_gb) + ' GB' : 'size unknown';
+      var fitBadge = self.placementBadge(m);
+      var catalogBadge = m.in_catalog ? '<span class="fit-badge rec">✓ Recommended</span>' : '';
+      var quantBadge = m.quant ? '<span class="fit-badge ' + (/MLX|GGUF/.test(m.quant) ? 'untested' : 'quant') + '">' + self.esc(m.quant) + '</span>' : '';
+      var statusBadge = isLoaded ? '<span class="model-badge loaded">Loaded</span>'
+        : isOnDisk ? '<span class="model-badge loaded">Downloaded</span>'
+        : '<span class="model-badge available">Available</span>';
+      var downloadsStr = m.downloads ? self.formatNumber(m.downloads) + ' downloads' : '';
+      var detailsBtn = '<button class="btn-sm download-details-btn" data-info-repo="' + self.esc(m.hf_repo) + '">Details</button>';
+      var downloadBtn = isOnDisk ? '' : '<button class="btn-sm downloads-download-btn" data-model-id="' + self.esc(m.hf_repo) + '">Download</button>';
+      return '<div class="download-card' + (dimmed ? ' dimmed' : '') + '" data-model-id="' + self.esc(m.hf_repo) + '">' +
+        '<div class="download-card-main">' +
+        '<div class="download-card-info">' +
+        '<div class="download-card-header">' +
+        '<div class="download-card-name">' + self.esc(m.name) + '</div>' +
+        '<div class="download-card-badges">' + catalogBadge + quantBadge + fitBadge + statusBadge + '</div>' +
+        '</div>' +
+        '<div class="download-card-repo">' + self.esc(m.hf_repo) + '</div>' +
+        '<div class="download-card-desc">' + sizeStr + (downloadsStr ? ' &middot; ' + downloadsStr : '') + '</div>' +
+        '</div>' +
+        '<div class="download-card-actions">' + detailsBtn + downloadBtn + '</div>' +
+        '</div>' +
+        '</div>';
+    }
+
+    var body = shown.length
+      ? '<div class="downloads-grid">' + shown.map(card).join('') + '</div>'
+      : '<div class="downloads-empty">No models here can run on this cluster.</div>';
+    var toggle = hiddenCount ? '<div class="hf-toggle-row"><button id="hf-show-all" class="btn-sm">' +
+      (showAll ? 'Hide incompatible / too-large' : 'Show ' + hiddenCount + ' hidden (incompatible or too large)') +
+      '</button></div>' : '';
+    resultsContainer.innerHTML = body + toggle;
+    self.bindRepoDownloadButtons(resultsContainer);
+    var tbtn = document.getElementById('hf-show-all');
+    if (tbtn) tbtn.addEventListener('click', function () {
+      self.state.hfShowAll = !self.state.hfShowAll;
+      self.renderHfResults();
+    });
   },
 
   formatNumber(n) {
     if (n >= 1e6) return (n / 1e6).toFixed(1) + 'M';
     if (n >= 1e3) return (n / 1e3).toFixed(1) + 'K';
     return String(n);
+  },
+
+  // Placement of a model on THIS cluster. Returns {known, tooLarge, tp, label, cls}.
+  // Accepts catalog-shaped (sizeGb/minMem/proven_tp) or HF-shaped (size_gb) models.
+  placementInfo(model) {
+    var nodes = this.state.nodes || [];
+    var nodeCount = nodes.length || 1;
+    var st = this.state.status;
+    var perNode = (st && st.gpu && st.gpu.memory_total_mb) ? st.gpu.memory_total_mb / 1024
+      : ((nodes[0] && nodes[0].gpu_memory_gb) || 0);
+    var size = model.sizeGb || model.size_gb || 0;
+    if (!size || !perNode) return { known: false };  // unknown size → make no claim
+    // ponytail: weights × 1.2 for KV/activation headroom; minMem wins if curated.
+    var req = (model.minMem && model.minMem > size) ? model.minMem : size * 1.2;
+    var needed = Math.ceil(req / perNode);
+    var neededTp = needed <= 1 ? 1 : needed <= 2 ? 2 : needed <= 4 ? 4 : 8;
+    // Honor the proven launch config when it's at least what memory requires.
+    var tp = (model.proven_tp && model.proven_tp >= neededTp) ? model.proven_tp : neededTp;
+    if (needed > nodeCount || tp > nodeCount) {
+      return { known: true, tooLarge: true, label: 'Too large for cluster', cls: 'no-fit' };
+    }
+    if (tp === 1) return { known: true, tooLarge: false, tp: 1, label: 'Runs on 1 node', cls: 'fits' };
+    return { known: true, tooLarge: false, tp: tp, label: 'Good for TP=' + tp + ' · ' + tp + ' nodes', cls: 'cluster' };
+  },
+
+  placementBadge(model) {
+    var p = this.placementInfo(model);
+    return p.known ? '<span class="fit-badge ' + p.cls + '">' + p.label + '</span>' : '';
+  },
+
+  // Can AINode's vLLM engine serve this repo? MLX is Apple-only, GGUF is llama.cpp.
+  hfRunnable(m) {
+    var repo = (m.hf_repo || '').toLowerCase();
+    var vllmOk = m.vllm_ok !== false && !/mlx|gguf|ggml/.test(repo);
+    var info = this.placementInfo(m);
+    // Unknown size (GGUF etc.) can't be placed — treat as not-runnable-here.
+    return vllmOk && info.known && !info.tooLarge;
   },
 
   renderDownloads() {
@@ -2449,6 +2592,10 @@ const AINode = {
             hf_repo: m.hf_repo || '',
             context_length: m.context_length || 0,
             license: m.license || '',
+            verified: m.verified === true,
+            curated: m.curated === true,
+            proven_tp: m.proven_tp || 1,
+            downloaded: m.downloaded === true,
           };
         });
         self.renderDownloads();
@@ -2459,109 +2606,55 @@ const AINode = {
 
     var catalog = this.state.catalog;
     var query = (this.state.modelsSearch || '').toLowerCase();
-    var totalCount = catalog.length;
+    var dlMap = this.state.downloadedModels || {};
 
-    // Build filter pills now so HF branch can use them
-    var allFilters = ['all', 'recommended', 'downloaded', 'trending', 'openrouter', 'latest', 'huggingface'];
-    var filterLabels = {
-      all: 'All',
-      recommended: 'Recommended',
-      downloaded: 'Downloaded',
-      trending: '🔥 Trending',
-      openrouter: '🚀 Most Used',
-      latest: '✨ Latest',
-      huggingface: '🤗 Search HF',
-    };
-    var filterPills = allFilters.map(function (f) {
-      var active = self.state.modelsFilter === f ? ' active' : '';
-      return '<button class="pill downloads-filter' + active + '" data-filter="' + f + '">' + filterLabels[f] + '</button>';
-    }).join('');
-
-    // Live-fetch filters — delegate to renderLiveCatalog
-    if (['trending', 'openrouter', 'latest'].indexOf(this.state.modelsFilter) !== -1) {
-      return this.renderLiveCatalog(container, loaded, gpuMem, filterPills, this.state.modelsFilter);
-    }
-
-    // HuggingFace live search mode
+    // Browse HuggingFace — the single escape hatch for grabbing anything not
+    // in our known-good catalog.
     if (this.state.modelsFilter === 'huggingface') {
-      return this.renderHuggingFaceSearch(container, loaded, gpuMem, clusterNodeCount, totalClusterMem, filterPills, totalCount);
+      return this.renderHuggingFaceSearch(container, loaded, gpuMem, clusterNodeCount, totalClusterMem, '', catalog.length);
     }
 
-    var models = catalog.filter(function (m) {
-      if (query && m.id.toLowerCase().indexOf(query) === -1 &&
-          m.desc.toLowerCase().indexOf(query) === -1 &&
-          (m.family || '').toLowerCase().indexOf(query) === -1) return false;
-      var isLoaded = loaded.includes(m.id);
-      var isOnDisk = isLoaded || !!(self.state.downloadedModels && self.state.downloadedModels[m.id]);
-      if (self.state.modelsFilter === 'downloaded' && !isOnDisk) return false;
-      if (self.state.modelsFilter === 'available' && isLoaded) return false;
-      if (self.state.modelsFilter === 'recommended' && !m.recommended) return false;
-      return true;
-    });
-
-    if (this.state.modelsSort === 'size-asc') models.sort(function (a, b) { return a.sizeGb - b.sizeGb; });
-    else if (this.state.modelsSort === 'size-desc') models.sort(function (a, b) { return b.sizeGb - a.sizeGb; });
-    else if (this.state.modelsSort === 'name') models.sort(function (a, b) { return a.id.localeCompare(b.id); });
-    else {
-      // Default: recommended first, then by size
-      models.sort(function (a, b) {
-        if (a.recommended !== b.recommended) return a.recommended ? -1 : 1;
-        return a.sizeGb - b.sizeGb;
-      });
+    function matchesQuery(m) {
+      if (!query) return true;
+      return (m.id || '').toLowerCase().indexOf(query) !== -1 ||
+             (m.name || '').toLowerCase().indexOf(query) !== -1 ||
+             (m.desc || '').toLowerCase().indexOf(query) !== -1 ||
+             (m.family || '').toLowerCase().indexOf(query) !== -1;
+    }
+    function isOnDisk(m) {
+      return m.downloaded === true || !!dlMap[m.hf_repo] || !!dlMap[m.id] ||
+             loaded.includes(m.slug) || loaded.includes(m.id);
     }
 
-    var filteredCount = models.length;
+    // Two lists, period: what you HAVE (on disk) and the curated CATALOG you can
+    // grab (our known-good picks, verified ones badged). Anything else: Browse HF.
+    var installed = catalog.filter(function (m) { return isOnDisk(m) && matchesQuery(m); });
+    var knownGood = catalog.filter(function (m) { return m.curated === true && !isOnDisk(m) && matchesQuery(m); });
+    var bySize = function (a, b) { return (a.sizeGb || 0) - (b.sizeGb || 0); };
+    installed.sort(bySize);
+    knownGood.sort(bySize);
 
-    // If we're coming from HF mode, clear the container
-    if (container.querySelector('#hf-search-input')) {
-      container.innerHTML = '';
-    }
-
-    // Render toolbar once; only results re-render on search
-    var needsToolbar = !container.querySelector('#downloads-search');
-    var html = '';
-    if (needsToolbar) {
-      html += '<div class="downloads-header">' +
-        '<h2 class="view-title">Model Catalog</h2>' +
-        '<div class="downloads-count" id="downloads-count">' + filteredCount + ' of ' + totalCount + ' models</div>' +
-        '</div>' +
-        '<div id="downloads-queue" class="downloads-queue"></div>' +
-        '<div class="downloads-toolbar">' +
-        '<input type="text" id="downloads-search" class="search-input" placeholder="Search models, families, or descriptions..." value="' + this.esc(this.state.modelsSearch) + '">' +
-        '<div class="pill-group downloads-filters" id="downloads-filters">' + filterPills + '</div>' +
-        '</div>' +
-        '<div id="downloads-results"></div>';
-    } else {
-      // Just update count + filter pills
-      var countEl = container.querySelector('#downloads-count');
-      if (countEl) countEl.textContent = filteredCount + ' of ' + totalCount + ' models';
-      var pillsEl = container.querySelector('#downloads-filters');
-      if (pillsEl) pillsEl.innerHTML = filterPills;
-    }
-
-    // Results list HTML (rebuilt on every render, but appended separately)
-    var resultsRows = models.map(function (model) {
-      var isLoaded = loaded.includes(model.id);
+    function cardHtml(model) {
+      var isLoaded = loaded.includes(model.slug) || loaded.includes(model.id);
+      var onDisk = isOnDisk(model);
       var fits = gpuMem >= (model.minMem || model.sizeGb);
-      var fitBadge = gpuMem > 0 ? (fits ?
-        '<span class="fit-badge fits">Fits GPU</span>' :
-        '<span class="fit-badge no-fit">Too large</span>') : '';
+      var fitBadge = self.placementBadge(model);
       var statusBadge = isLoaded ?
         '<span class="model-badge loaded">Loaded</span>' :
-        '<span class="model-badge available">Available</span>';
-      var recBadge = model.recommended ? '<span class="fit-badge rec">Recommended</span>' : '';
+        (onDisk ? '<span class="model-badge loaded">On disk</span>' :
+          '<span class="model-badge available">Available</span>');
+      var verBadge = model.verified ? '<span class="fit-badge rec">✓ Verified on GB10</span>'
+        : (model.curated ? '<span class="fit-badge untested">Curated · untested</span>' : '');
       var quantBadge = model.quantization ? '<span class="fit-badge quant">' + self.esc(model.quantization.toUpperCase()) + '</span>' : '';
       var paramsText = model.params ? model.params + ' params' : '';
-      var ageText = model.created_at ? self.relativeTime(model.created_at) : '';
-      var downloadsText = model.downloads ? self.formatNumber(model.downloads) + ' ⬇' : '';
-      var descParts = [paramsText, model.size, ageText, downloadsText].filter(Boolean);
+      var descParts = [paramsText, model.size].filter(Boolean);
       var capabilityBadges = self.renderCapabilityBadges(model);
-      var isDownloaded = model.downloaded === true;
-      var actionBtn = isDownloaded
+      var actionBtn = onDisk
         ? '<button class="btn-sm downloads-delete-btn" data-model-id="' + self.esc(model.hf_repo || model.id) + '">Delete</button>'
         : '<button class="btn-sm downloads-download-btn" data-model-id="' + self.esc(model.hf_repo || model.id) + '">Download</button>';
       var shardBtn = '';
-      if (!fits && clusterNodeCount > 1 && totalClusterMem >= model.sizeGb && !isDownloaded) {
+      var needsCluster = !fits || (model.proven_tp || 1) > 1;
+      if (needsCluster && clusterNodeCount > 1 && totalClusterMem >= model.sizeGb && !onDisk) {
         shardBtn = '<button class="btn-sm downloads-shard-btn" data-model-id="' + self.esc(model.id) + '">Shard Across Cluster</button>';
       }
       var detailsBtn = '<button class="btn-sm download-details-btn" data-info-repo="' + self.esc(model.hf_repo || model.id) + '">Details</button>';
@@ -2570,32 +2663,53 @@ const AINode = {
         '<div class="download-card-info">' +
         '<div class="download-card-header">' +
         '<div class="download-card-name">' + self.esc(model.name || model.id) + '</div>' +
-        '<div class="download-card-badges">' + recBadge + quantBadge + capabilityBadges + fitBadge + statusBadge + '</div>' +
+        '<div class="download-card-badges">' + verBadge + quantBadge + capabilityBadges + fitBadge + statusBadge + '</div>' +
         '</div>' +
-        '<div class="download-card-repo">' + self.esc(model.id) + '</div>' +
+        '<div class="download-card-repo">' + self.esc(model.hf_repo || model.id) + '</div>' +
         '<div class="download-card-desc">' + descParts.join(' &middot; ') + (model.desc ? '<br><span class="download-card-tagline">' + self.esc(model.desc) + '</span>' : '') + '</div>' +
         '</div>' +
         '<div class="download-card-actions">' + detailsBtn + actionBtn + shardBtn + '</div>' +
         '</div>' +
         '</div>';
-    }).join('');
-
-    var resultsHtml = '<div class="downloads-grid">' + resultsRows + '</div>';
-    if (models.length === 0) {
-      resultsHtml = '<div class="downloads-empty">No models match your filters.</div>';
     }
 
-    // First render: inject full toolbar + results
+    function sectionHtml(title, sub, items, emptyMsg) {
+      var body = items.length
+        ? '<div class="downloads-grid">' + items.map(cardHtml).join('') + '</div>'
+        : '<div class="downloads-empty">' + emptyMsg + '</div>';
+      return '<section class="downloads-section">' +
+        '<div class="downloads-section-title">' + title +
+        ' <span class="downloads-section-count">' + items.length + '</span>' +
+        ' <span class="downloads-section-sub">' + sub + '</span></div>' +
+        body + '</section>';
+    }
+
+    // Toolbar once; only #downloads-results re-renders on search (keeps focus).
+    var needsToolbar = !container.querySelector('#downloads-search');
     if (needsToolbar) {
-      container.innerHTML = html;
+      container.innerHTML =
+        '<div class="downloads-header downloads-actions-row">' +
+        '<button id="browse-hf-btn" class="btn-sm">🤗 Browse Hugging Face</button>' +
+        '</div>' +
+        '<div id="downloads-queue" class="downloads-queue"></div>' +
+        '<div class="downloads-toolbar">' +
+        '<input type="text" id="downloads-search" class="search-input" placeholder="Filter your models and catalog..." value="' + this.esc(this.state.modelsSearch) + '">' +
+        '</div>' +
+        '<div id="downloads-results"></div>';
     }
-    // Update only the results area so search input keeps focus
+
+    var catalogEmpty = query ? 'No catalog models match.'
+      : 'You already have every curated model. Use 🤗 Browse Hugging Face to grab anything else.';
+
     var resultsContainer = container.querySelector('#downloads-results');
     if (resultsContainer) {
-      resultsContainer.innerHTML = resultsHtml;
+      resultsContainer.innerHTML =
+        sectionHtml('Installed', 'on your nodes — what you have', installed,
+          query ? 'No installed models match.' : 'Nothing downloaded yet. Grab one from the catalog below.') +
+        sectionHtml('Catalog', 'curated known-good picks — ready to download', knownGood, catalogEmpty);
     }
 
-    // Bind search (only once, on first render)
+    // Bind search once.
     var searchInput = document.getElementById('downloads-search');
     if (searchInput && !searchInput.dataset.bound) {
       searchInput.dataset.bound = '1';
@@ -2605,18 +2719,18 @@ const AINode = {
       });
     }
 
-    // Bind filter pills (rebind each time since innerHTML was replaced)
-    container.querySelectorAll('.downloads-filter').forEach(function (btn) {
-      btn.addEventListener('click', function () {
-        self.state.modelsFilter = btn.dataset.filter;
+    // Bind Browse HuggingFace.
+    var hfBtn = document.getElementById('browse-hf-btn');
+    if (hfBtn && !hfBtn.dataset.bound) {
+      hfBtn.dataset.bound = '1';
+      hfBtn.addEventListener('click', function () {
+        self.state.modelsFilter = 'huggingface';
         self.renderDownloads();
       });
-    });
+    }
 
-    // Bind download buttons — unified to repo-based download with progress view
+    // Bind download/delete/details + queue.
     self.bindRepoDownloadButtons(container);
-
-    // Render active downloads queue
     self.renderDownloadsQueue();
 
     // Bind shard buttons

--- a/ainode/web/static/js/topology.js
+++ b/ainode/web/static/js/topology.js
@@ -752,7 +752,7 @@
   function Topology(canvas) {
     const renderer = new TopologyRenderer(canvas);
     return {
-      update(nodes) { renderer.update(nodes); },
+      update(nodes, engineReady) { renderer.update(nodes, engineReady); },
       destroy() {},
       get onNodeSelect() { return renderer.onNodeSelect; },
       set onNodeSelect(fn) { renderer.onNodeSelect = fn; },

--- a/ainode/web/templates/index.html
+++ b/ainode/web/templates/index.html
@@ -30,7 +30,7 @@
         <button class="nav-pill active" data-view="dashboard">Cluster</button>
         <button class="nav-pill" data-view="chat">Chat</button>
         <button class="nav-pill" data-view="server">Server</button>
-        <button class="nav-pill" data-view="downloads">Downloads</button>
+        <button class="nav-pill" data-view="downloads">Models</button>
         <button class="nav-pill" data-view="training">Training</button>
         <button class="nav-pill" data-view="config">Config</button>
       </nav>
@@ -89,8 +89,8 @@
       <!-- Downloads view -->
       <div id="view-downloads" class="view" style="display:none">
         <div class="view-header">
-          <h2>Downloads</h2>
-          <p>Manage model downloads across the cluster</p>
+          <h2>Models</h2>
+          <p>Installed models on your cluster, plus Hugging Face downloads</p>
         </div>
         <div id="downloads-content"></div>
       </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainode"
-version = "0.4.37"
+version = "0.4.43"
 description = "Turn any NVIDIA GPU into a local AI platform. Inference + fine-tuning in your browser."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_engine_serving.py
+++ b/tests/test_engine_serving.py
@@ -1,0 +1,58 @@
+"""Tests for _engine_serving — the liveness probe behind BUG A FIX 2.
+
+The latched `ready` flag never flips False on crash, so a dead engine reads
+READY forever (phantom). _engine_serving probes the engine's own API instead:
+truthful when serving, loading (api not up yet), crashed, or erroring.
+"""
+
+import asyncio
+
+from ainode.api.server import _engine_serving
+
+
+class _Backend:
+    def __init__(self, health):
+        self._health = health
+
+    def health_check(self):
+        if isinstance(self._health, Exception):
+            raise self._health
+        return self._health
+
+
+def _run(backend):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(_engine_serving(backend, loop))
+    finally:
+        loop.close()
+
+
+def test_serving_when_api_responds():
+    assert _run(_Backend({"api_responding": True})) is True
+
+
+def test_not_serving_while_loading():
+    # process up, api not yet answering — must NOT be advertised
+    assert _run(_Backend({"api_responding": False, "process_alive": True})) is False
+
+
+def test_not_serving_when_crashed():
+    assert _run(_Backend({"api_responding": False, "process_alive": False})) is False
+
+
+def test_not_serving_on_probe_error():
+    assert _run(_Backend(RuntimeError("connection refused"))) is False
+
+
+def test_no_backend():
+    assert _run(None) is False
+
+
+if __name__ == "__main__":
+    test_serving_when_api_responds()
+    test_not_serving_while_loading()
+    test_not_serving_when_crashed()
+    test_not_serving_on_probe_error()
+    test_no_backend()
+    print("ok")

--- a/tests/test_start_clean.py
+++ b/tests/test_start_clean.py
@@ -1,0 +1,48 @@
+"""Tests for consume_start_clean — the closet #310 one-shot 'start clean' knob.
+
+Skips replaying persisted models on a boot so an operator can `restart` to free
+a node. Triggered by env AINODE_START_CLEAN or a consumed sentinel file.
+"""
+
+import os
+from pathlib import Path
+
+from ainode.core.config import AINODE_HOME
+from ainode.models.api_routes import consume_start_clean
+
+SENTINEL = Path(AINODE_HOME) / ".start-clean"
+
+
+def _reset():
+    os.environ.pop("AINODE_START_CLEAN", None)
+    if SENTINEL.exists():
+        SENTINEL.unlink()
+
+
+def test_neither_is_false():
+    _reset()
+    assert consume_start_clean() is False
+
+
+def test_env_triggers():
+    _reset()
+    os.environ["AINODE_START_CLEAN"] = "1"
+    try:
+        assert consume_start_clean() is True
+    finally:
+        os.environ.pop("AINODE_START_CLEAN", None)
+
+
+def test_sentinel_triggers_and_is_consumed():
+    _reset()
+    SENTINEL.parent.mkdir(parents=True, exist_ok=True)
+    SENTINEL.write_text("")
+    assert consume_start_clean() is True
+    assert not SENTINEL.exists()  # single-use
+
+
+if __name__ == "__main__":
+    test_neither_is_false()
+    test_env_triggers()
+    test_sentinel_triggers_and_is_consumed()
+    print("ok")

--- a/tests/test_vllm_args.py
+++ b/tests/test_vllm_args.py
@@ -1,0 +1,35 @@
+"""Tests for NvidiaBackend._build_vllm_serve_args — the GB10 vLLM flag defaults.
+
+Closet #301: assert the proven distributed-MoE flags land in the serve args —
+fp8 KV cache (long-context survival) + tensor-parallel sizing — and that the
+fp8 default has an escape hatch.
+"""
+
+from ainode.core.config import NodeConfig
+from ainode.engine.backends.nvidia import NvidiaBackend
+
+
+def _args(tp, **cfg):
+    c = NodeConfig(node_id="t", node_name="T", **cfg)
+    return NvidiaBackend(c)._build_vllm_serve_args(tp_size=tp)
+
+
+def test_fp8_kv_and_tp_land():
+    a = _args(4)
+    assert "--kv-cache-dtype" in a and a[a.index("--kv-cache-dtype") + 1] == "fp8"
+    assert "--tensor-parallel-size" in a and a[a.index("--tensor-parallel-size") + 1] == "4"
+
+
+def test_enforce_eager_always_on():
+    assert "--enforce-eager" in _args(1)
+
+
+def test_kv_dtype_escape_hatch():
+    assert "--kv-cache-dtype" not in _args(1, kv_cache_dtype="")
+
+
+if __name__ == "__main__":
+    test_fp8_kv_and_tp_land()
+    test_enforce_eager_always_on()
+    test_kv_dtype_escape_hatch()
+    print("ok")


### PR DESCRIPTION
## Models redesign + HF browse + Unload fan-out + BUG A (cache + crash liveness) + fp8 KV + start-clean

Promotes the Spark-1 hot-patch to a real baked image and fixes the federation state/serving bugs. All verified live on the 4-node GB10 fleet (`ainode:0.4.42-catalog`).

### Commits
- `96b1add` — Models page redesign + engine-aware HF browse + Unload fan-out fix
- `fbeac1f` — BUG A: re-broadcast live model each sync cycle (`/api/nodes` ↔ `/v1/models` divergence)
- `bbb9ca9` — BUG A FIX 2: probe engine liveness, not the latched `ready` flag (crash-case phantom + ghost routing)
- `37f46dd` — fp8 KV-cache default for GB10 vLLM serve
- `7cd529d` — start-clean knob to skip model replay on boot

All five verified live; details below.

### Models page + Unload (`96b1add`)
Two-list Models page (Installed + curated Catalog), engine-aware Browse-HF (real safetensors-dtype sizes, hides MLX/GGUF/too-large), placement badges, space-aware Launch auto-recommend, Delete→Unload. `registry.py` HF-search fix (`pipeline_tag`; drop removed `direction`/`task` kwargs). Unload fan-out: truthful local stop + dispatch to the owning node over the fabric, `fanout=0` recursion guard. Tests: remote `peers_reached:3`, local `remaining:0`, negative `stopped:false`, no recursion storm.

### BUG A — stale discovery cache (`fbeac1f`)
`NodeAnnouncement.model` was set once at startup and never re-broadcast → `/api/nodes` stale while `/v1/models` fresh; unloads never propagated. `_cluster_sync_loop` now re-broadcasts `config.model` each cycle. Live: load reflects within one cycle; unload clears in ~8s.

### BUG A FIX 2 — crash-case liveness (`bbb9ca9`)
Latched `ready` never flips False on crash → dead engine read READY forever (phantom + 502 ghost routing). Sync loop now gates model/status/instances on an active localhost API probe (`_engine_serving`, in the executor). Live: `docker kill`'d a peer engine → dropped from `/api/nodes` + `/v1/models` in 2 cycles; dead-model chat → `model_not_found` in 0.005s. Closes BUG C. Unit test `tests/test_engine_serving.py`.

### fp8 KV-cache (`37f46dd`)
Config-driven `kv_cache_dtype` (default `fp8`, `""` disables) emitted in `_build_vllm_serve_args` — `engine/AGENTS.md` requires it for long context. Live: 9B serves with it, `max_model_len` 262144. Unit test `tests/test_vllm_args.py`.

### start-clean (`7cd529d`)
A node persists + replays `config.model` and the stacked manifest on restart, so restart-to-free just reloads. `consume_start_clean()` (env `AINODE_START_CLEAN` or one-shot `touch <AINODE_HOME>/.start-clean`) nulls the model, skips replay, and sweeps the engine container to actually free memory; non-destructive. Live: sentinel boot → container freed + node idle + sentinel consumed; normal restart → 9B replays. Unit test `tests/test_start_clean.py`.


### Dashboard truth (`6613d2b`, closet #302) — verified live via headless screenshots
The cluster dashboard UI was already polished but showed wrong data:
- **VRAM 0% on /api/status**: detect_gpu() reports free==total on GB10 unified memory. Overlay the collector's live psutil reading (same source /api/nodes uses) → master reads real 38% used, both endpoints agree.
- **Master card stuck "starting…" while serving**: two root causes — (a) wait_ready() latches _ready via the API-poll path before _stream_logs sees the startup marker, leaving load_phase="starting" → /api/status now derives load_phase from the live readiness probe; (b) topology.js's Topology facade dropped the engineReady arg (`update(nodes)` not `update(nodes, engineReady)`) so the loading overlay never cleared → forward the arg. Master now shows a solid READY ring.
- **Solo model labeled "DISTRIBUTED · TP=1"**: gate the badge on tensor_parallel_size > 1 → "SOLO · TP=1".
- **Footer version 0.4.37 → 0.4.43** (the shipping build).

Files: server.py, nvidia.py (+ load_phase property), app.js, topology.js, __init__.py, pyproject.toml.

### Deploy state (updated)
Baked into **`ainode:0.4.43-catalog`**, rolled to all 4 nodes. Fleet healthy, chat verified, dashboard data truthful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
