### PR TITLE
feat(training): AutoData MVP — Δ-filtered synthetic data generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-_Next release — changes accumulate here until tagged._
+### Added
+- **AutoData (training utility, MVP)** — agentic Δ-filtered synthetic-data generation
+  (Meta Autodata). `ainode/training/autodata/`: a Challenger generates tasks, weak +
+  strong solvers attempt each, a Judge grades both, and only `Δ = I_strong - I_weak == 1`
+  examples (strong solves, weak fails — the "zone of proximal development") are kept and
+  emitted as ShareGPT JSONL with a yield report. Pure HTTP over AInode-served
+  OpenAI-compatible endpoints (no torch — runs in the slim orchestrator). CLI:
+  `python -m ainode.training.autodata.run --config cfg.json`. Validated live on the GB10
+  fleet (Aegis-14B challenger/strong/judge + Qwen2.5-0.5B weak): 12 tasks → 1 kept,
+  correctly bucketing too-easy/too-hard. Orchestrator meta-optimization + `lift`
+  document-ingestion are deferred (v2).
 
 ---
 

--- a/ainode/training/autodata/V2_DESIGN.md
+++ b/ainode/training/autodata/V2_DESIGN.md
@@ -1,0 +1,61 @@
+# AutoData v2 — design (Open Thoughts–grounded)
+
+> v1 (shipped) = the Δ-filter loop: Challenger → weak/strong solvers → Judge → keep Δ=1 → ShareGPT JSONL.
+> v2 closes the loop and stops reinventing curation: it adopts the **Open Thoughts** recipe
+> ([arXiv 2506.04178], Bespoke Labs + DataComp) and **Evalchemy** (their open eval harness),
+> so AutoData *productizes a proven curation pipeline on the fleet* instead of guessing.
+> v1's 8% yield on a fixed prompt is exactly the gap v2 closes.
+
+## Why Open Thoughts
+Open Thoughts ran **1000+ ablations** on what makes good reasoning-SFT data and shipped it
+fully open: datasets (OpenThoughts3-1.2M, OpenThoughts-Agent), models (OpenThinker3-7B, SOTA
+open-data 7B), the generation/curation code, and **Evalchemy**. Their loop —
+*generate traces from a strong teacher → **verify correctness** → curate* — is exactly
+AutoData's Challenger→Judge, validated at 1.2M scale. We take their findings as the priors.
+
+## v2 components (over the v1 MVP)
+
+### 1. Orchestrator meta-optimization (raises yield — the headline)
+Implements the AutoData reward objective `P* = argmax_P E[Reward(M(x; D(G,P)), y)]`.
+- Loop: run a batch → measure yield (Δ=1 rate) **and** a val-set score → if yield/score is
+  below threshold, an LLM optimizer rewrites `P_t → P_{t+1}` (and recipe knobs) toward the ZPD.
+- This automates the manual ablation search Open Thoughts did by hand. Fixes the v1 8%.
+- Loop-until-target or loop-until-budget (mirror the workflow patterns).
+
+### 2. Evalchemy as the Judge + the objective
+Replace v1's hand-rolled judge with Evalchemy's **proven verifiers** for benchmarkable domains:
+- **Math-Verify** (symbolic exact), **code execution** (test-passing), **LLM-judge-with-GT**.
+- The meta-optimizer's **reward** = Evalchemy score on a held-out val set (not just Δ-yield),
+  giving the objective a real, comparable signal. Evalchemy already evaluates **vLLM
+  OpenAI endpoints** → drops onto AInode-served models with no new infra.
+- v1's rubric/exact judge stays as the lightweight default for open-ended domains.
+
+### 3. Recipe knobs (from the OpenThoughts paper, as config)
+Expose what they ablated, with their best-performers as defaults; the meta-opt searches them:
+- **Teacher (strong solver)** choice — they moved R1 → QwQ-32B; we point it at a fleet model.
+- **Question-generation methodology** — they ablated 26 and sampled the top; v2 ships a small
+  menu (persona, difficulty-laddered, seed-perturbation, multi-hop) the meta-opt selects from.
+- **Verification + dedup** — Evalchemy verify + content-hash dedup (their CuratedThoughts step).
+- **Domain mix** — math/code/science/agent weights (their OpenThoughts3 = 850k/250k/100k).
+
+### 4. Seeds from Open Thoughts datasets (+ lift)
+- Bootstrap the Challenger with exemplars from **OpenThoughts3-1.2M** / **OpenThoughts-Agent**
+  (few-shot the generator toward proven-good distributions), and benchmark against their splits.
+- **lift** (datalab-to) ingests PDFs/scans → structured seeds → AutoData extends them
+  synthetically (your small-dataset → big-dataset insight). Real-world seed → synthetic scale.
+
+## Build slices (each its own /goal, smallest-first)
+- **v2.1 — meta-optimizer** (the yield fix): the `P_t→P_{t+1}` loop + val-set objective. Biggest payoff.
+- **v2.2 — Evalchemy integration**: wire Evalchemy as the verifier/objective (served-endpoint eval).
+- **v2.3 — recipe knobs + OpenThoughts seeds**: the methodology menu + dataset bootstrapping.
+- **v2.4 — lift ingestion**: documents → structured seeds → synthetic extension.
+
+## Non-goals (still)
+- Re-deriving curation research (we adopt Open Thoughts' findings).
+- A new eval harness (use Evalchemy).
+- Re-generating OpenThoughts data (use theirs as seeds/benchmarks; generate only domain-specific deltas).
+
+## References
+- OpenThoughts: Data Recipes for Reasoning Models — arXiv 2506.04178
+- Datasets: open-thoughts/OpenThoughts3-1.2M, OpenThoughts-Agent · Model: open-thoughts/OpenThinker3-7B (Qwen2.5-7B base, Apache-2.0)
+- Evalchemy: github.com/mlfoundations/evalchemy

--- a/ainode/training/autodata/__init__.py
+++ b/ainode/training/autodata/__init__.py
@@ -1,0 +1,8 @@
+"""AutoData — agentic Δ-filtered synthetic training-data generation (Meta Autodata, MVP).
+
+Pure HTTP orchestration over AInode-served OpenAI-compatible endpoints. No torch/GPU here
+— the compute is the served models, so this runs in the slim orchestrator. The loop keeps
+only "zone of proximal development" examples: tasks the STRONG solver gets right and the
+WEAK solver gets wrong (Δ = I_strong - I_weak == 1).
+"""
+from .core import run, AutoDataConfig  # noqa: F401

--- a/ainode/training/autodata/core.py
+++ b/ainode/training/autodata/core.py
@@ -1,0 +1,201 @@
+"""AutoData core — Challenger -> weak/strong Solvers -> Judge Δ-filter -> ShareGPT JSONL.
+
+Δ = I_strong - I_weak. Keep only Δ == 1 (strong solves, weak fails): the high-value
+"zone of proximal development". Δ == 0 is too-easy (both pass) or too-hard (both fail);
+Δ == -1 (weak passes, strong fails) is judge noise / a bad task — dropped.
+
+Everything is OpenAI-compatible HTTP, so the four roles are just AInode-served endpoints
+(strong = a big model, weak = a small model or low-compute pass). `call_model` is module-
+level so tests inject a fake and run the whole loop with no network. See demo() at bottom.
+"""
+from __future__ import annotations
+
+import json
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Endpoint:
+    url: str                       # OpenAI base, e.g. http://localhost:8001/v1
+    model: str
+    max_tokens: int = 512
+    temperature: float = 0.0
+    api_key: str = "EMPTY"
+    timeout: int = 120
+
+
+@dataclass
+class AutoDataConfig:
+    task_spec: str                 # what kind of tasks to generate
+    gen_prompt: str                # the Challenger system prompt (P)
+    challenger: Endpoint
+    weak: Endpoint
+    strong: Endpoint
+    judge: Endpoint
+    n_tasks: int = 50
+    system_prompt: str = ""        # optional system msg for solvers + emitted data
+    judge_mode: str = "rubric"     # "rubric" (LLM) or "exact" (string match vs reference)
+    concurrency: int = 8
+    out: str = ""                  # JSONL output path (optional)
+
+    @staticmethod
+    def from_dict(d: dict) -> "AutoDataConfig":
+        ep = lambda k: Endpoint(**d[k])  # noqa: E731
+        return AutoDataConfig(
+            task_spec=d["task_spec"], gen_prompt=d["gen_prompt"],
+            challenger=ep("challenger"), weak=ep("weak"), strong=ep("strong"), judge=ep("judge"),
+            n_tasks=int(d.get("n_tasks", 50)), system_prompt=d.get("system_prompt", ""),
+            judge_mode=d.get("judge_mode", "rubric"), concurrency=int(d.get("concurrency", 8)),
+            out=d.get("out", ""),
+        )
+
+
+def _http_chat(ep: Endpoint, messages: list, json_mode: bool = False) -> str:
+    body = {"model": ep.model, "messages": messages,
+            "temperature": ep.temperature, "max_tokens": ep.max_tokens}
+    if json_mode:
+        body["response_format"] = {"type": "json_object"}
+    req = urllib.request.Request(
+        ep.url.rstrip("/") + "/chat/completions",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json", "Authorization": f"Bearer {ep.api_key}"},
+    )
+    with urllib.request.urlopen(req, timeout=ep.timeout) as r:
+        return json.load(r)["choices"][0]["message"]["content"]
+
+
+# Injection point: tests replace this with a fake (signature: (Endpoint, messages, json_mode) -> str).
+call_model = _http_chat
+
+
+def _norm(s: str) -> str:
+    return " ".join((s or "").lower().split())
+
+
+def generate_tasks(cfg: AutoDataConfig) -> list:
+    """Challenger emits n candidate tasks as JSON: [{"input", "reference"?}]."""
+    user = (
+        f"{cfg.task_spec}\n\nGenerate {cfg.n_tasks} DIVERSE, challenging tasks. "
+        'Return STRICT JSON only: {"tasks":[{"input":"<the task prompt the solver sees>",'
+        '"reference":"<the correct answer, or null if open-ended>"}]}'
+    )
+    out = call_model(cfg.challenger,
+                     [{"role": "system", "content": cfg.gen_prompt}, {"role": "user", "content": user}],
+                     True)
+    tasks = json.loads(out).get("tasks", [])
+    return [t for t in tasks if isinstance(t, dict) and t.get("input")][: cfg.n_tasks]
+
+
+def solve(ep: Endpoint, system: str, x: str) -> str:
+    msgs = ([{"role": "system", "content": system}] if system else []) + [{"role": "user", "content": x}]
+    return call_model(ep, msgs, False)
+
+
+def judge_correct(cfg: AutoDataConfig, x: str, output: str, reference) -> int:
+    """1 if `output` is correct for task `x`, else 0."""
+    if cfg.judge_mode == "exact" and reference:
+        return int(_norm(reference) in _norm(output))
+    ref = f"\n\nReference answer:\n{reference}" if reference else ""
+    prompt = (f"Task:\n{x}\n\nCandidate answer:\n{output}{ref}\n\n"
+              'Is the candidate answer correct and high-quality for this task? '
+              'Return STRICT JSON only: {"correct": true|false}.')
+    out = call_model(cfg.judge, [{"role": "user", "content": prompt}], True)
+    try:
+        return int(bool(json.loads(out).get("correct")))
+    except Exception:
+        return int("true" in out.lower()[:24])
+
+
+def run(config, on_progress=None) -> dict:
+    """Run the Δ-filter loop. `config` is an AutoDataConfig or a dict. Returns
+    {kept: [sharegpt...], report: {...}, out: path}."""
+    cfg = config if isinstance(config, AutoDataConfig) else AutoDataConfig.from_dict(config)
+    tasks = generate_tasks(cfg)
+    report = {"total": len(tasks), "kept": 0, "too_easy": 0, "too_hard": 0,
+              "strong_worse": 0, "errors": 0}
+    kept = []
+
+    def process(t):
+        x, ref = t["input"], t.get("reference")
+        w, s = solve(cfg.weak, cfg.system_prompt, x), solve(cfg.strong, cfg.system_prompt, x)
+        return x, s, judge_correct(cfg, x, w, ref), judge_correct(cfg, x, s, ref)
+
+    with ThreadPoolExecutor(max_workers=cfg.concurrency) as ex:
+        for res in ex.map(lambda t: _safe(process, t), tasks):
+            if res is None:
+                report["errors"] += 1
+                continue
+            x, strong_out, i_weak, i_strong = res
+            delta = i_strong - i_weak
+            if delta == 1:                       # strong solves, weak fails — KEEP
+                conv = ([{"from": "system", "value": cfg.system_prompt}] if cfg.system_prompt else [])
+                conv += [{"from": "human", "value": x}, {"from": "gpt", "value": strong_out}]
+                kept.append({"conversations": conv})
+                report["kept"] += 1
+            elif delta == 0:
+                report["too_easy" if i_strong == 1 else "too_hard"] += 1
+            else:                                # delta == -1
+                report["strong_worse"] += 1
+            if on_progress:
+                on_progress(report)
+
+    if cfg.out:
+        with open(cfg.out, "w") as f:
+            for r in kept:
+                f.write(json.dumps(r) + "\n")
+    report["yield_pct"] = round(100 * report["kept"] / max(report["total"], 1))
+    return {"kept": kept, "report": report, "out": cfg.out}
+
+
+def _safe(fn, t):
+    try:
+        return fn(t)
+    except Exception:
+        return None
+
+
+def demo() -> None:
+    """Self-check with a fake model: only the strong-solves/weak-fails task survives."""
+    global call_model
+    # 3 tasks: A (only strong solves), B (both solve = too easy), C (neither = too hard)
+    def fake(ep: Endpoint, messages: list, json_mode: bool) -> str:
+        last = messages[-1]["content"]
+        if json_mode and "Generate" in last:        # challenger
+            return json.dumps({"tasks": [
+                {"input": "TASK_A", "reference": "A"},
+                {"input": "TASK_B", "reference": "B"},
+                {"input": "TASK_C", "reference": "C"}]})
+        if json_mode and "Candidate answer" in last:  # judge (exact-ish via rubric path)
+            # mark correct unless the answer literally says WRONG
+            return json.dumps({"correct": "WRONG" not in last})
+        # solver: weak gets only B right; strong gets A and B right, C wrong
+        task = messages[-1]["content"]
+        strong = ep.model == "strong"
+        if task == "TASK_A":
+            return "A" if strong else "WRONG"
+        if task == "TASK_B":
+            return "B"
+        return "WRONG"  # TASK_C: both wrong
+
+    call_model = fake
+    try:
+        cfg = AutoDataConfig(
+            task_spec="x", gen_prompt="x", n_tasks=3, concurrency=1,
+            challenger=Endpoint("u", "challenger"), weak=Endpoint("u", "weak"),
+            strong=Endpoint("u", "strong"), judge=Endpoint("u", "judge"))
+        out = run(cfg)
+        rep = out["report"]
+        assert rep["total"] == 3, rep
+        assert rep["kept"] == 1, rep            # only TASK_A (strong yes / weak no)
+        assert rep["too_easy"] == 1, rep        # TASK_B
+        assert rep["too_hard"] == 1, rep        # TASK_C
+        assert out["kept"][0]["conversations"][-1]["value"] == "A", out["kept"]
+        print("autodata demo OK:", rep)
+    finally:
+        call_model = _http_chat
+
+
+if __name__ == "__main__":
+    demo()

--- a/ainode/training/autodata/core.py
+++ b/ainode/training/autodata/core.py
@@ -11,9 +11,10 @@ level so tests inject a fake and run the whole loop with no network. See demo() 
 from __future__ import annotations
 
 import json
+import time
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 
 @dataclass
@@ -38,6 +39,7 @@ class AutoDataConfig:
     system_prompt: str = ""        # optional system msg for solvers + emitted data
     judge_mode: str = "rubric"     # "rubric" (LLM) or "exact" (string match vs reference)
     concurrency: int = 8
+    retries: int = 2               # transient HTTP/parse retries per model call
     out: str = ""                  # JSONL output path (optional)
 
     @staticmethod
@@ -48,7 +50,7 @@ class AutoDataConfig:
             challenger=ep("challenger"), weak=ep("weak"), strong=ep("strong"), judge=ep("judge"),
             n_tasks=int(d.get("n_tasks", 50)), system_prompt=d.get("system_prompt", ""),
             judge_mode=d.get("judge_mode", "rubric"), concurrency=int(d.get("concurrency", 8)),
-            out=d.get("out", ""),
+            retries=int(d.get("retries", 2)), out=d.get("out", ""),
         )
 
 
