### PR TITLE
docs: refresh README + CHANGELOG to 0.4.44 (+ fix stale image tag & docs link)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,98 @@ _Next release — changes accumulate here until tagged._
 
 ---
 
+## [0.4.44] — 2026-06-27
+
+### Added
+- **In-browser quantization (Quantize feature).** New **Training → Quantize a
+  Model** panel and `POST /api/training/jobs` with `method:"quantize"`. Runs
+  llm-compressor one-shot PTQ inside a GPU container, producing a
+  compressed-tensors checkpoint vLLM serves natively. Schemes: **AWQ** (W4A16,
+  serves as `awq_marlin` on GB10) and **NVFP4** (Blackwell-native). Output lands
+  in the model store at `~/.ainode/models/<org--name>-<scheme>`, discoverable in
+  Installed.
+- **Push quantized models to Hugging Face.** Optional `push_to_hf` uploads a
+  private repo under the write-token owner's namespace after the job exits.
+- **Hugging Face _write_ token + Secrets slot.** `huggingface_write_token`
+  preferred over the read token for pushes; read-only tokens are rejected up
+  front (no wasted multi-GB transfer). Secrets store also holds NGC / W&B /
+  OpenAI keys, masked with a per-key Test.
+- **Idle-node guardrail.** A quant job is refused with `409` if the node is
+  serving a model (quantization needs the full unified memory); override with
+  `force=true`.
+
+### Fixed
+- **Qwen3.5 family quantizes to a servable checkpoint.** These are
+  `*ForConditionalGeneration` (bundled vision tower + text sub-config) and hybrid
+  (Gated-DeltaNet linear attention). The runner now loads the full model class so
+  `save_pretrained` emits the complete config, ignores the vision tower /
+  embeddings / `lm_head` and the tiny `linear_attn` projections (Marlin can't
+  tile them), and saves the image processor. AWQ verified servable;
+  NVFP4-on-Qwen3.5 remains experimental.
+- Quant job bodies parse without a dataset; output always written to the
+  RW-mounted model store (never the throwaway `--rm` layer); tokenizer passed as
+  processor to avoid the `mistral_common` import conflict.
+- `service/systemd.py` image tag now follows `__version__` (was pinned to an old
+  tag, so a fresh install could render a unit pulling the wrong image).
+
+---
+
+## [0.4.38] – [0.4.42] — 2026-06-25..26
+
+### Added
+- **Models page redesign** — two lists (Installed vs Browse), smarter live HF
+  browse, and the instance control relabeled **DELETE → UNLOAD** (a real unload,
+  including force-clear of dead/phantom instances).
+- **fp8 KV-cache default on GB10 vLLM serve** — long-context headroom by default.
+- **`start-clean` knob** — skip model replay on boot.
+
+### Fixed
+- **BUG A (discovery cache).** The cluster re-broadcasts the live model each sync
+  cycle, and discovery probes engine _liveness_ (`/v1/models`) instead of a
+  latched "ready" flag, so a node that died no longer advertises a stale model.
+- Dashboard displays the truthful state (no phantom READY).
+
+---
+
+## [0.4.32] – [0.4.37] — 2026-06-23..24
+
+### Added
+- **Model stacking — N models per node.** Solo loads append into an
+  `InstanceManager` instead of fighting over the primary slot; the boot engine
+  seeds the manager so it doesn't collide on `:8000`.
+- **AWQ catalog + always-on instance persistence** — running instances persist
+  and replay on restart (orphan sweep first; loads serialized to avoid
+  concurrent-load OOM).
+- **Serve models from on-disk weights** (`~/.ainode/models/<slug>`) + per-node
+  download cap. Community MoE picks added (Nemotron Cascade 2, MiniMax-M2.7);
+  4B-AWQ verified (~15 t/s — dense AWQ is dequant-bound on GB10).
+
+---
+
+## [0.4.24] – [0.4.31] — 2026-06-21
+
+### Added
+- **Federated master router (F1).** The master routes `/v1/*` requests to the
+  node serving the requested model.
+- **Load / unload any model on any node from the master (F2).**
+- **Federation usable from the browser** — per-node memory-utilization knob,
+  fleet UI, routing failover, and GB10 unified-memory telemetry.
+
+### Fixed
+- Federation proxy: strip forwarded charset/Content-Length, drop the stale 503
+  guard; `--include-dashboard` is head-only (restores worker join); `start_solo`
+  pre-cleans its container name for idempotent launch.
+
+---
+
+## [0.4.23] — 2026-06-21
+
+### Added
+- Auto-distribute weights at launch (rsync-preferred) groundwork toward
+  federation.
+
+---
+
 ## [0.4.22] — 2026-06-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ platform, open source ChatGPT alternative.
 <p align="center">
   <a href="https://ainode.dev">ainode.dev</a>
   &nbsp;·&nbsp;