@@ -70,8 +72,24 @@ def _http_chat(ep: Endpoint, messages: list, json_mode: bool = False) -> str:
 call_model = _http_chat
 
 
-def _norm(s: str) -> str:
-    return " ".join((s or "").lower().split())
+def _retry(fn, attempts: int = 2, base_delay: float = 0.5):
+    """Run fn(); retry on ANY exception up to `attempts` extra times with exp backoff.
+    Used to absorb transient HTTP timeouts and malformed-JSON responses (each retry
+    re-calls the model, so a bad parse gets a fresh generation)."""
+    last = None
+    for i in range(attempts + 1):
+        try:
+            return fn()
+        except Exception as exc:  # noqa: BLE001 — transient model/HTTP/parse failures
+            last = exc
+            if i < attempts:
+                time.sleep(base_delay * (2 ** i))
+    raise last
+
+
+def _norm(s) -> str:
+    # coerce non-str (the Challenger may emit numeric/None references) before normalizing
+    return " ".join(str("" if s is None else s).lower().split())
 
 
 def generate_tasks(cfg: AutoDataConfig) -> list:
@@ -81,16 +99,18 @@ def generate_tasks(cfg: AutoDataConfig) -> list:
         'Return STRICT JSON only: {"tasks":[{"input":"<the task prompt the solver sees>",'
         '"reference":"<the correct answer, or null if open-ended>"}]}'
     )
-    out = call_model(cfg.challenger,
-                     [{"role": "system", "content": cfg.gen_prompt}, {"role": "user", "content": user}],
-                     True)
-    tasks = json.loads(out).get("tasks", [])
+    def _gen():
+        out = call_model(cfg.challenger,
+                         [{"role": "system", "content": cfg.gen_prompt}, {"role": "user", "content": user}],
+                         True)
+        return json.loads(out).get("tasks", [])
+    tasks = _retry(_gen, cfg.retries)
     return [t for t in tasks if isinstance(t, dict) and t.get("input")][: cfg.n_tasks]
 
 
-def solve(ep: Endpoint, system: str, x: str) -> str:
+def solve(ep: Endpoint, system: str, x: str, retries: int = 2) -> str:
     msgs = ([{"role": "system", "content": system}] if system else []) + [{"role": "user", "content": x}]
-    return call_model(ep, msgs, False)
+    return _retry(lambda: call_model(ep, msgs, False), retries)
 
 
 def judge_correct(cfg: AutoDataConfig, x: str, output: str, reference) -> int:
@@ -101,11 +121,18 @@ def judge_correct(cfg: AutoDataConfig, x: str, output: str, reference) -> int:
     prompt = (f"Task:\n{x}\n\nCandidate answer:\n{output}{ref}\n\n"
               'Is the candidate answer correct and high-quality for this task? '
               'Return STRICT JSON only: {"correct": true|false}.')