-  <a href="https://docs.argentos.ai">docs</a>
+  <a href="https://docs.ainode.dev">docs</a>
   &nbsp;·&nbsp;
   <a href="#getting-started--step-by-step">Getting Started</a>
   &nbsp;·&nbsp;
@@ -140,7 +140,7 @@ current member list with per-node role, address, and last-seen.
    ```
    That one-liner performs:
    ```
-   docker pull ghcr.io/getainode/ainode:0.4.0
+   docker pull ghcr.io/getainode/ainode:latest
    systemctl enable --now ainode.service
    ```
 3. **Open the UI** at `http://<your-ip>:3000`. First-run onboarding walks
@@ -154,8 +154,9 @@ images — GHCR is canonical (what the installer uses), Docker Hub is a
 public mirror:
 
 ```bash
-docker pull ghcr.io/getainode/ainode:0.4.0      # canonical
-docker pull argentaios/ainode:0.4.0              # Docker Hub mirror
+docker pull ghcr.io/getainode/ainode:latest      # canonical (always newest)
+docker pull argentaios/ainode:latest             # Docker Hub mirror
+# pin a release instead: …/ainode:0.4.44
 ```
 
 ### Two nodes (distributed mode)
@@ -198,6 +199,36 @@ panel, pick the model, set **Minimum Nodes=2**, click **Tensor** →
 
 ---
 
+## Quantize a model (AWQ / NVFP4)
+
+AINode can compress a full-precision model to 4-bit **in the browser**, on your
+own GPU — no external service. Open **Training → Quantize a Model**:
+
+1. **Base model** — a Hugging Face repo id (`Qwen/Qwen3.5-4B`) or an installed model.
+2. **Scheme** — **AWQ** (W4A16, proven on GB10 via `awq_marlin`) or **NVFP4**
+   (Blackwell-native 4-bit float).
+3. **Calibration samples** — default 256 (from `HuggingFaceH4/ultrachat_200k`).
+4. *(optional)* **Push result to Hugging Face** — requires a **write** token;
+   pushes a private repo under your namespace.
+
+The target node must be **idle** — quantization needs the full unified memory, so
+AINode refuses to start a quant job while a model is loaded (unload first, or pass
+`force=true`). The output lands in **Installed** as `<org--name>-<scheme>`, ready
+to serve.
+
+> AWQ is the proven path on GB10. NVFP4 quantization is newer; **NVFP4 on
+> multimodal models (e.g. Qwen3.5) is experimental and not yet verified** — prefer
+> AWQ for the Qwen3.5 family today.
+
+**Hugging Face tokens (read vs write).** AINode keeps credentials in a local
+Secrets store (`~/.ainode/secrets.json`, mode 0600, obfuscated at rest) with two
+HF slots: a **read** token (download gated models) and a **write** token (push to
+the Hub — read-only tokens are rejected before any multi-GB transfer). Set them in
+**Config → Secrets** (each has a **Test** button showing the detected scope), or
+set the read token with `ainode config --hf-token hf_xxx`.
+
+---
+
 ## Features
 
 | Feature | Status |
@@ -227,6 +258,14 @@ panel, pick the model, set **Minimum Nodes=2**, click **Tensor** →
 | Cluster-wide update from master UI (`⬆ Update all` button) | ✅ |
 | Topology loading animation + per-node fade-in | ✅ |
 | AWQ models on GB10 (sm_12.1) — `awq_marlin` kernel fix | ✅ |
+| In-browser quantization (AWQ W4A16 / NVFP4) → serve or push to HF | ✅ v0.4.44 |
+| Push quantized / fine-tuned models to Hugging Face (write-token) | ✅ |
+| Secrets store (HF read + HF write + NGC + W&B + OpenAI), masked + testable | ✅ |
+| Federated master router — route `/v1/*` by model name across the cluster | ✅ |
+| Load / unload any model on any node from the master UI | ✅ |
+| Model stacking — N concurrent models per node, persisted + replayed on boot | ✅ |
+| Serve models from on-disk weights (`~/.ainode/models/<slug>`) | ✅ |
+| fp8 KV-cache default on GB10 (long-context headroom) | ✅ |
 
 ---
 
@@ -248,7 +287,7 @@ practical.
 
 ---
 
-## State of Distributed Inference (April 2026)
+## State of Distributed Inference (June 2026)
 
 We owe readers the honest picture, not a checkmark-soup. Here's what's
 really running on our hardware.