-    out = call_model(cfg.judge, [{"role": "user", "content": prompt}], True)
-    try:
+    def _grade():
+        out = call_model(cfg.judge, [{"role": "user", "content": prompt}], True)
         return int(bool(json.loads(out).get("correct")))
+    try:
+        return _retry(_grade, cfg.retries)
     except Exception:
-        return int("true" in out.lower()[:24])
+        # last-ditch: one plain (non-JSON-mode) call with a lenient parse
+        try:
+            out = call_model(cfg.judge, [{"role": "user", "content": prompt}], False).lower()
+            return int('"correct": true' in out or out.strip().startswith(("yes", "true")))
+        except Exception:
+            return 0
 
 
 def run(config, on_progress=None) -> dict:
@@ -119,7 +146,8 @@ def run(config, on_progress=None) -> dict:
 
     def process(t):
         x, ref = t["input"], t.get("reference")
-        w, s = solve(cfg.weak, cfg.system_prompt, x), solve(cfg.strong, cfg.system_prompt, x)
+        w = solve(cfg.weak, cfg.system_prompt, x, cfg.retries)
+        s = solve(cfg.strong, cfg.system_prompt, x, cfg.retries)
         return x, s, judge_correct(cfg, x, w, ref), judge_correct(cfg, x, s, ref)
 
     with ThreadPoolExecutor(max_workers=cfg.concurrency) as ex:

--- a/ainode/training/autodata/meta.py
+++ b/ainode/training/autodata/meta.py
@@ -1,0 +1,138 @@
+"""AutoData v2.1 — meta-optimizer.
+
+Close the loop: run v1's Δ-filter batch, read the bucket stats, and have an LLM rewrite
+the generation prompt P_t → P_t+1 toward the zone of proximal development (too_easy ⇒
+harder, too_hard ⇒ easier). Repeat until target yield or max_rounds. Optimizes on the
+Δ=1-yield PROXY only — the val-set objective (Evalchemy) is v2.2.
+
+Reuses v1 (run / call_model / _retry). `core.call_model` is referenced dynamically so the
+self-check's fake injection is seen here too. See demo() at the bottom.
+"""
+from __future__ import annotations
+
+import copy
+import json
+import re
+
+from . import core
+from .core import AutoDataConfig, run
+
+
+def _optimize_prompt(ep, current_prompt: str, task_spec: str, report: dict, retries: int = 2) -> str:
+    """Ask an LLM to rewrite the generator prompt toward the ZPD, given last round's stats."""
+    stats = (f"yield={report.get('yield_pct', 0)}% kept={report['kept']} "
+             f"too_easy={report['too_easy']} (both strong+weak solved) "
+             f"too_hard={report['too_hard']} (both failed) total={report['total']}")
+    msg = (
+        "You tune the SYSTEM PROMPT of a task-generator in a synthetic-data pipeline. "
+        "We keep only tasks a STRONG model solves but a WEAK model fails (the zone of "
+        "proximal development). Current generator prompt:\n"
+        f"---\n{current_prompt}\n---\n"
+        f"Task domain: {task_spec}\n"
+        f"Last round: {stats}\n"
+        "If too_easy dominates, make generated tasks HARDER / more multi-step so the weak "
+        "model fails. If too_hard dominates, make them EASIER / clearer so the strong model "
+        "still solves. Maximize the strong-solves-weak-fails zone. "
+        'Return STRICT JSON only: {"prompt": "<the rewritten generator system prompt>"}.'
+    )
+
+    def _opt():
+        out = core.call_model(ep, [{"role": "user", "content": msg}], True)
+        p = (json.loads(out).get("prompt") or "").strip()
+        if not p:
+            raise ValueError("empty rewritten prompt")
+        return p
+    return core._retry(_opt, retries)
+
+
+def _key(ex: dict) -> str:
+    for m in ex["conversations"]:
+        if m["from"] == "human":
+            return m["value"]
+    return json.dumps(ex, sort_keys=True)
+
+
+def meta_optimize(config, target_yield: float = 30, max_rounds: int = 4,
+                  optimizer=None, on_round=None) -> dict:
+    """Iteratively rewrite P to raise Δ=1 yield.
+
+    Returns {best_prompt, best_yield, dataset (merged+deduped Δ=1), rounds[], out}.
+    """
+    cfg = config if isinstance(config, AutoDataConfig) else AutoDataConfig.from_dict(config)
+    opt_ep = optimizer or cfg.challenger          # reuse the challenger endpoint for the rewrite
+    out_path = cfg.out
+    cfg = copy.copy(cfg)
+    cfg.out = ""                                    # we write the merged dataset ourselves
+
+    rounds, dataset, seen = [], [], set()
+    best = {"yield": -1.0, "prompt": cfg.gen_prompt}
+    for r in range(1, max_rounds + 1):
+        result = run(cfg)
+        rep = result["report"]
+        for ex in result["kept"]:
+            k = _key(ex)
+            if k not in seen:
+                seen.add(k)
+                dataset.append(ex)
+        entry = {"round": r, "yield_pct": rep["yield_pct"], "kept": rep["kept"],
+                 "too_easy": rep["too_easy"], "too_hard": rep["too_hard"],
+                 "total": rep["total"], "prompt": cfg.gen_prompt}
+        rounds.append(entry)
+        if rep["yield_pct"] > best["yield"]:
+            best = {"yield": rep["yield_pct"], "prompt": cfg.gen_prompt}
+        if on_round:
+            on_round(entry)
+        if rep["yield_pct"] >= target_yield or r == max_rounds:
+            break
+        try:
+            cfg.gen_prompt = _optimize_prompt(opt_ep, cfg.gen_prompt, cfg.task_spec, rep, cfg.retries)
+        except Exception:
+            break                                   # can't improve P → stop
+
+    if out_path:
+        with open(out_path, "w") as f:
+            for ex in dataset:
+                f.write(json.dumps(ex) + "\n")
+    return {"best_prompt": best["prompt"], "best_yield": best["yield"],
+            "dataset": dataset, "rounds": rounds, "out": out_path}
+
+
+def demo() -> None:
+    """Self-check: a fake where harder prompts (DIFF=k) yield more Δ=1; the loop must
+    raise yield round-over-round and converge to the harder prompt."""
+    def fake(ep, messages, json_mode):
+        sysmsg = messages[0]["content"] if messages and messages[0]["role"] == "system" else ""
+        last = messages[-1]["content"]
+        if json_mode and "rewritten generator" in last:        # optimizer: bump difficulty
+            d = int((re.search(r"DIFF=(\d+)", last) or [0, "0"])[1])
+            return json.dumps({"prompt": f"DIFF={d + 1}"})
+        if json_mode and "Generate" in last:                   # challenger: emit tasks at DIFF
+            d = int((re.search(r"DIFF=(\d+)", sysmsg) or [0, "0"])[1])
+            return json.dumps({"tasks": [{"input": f"L{d}_{i}", "reference": None} for i in range(6)]})
+        if json_mode and "Candidate answer" in last:           # judge: CORRECT in the answer?
+            return json.dumps({"correct": "CORRECT" in last})
+        level = int((re.search(r"L(\d+)_", last) or [0, "0"])[1])  # solver
+        ability = 0 if ep.model == "weak" else 2               # weak solves L0; strong solves ≤L2
+        return "CORRECT" if level <= ability else "WRONG"
+
+    core.call_model = fake
+    try:
+        cfg = AutoDataConfig(
+            task_spec="x", gen_prompt="DIFF=0", n_tasks=6, concurrency=1,
+            challenger=core.Endpoint("u", "challenger"), weak=core.Endpoint("u", "weak"),
+            strong=core.Endpoint("u", "strong"), judge=core.Endpoint("u", "judge"))
+        out = meta_optimize(cfg, target_yield=30, max_rounds=4)
+        rounds = out["rounds"]
+        assert len(rounds) >= 2, rounds
+        assert rounds[0]["yield_pct"] == 0, rounds            # DIFF=0 → all too_easy
+        assert rounds[-1]["yield_pct"] > rounds[0]["yield_pct"], rounds  # yield rose
+        assert out["best_yield"] >= 30, out
+        assert "DIFF=1" in out["best_prompt"], out            # converged to the harder prompt
+        assert len(out["dataset"]) == out["rounds"][-1]["kept"], out
+        print("autodata meta demo OK:", [(r["round"], r["yield_pct"]) for r in rounds])
+    finally:
+        core.call_model = core._http_chat
+
+
+if __name__ == "__main__":
+    demo()