@@ -272,11 +311,20 @@ really running on our hardware.
 - **Inference throughput:** ~35 tok/s for a warmed-up model over
   the RoCE fabric.
 
-### What doesn't work yet
+- **Four-node TP=4** — verified live on frontier MoE: `nvidia/Qwen3-235B-A22B-NVFP4`
+  served at TP=4 across 4× GB10 (~16–17 t/s single-stream, survived a 3,513-token
+  prefill). The GB10 sm120 fix was `--enforce-eager` (vLLM's FlashInfer prefill
+  kernel emits an `illegal instruction` under CUDA-graph capture on GB10).
+- **Federated serving** — a master routes `/v1/*` to the node holding each model;
+  models load/unload per node from the browser.
+- **Model stacking** — multiple models per node, persisted and replayed on boot.
+- **In-browser quantization** — AWQ and NVFP4 jobs run on an idle node and land
+  the result in Installed (optionally pushed to Hugging Face).
 
-- **TP=4 distributed inference** across all four nodes — cluster forms
-  correctly, distributed launch under test.
+### What still needs care
+
 - **Ray over Tailscale** — use physical cables or a dedicated switch.
+- **Single NIC per cluster subnet** — multi-NIC ambiguity still breaks the NCCL ring.
 
 ### Lessons learned the hard way
 
@@ -555,8 +603,11 @@ scrape_configs:
 - [x] Training artifact retrieval, LoRA merge, checkpoint resume
 - [x] Evaluation loop + W&B integration
 - [x] Prometheus metrics endpoint (`/metrics`)
-- [ ] 4-node TP=4 sharded inference (cluster hardware ready, launch under test)
-- [ ] Model marketplace (quantized variants, custom registries)
+- [x] 4-node TP=4 sharded inference (verified — 235B-A22B-NVFP4)
+- [x] In-browser quantization (AWQ / NVFP4) + push to Hugging Face
+- [x] Federated multi-model serving (master routes `/v1/*` by model name)
+- [x] Model stacking (N models per node, persisted + replayed)
+- [ ] Model marketplace (custom registries)
 - [ ] Mobile-friendly UI
 
 ---

--- a/ainode/service/systemd.py
+++ b/ainode/service/systemd.py
@@ -21,8 +21,11 @@ SERVICE_NAME = "ainode.service"
 SYSTEM_UNIT_DIR = Path("/etc/systemd/system")
 USER_UNIT_DIR = Path.home() / ".config" / "systemd" / "user"
 
-# Image tag bumped when we cut a release and republish to GHCR.
-AINODE_IMAGE_TAG = "0.4.31"
+# Image tag follows the package version so a fresh install pulls the matching
+# image (env override for testing pre-release tags). Republished to GHCR per release.
+from ainode import __version__ as _AINODE_VERSION
+
+AINODE_IMAGE_TAG = os.environ.get("AINODE_IMAGE_TAG") or _AINODE_VERSION
 AINODE_IMAGE = f"ghcr.io/getainode/ainode:{AINODE_IMAGE_TAG}"
 
 UNIT_FILE_TEMPLATE = """\


### PR DESCRIPTION
## Docs refresh → 0.4.44

The public README was frozen at ~0.4.0 and the CHANGELOG stopped at 0.4.8 — ~11 weeks / 36 releases behind the code. This catches both up and fixes two broken windows.

### README
- Install pulls **`:latest`** (was hardcoded `:0.4.0`); pin-a-release note added.
- Docs link → **`docs.ainode.dev`** (was `docs.argentos.ai`).
- **State of Distributed Inference** → June 2026: **TP=4 verified** (235B-A22B-NVFP4), plus federation / model-stacking / in-browser quantization now under "what works."
- New **Quantize a model** section (AWQ/NVFP4, idle-node guardrail, HF read/write tokens) — with the honest "NVFP4-on-Qwen3.5 is experimental" caveat.
- Feature-table rows: quantize, HF push, Secrets store, federation, stacking, on-disk serve, fp8-KV.
- Roadmap checkboxes flipped (TP=4, quantize, federation, stacking).

### CHANGELOG
- Added **0.4.23 → 0.4.44** (federation F1/F2, model stacking, AWQ catalog + always-on, Models redesign + BUG-A, fp8-KV default, the quantize feature + Qwen3.5 handling).

### Fix (broken window)
- `service/systemd.py` image tag now follows `__version__` (was pinned `0.4.31`), so a fresh `ainode service install` renders a unit pulling the matching image.

> Not documented (deliberately): DS4 (not built), NVFP4-on-Qwen3.5 (untested), `TRITON_ATTN` (no-op on the current serve image). The docs *site* (Mintlify) refresh is a separate follow-up PR on `getainode/ainode-docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