--- a/ainode/training/autodata/meta.py
+++ b/ainode/training/autodata/meta.py
@@ -18,22 +18,25 @@ from . import core
 from .core import AutoDataConfig, run
 
 
-def _optimize_prompt(ep, current_prompt: str, task_spec: str, report: dict, retries: int = 2) -> str:
-    """Ask an LLM to rewrite the generator prompt toward the ZPD, given last round's stats."""
-    stats = (f"yield={report.get('yield_pct', 0)}% kept={report['kept']} "
-             f"too_easy={report['too_easy']} (both strong+weak solved) "
-             f"too_hard={report['too_hard']} (both failed) total={report['total']}")
+def _optimize_prompt(ep, rounds: list, task_spec: str, retries: int = 2) -> str:
+    """Propose the NEXT generator prompt from the FULL round trajectory, so the optimizer
+    learns from an overshoot (too_hard) instead of repeating it. too_easy = both solved
+    (push harder); too_hard = both failed (dial back)."""
+    traj = "\n".join(
+        f"Round {e['round']}: yield={e['yield_pct']}% too_easy={e['too_easy']} "
+        f"too_hard={e['too_hard']}  | prompt: {e['prompt']}"
+        for e in rounds)
     msg = (
         "You tune the SYSTEM PROMPT of a task-generator in a synthetic-data pipeline. "
-        "We keep only tasks a STRONG model solves but a WEAK model fails (the zone of "
-        "proximal development). Current generator prompt:\n"
-        f"---\n{current_prompt}\n---\n"
+        "We keep only tasks a STRONG model solves but a WEAK model FAILS (the zone of "
+        "proximal development). too_easy = both solved (too easy); too_hard = both failed "
+        "(too hard). Trajectory so far:\n"
+        f"{traj}\n\n"
         f"Task domain: {task_spec}\n"
-        f"Last round: {stats}\n"
-        "If too_easy dominates, make generated tasks HARDER / more multi-step so the weak "
-        "model fails. If too_hard dominates, make them EASIER / clearer so the strong model "
-        "still solves. Maximize the strong-solves-weak-fails zone. "
-        'Return STRICT JSON only: {"prompt": "<the rewritten generator system prompt>"}.'
+        "Propose the NEXT generator prompt to MAXIMIZE yield — LEARN from the trajectory: "
+        "if a prompt overshot to too_hard, dial difficulty back; if too_easy, push harder; "
+        "converge toward the middle. "
+        'Return STRICT JSON only: {"prompt": "<the next generator system prompt>"}.'
     )
 
     def _opt():
@@ -85,7 +88,8 @@ def meta_optimize(config, target_yield: float = 30, max_rounds: int = 4,
         if rep["yield_pct"] >= target_yield or r == max_rounds:
             break
         try:
-            cfg.gen_prompt = _optimize_prompt(opt_ep, cfg.gen_prompt, cfg.task_spec, rep, cfg.retries)
+            # feed the full trajectory so the optimizer corrects an overshoot, not repeats it
+            cfg.gen_prompt = _optimize_prompt(opt_ep, rounds, cfg.task_spec, cfg.retries)
         except Exception:
             break                                   # can't improve P → stop
 
@@ -103,9 +107,9 @@ def demo() -> None:
     def fake(ep, messages, json_mode):
         sysmsg = messages[0]["content"] if messages and messages[0]["role"] == "system" else ""
         last = messages[-1]["content"]
-        if json_mode and "rewritten generator" in last:        # optimizer: bump difficulty
-            d = int((re.search(r"DIFF=(\d+)", last) or [0, "0"])[1])
-            return json.dumps({"prompt": f"DIFF={d + 1}"})
+        if json_mode and "task-generator" in last:             # optimizer: bump difficulty
+            ds = [int(x) for x in re.findall(r"DIFF=(\d+)", last)]
+            return json.dumps({"prompt": f"DIFF={(max(ds) if ds else 0) + 1}"})
         if json_mode and "Generate" in last:                   # challenger: emit tasks at DIFF
             d = int((re.search(r"DIFF=(\d+)", sysmsg) or [0, "0"])[1])
             return json.dumps({"tasks": [{"input": f"L{d}_{i}", "reference": None} for i in range(6)]})

--- a/ainode/training/autodata/run.py
+++ b/ainode/training/autodata/run.py
@@ -14,9 +14,26 @@ from .core import run
 def main() -> None:
     ap = argparse.ArgumentParser(description="AutoData — Δ-filtered synthetic data generation")
     ap.add_argument("--config", required=True, help="Path to AutoData config JSON")
+    ap.add_argument("--meta", action="store_true", help="v2.1 meta-optimizer: rewrite P each round to raise yield")
+    ap.add_argument("--target-yield", type=float, default=30, help="meta: stop when yield%% reaches this")
+    ap.add_argument("--max-rounds", type=int, default=4, help="meta: max optimization rounds")
     args = ap.parse_args()
 
     cfg = json.loads(open(args.config).read())
+
+    if args.meta:
+        from .meta import meta_optimize
+        out = meta_optimize(cfg, target_yield=args.target_yield, max_rounds=args.max_rounds,
+                            on_round=lambda e: print(
+                                f"  round {e['round']}: yield={e['yield_pct']}% "
+                                f"(kept={e['kept']} too_easy={e['too_easy']} too_hard={e['too_hard']})",
+                                file=sys.stderr))
+        print(json.dumps({"best_yield": out["best_yield"], "best_prompt": out["best_prompt"],
+                          "rounds": [{k: r[k] for k in ("round", "yield_pct", "kept")} for r in out["rounds"]],
+                          "dataset_size": len(out["dataset"]), "out": out["out"]}, indent=2))
+        print(f"\nBest yield {out['best_yield']}% over {len(out['rounds'])} rounds; "
+              f"{len(out['dataset'])} examples -> {out['out'] or '(not written)'}", file=sys.stderr)
+        return
     result = run(cfg, on_progress=lambda r: print(
         f"\r  kept={r['kept']} too_easy={r['too_easy']} too_hard={r['too_hard']} "
         f"strong_worse={r['strong_worse']} err={r['errors']}", end="", file=sys.stderr))

--- a/ainode/training/autodata/run.py
+++ b/ainode/training/autodata/run.py
@@ -1,0 +1,31 @@
+"""AutoData CLI: `python -m ainode.training.autodata.run --config cfg.json`.
+
+Config JSON keys: task_spec, gen_prompt, challenger/weak/strong/judge (each
+{url, model, max_tokens?, temperature?, api_key?}), n_tasks?, system_prompt?,
+judge_mode? (rubric|exact), concurrency?, out?.
+"""
+import argparse
+import json
+import sys
+
+from .core import run
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="AutoData — Δ-filtered synthetic data generation")
+    ap.add_argument("--config", required=True, help="Path to AutoData config JSON")
+    args = ap.parse_args()
+
+    cfg = json.loads(open(args.config).read())
+    result = run(cfg, on_progress=lambda r: print(
+        f"\r  kept={r['kept']} too_easy={r['too_easy']} too_hard={r['too_hard']} "
+        f"strong_worse={r['strong_worse']} err={r['errors']}", end="", file=sys.stderr))
+    print(file=sys.stderr)
+    rep = result["report"]
+    print(json.dumps({"report": rep, "out": result["out"]}, indent=2))
+    print(f"\nKept {rep['kept']}/{rep['total']} ({rep['yield_pct']}% yield) -> {result['out'] or '(not written)'}",
+          file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## AutoData — Δ-filtered synthetic-data generation (training utility, MVP)

A first-class AInode **training** tool implementing Meta's **Autodata** loop: generate candidate tasks, have a **weak** and a **strong** solver attempt each, **Judge** both, and keep only the **Δ = I_strong − I_weak == 1** examples — the "zone of proximal development" (strong solves, weak fails). Output: ShareGPT JSONL + a yield report.

### Why it's a clean fit
- **Pure HTTP orchestration** over AInode-served OpenAI endpoints — *no torch*, so it runs in the slim orchestrator. The compute is the served models (the four roles are just endpoints: strong = a big model, weak = a small/low-compute pass). AInode dogfoods its own serving to make its own training data.
- This productizes the synthetic-data approach we hand-rolled for the Aegis-14B fine-tune — now with the Δ-filter doing automatic quality selection.

### What's here
- `ainode/training/autodata/` — `core.py` (Challenger / Solver / Judge / Δ-filter / JSONL + report), `run.py` (CLI), `__init__.py`.
- CLI: `python -m ainode.training.autodata.run --config cfg.json`.
- Self-check (`core.demo()`): verifies the Δ-filter keeps only the strong-pass/weak-fail task.

### Validated live (GB10 fleet)
Aegis-14B (challenger/strong/judge) + Qwen2.5-0.5B (weak): **12 tasks → 1 kept (Δ=1), 6 too-easy, 2 too-hard, 0 strong-worse.** Kept row is a genuine ZPD example (a probability word problem the 14B solved and the 0.5B missed). The low 8% yield is expected for a fixed prompt — and motivates the v2 Orchestrator meta-optimization.

### Deferred (v2, intentional NON-GOALS)
- Orchestrator **meta-optimization** of the generation prompt `P` (raise the Δ=1 yield).
- **`lift`** document-ingestion (datalab-to/lift) → real seeds from PDFs/scans, then extend synthetically.
- UI, multi-node training orchestration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
