### PR TITLE
feat(launch): served-model-name aliases + per-load config overrides

### DIFF
--- a/ainode/core/config.py
+++ b/ainode/core/config.py
@@ -36,6 +36,10 @@ class NodeConfig:
     engine_backend: str = "eugr"
     model: str = "meta-llama/Llama-3.2-3B-Instruct"
     models_dir: str = str(MODELS_DIR)
+    # Optional API aliases for /v1/models — emitted as ``--served-model-name a b c``.
+    # Lets a client/router address the model by a short name (e.g. "Aegis-14B")
+    # instead of the repo-id/slug. Falls back to ``model`` when unset.
+    served_model_name: Optional[List[str]] = None
     max_model_len: Optional[int] = None
     # vLLM sizes the KV cache to this fraction of the GPU regardless of model
     # size, so 0.9 made a tiny model reserve ~110 GB on a 122 GB unified-memory

--- a/ainode/engine/backends/nvidia.py
+++ b/ainode/engine/backends/nvidia.py
@@ -661,14 +661,21 @@ class NvidiaBackend(EngineBackend):
         resolve to an empty root-owned dir, so we must NOT point vLLM at it —
         falling back to the repo-id keeps the current (re-download) behaviour and
         guarantees no regression before the systemd unit sets AINODE_HOST_HOME."""
+        # API id(s) clients address the model by. Custom aliases (e.g. "Aegis-14B")
+        # win; otherwise pin the repo-id so /v1/models is stable even when serving
+        # from a local mount path. A list emits multiple --served-model-name values.
+        names = self.config.served_model_name or [self.config.model]
+        name_args: List[str] = ["--served-model-name", *names]
         in_container = os.environ.get("AINODE_IN_CONTAINER")
         mount_trustworthy = (not in_container) or bool(os.environ.get("AINODE_HOST_HOME"))
         if mount_trustworthy:
             local = self._local_model_dir()
             if local:
                 slug = self.config.model.replace("/", "--")
-                return f"{self.MODELS_MOUNT}/{slug}", ["--served-model-name", self.config.model]
-        return self.config.model, []
+                return f"{self.MODELS_MOUNT}/{slug}", name_args
+        # Remote (vLLM downloads the repo-id) — previously emitted NO name args, so
+        # the served id was the full repo-id with no alias option. Now aliasable too.
+        return self.config.model, name_args
 
     def _build_solo_docker_cmd(self, container_name: str) -> List[str]:
         """Single-container solo mode — ``docker run ... vllm serve ...``.

--- a/ainode/models/api_routes.py
+++ b/ainode/models/api_routes.py
@@ -114,10 +114,16 @@ def save_instance_manifest(app) -> None:
         # scope for auto-replay (they need peer coordination).
         if getattr(cfg, "distributed_mode", "solo") not in ("solo", None):
             continue
-        entries.append({
+        entry = {
             "model": inst.record.model,
             "gpu_memory_utilization": getattr(cfg, "gpu_memory_utilization", None),
-        })
+        }
+        # round-trip per-load overrides so restart-replay restores aliases + ctx len
+        for k in _OVERRIDE_KEYS:
+            v = getattr(cfg, k, None)
+            if v is not None:
+                entry[k] = v
+        entries.append(entry)
     try:
         p = _manifest_path()
         p.parent.mkdir(parents=True, exist_ok=True)
@@ -136,7 +142,11 @@ def load_instance_manifest() -> list:
         return []
 
 
-def append_solo_instance(app, model: str, gmu=None, *, persist: bool = True) -> dict:
+_OVERRIDE_KEYS = ("served_model_name", "max_model_len", "kv_cache_dtype",
+                  "quantization", "trust_remote_code")
+
+
+def append_solo_instance(app, model: str, gmu=None, *, overrides=None, persist: bool = True) -> dict:
     """APPEND a solo instance through the InstanceManager — the shared core of the
     /api/models/load solo path AND the startup replay. Returns a plain dict (no
     HTTP). Each model gets its own container/port/config snapshot so several stack
@@ -175,6 +185,11 @@ def append_solo_instance(app, model: str, gmu=None, *, persist: bool = True) -> 
                           peer_ips=[], api_port=port)
     if gmu is not None:
         inst_config = replace(inst_config, gpu_memory_utilization=gmu)
+    if overrides:
+        allowed = {k: v for k, v in overrides.items()
+                   if k in _OVERRIDE_KEYS and v is not None}
+        if allowed:
+            inst_config = replace(inst_config, **allowed)
 
     def _clear():
         # routing-truth: a failed primary launch must stop the node advertising a
@@ -296,7 +311,7 @@ async def replay_instances_on_startup(app) -> None:
             # backend.start() shells out to docker — run off the event loop.
             res = await loop.run_in_executor(
                 None,
-                lambda mm=m, g=e.get("gpu_memory_utilization"): append_solo_instance(app, mm, g, persist=False),
+                lambda mm=m, g=e.get("gpu_memory_utilization"), ov={k: e[k] for k in _OVERRIDE_KEYS if k in e}: append_solo_instance(app, mm, g, overrides=ov, persist=False),
             )
             have.add(m)
             # Serialize: let this model bind before launching the next one.
@@ -354,6 +369,26 @@ async def handle_model_load(request: web.Request) -> web.Response:
             gmu = max(0.05, min(0.95, float(raw_gmu)))
         except (TypeError, ValueError):
             gmu = None
+
+    # Per-load config overrides applied to the per-instance snapshot only (NOT the
+    # shared app config). served_model_name = API alias(es); the rest let stacked
+    # models differ in context length / KV dtype / quant without cross-wiring.
+    overrides: dict = {}
+    smn = body.get("served_model_name")
+    if isinstance(smn, str):
+        smn = [smn]
+    if isinstance(smn, list) and smn:
+        overrides["served_model_name"] = [str(s) for s in smn if str(s).strip()]
+    if body.get("max_model_len") is not None:
+        try:
+            overrides["max_model_len"] = int(body["max_model_len"])
+        except (TypeError, ValueError):
+            pass
+    for k in ("kv_cache_dtype", "quantization"):
+        if body.get(k) is not None:
+            overrides[k] = body[k]
+    if body.get("trust_remote_code") is not None:
+        overrides["trust_remote_code"] = bool(body["trust_remote_code"])
 
     # Decide: single-node or distributed?
     sharding_config = None
@@ -428,7 +463,7 @@ async def handle_model_load(request: web.Request) -> web.Response:
     if config is None:
         return web.json_response({"error": "Engine not initialized"}, status=503)
 
-    result = append_solo_instance(request.app, model, gmu)
+    result = append_solo_instance(request.app, model, gmu, overrides=overrides)
     if not result.get("ok"):
         return web.json_response({"error": result.get("error")},
                                  status=result.get("status", 500))

--- a/tests/test_nvidia_backend.py
+++ b/tests/test_nvidia_backend.py
@@ -1092,7 +1092,8 @@ def test_solo_cmd_falls_back_to_repo_id_when_containerized_without_host_home(tmp
     b = NvidiaBackend(_make_config(model=model, models_dir=str(tmp_path)))
     cmd = b._build_solo_docker_cmd("c1")
     assert cmd[cmd.index("serve") + 1] == model        # repo-id, safe fallback
-    assert "--served-model-name" not in cmd
+    # served id is now explicitly pinned to the repo-id (stable /v1/models; aliasable)
+    assert cmd[cmd.index("--served-model-name") + 1] == model
 
 
 def test_solo_cmd_serves_repo_id_when_not_downloaded(tmp_path, monkeypatch):
@@ -1101,7 +1102,8 @@ def test_solo_cmd_serves_repo_id_when_not_downloaded(tmp_path, monkeypatch):
     cmd = b._build_solo_docker_cmd("c1")
     i = cmd.index("serve")
     assert cmd[i + 1] == "Qwen/Qwen3.5-9B-AWQ"        # falls back to repo-id
-    assert "--served-model-name" not in cmd
+    # served id now explicitly pinned to the repo-id (was implicit before)
+    assert cmd[cmd.index("--served-model-name") + 1] == "Qwen/Qwen3.5-9B-AWQ"
 
 
 def test_solo_cmd_host_paths_the_mount_sources(tmp_path, monkeypatch):

--- a/tests/test_vllm_args.py
+++ b/tests/test_vllm_args.py
@@ -28,8 +28,28 @@ def test_kv_dtype_escape_hatch():
     assert "--kv-cache-dtype" not in _args(1, kv_cache_dtype="")
 
 
+def _name_args(**cfg):
+    # an off-disk model -> remote path, no filesystem dependency
+    c = NodeConfig(node_id="t", node_name="T", model="some-org/not-on-disk", **cfg)
+    _target, args = NvidiaBackend(c)._serve_target_and_name_args()
+    return args
+
+
+def test_served_name_defaults_to_model():
+    # no alias -> pin the repo-id so /v1/models is stable
+    assert _name_args() == ["--served-model-name", "some-org/not-on-disk"]
+
+
+def test_served_name_aliases_emitted():
+    # custom aliases -> client can address the model by a short name; multiple supported
+    args = _name_args(served_model_name=["Aegis-14B", "Aegis-7B"])
+    assert args == ["--served-model-name", "Aegis-14B", "Aegis-7B"]
+
+
 if __name__ == "__main__":
     test_fp8_kv_and_tp_land()
     test_enforce_eager_always_on()
     test_kv_dtype_escape_hatch()
+    test_served_name_defaults_to_model()
+    test_served_name_aliases_emitted()
     print("ok")


### PR DESCRIPTION
## Launch-path: served-model-name aliases + per-load config overrides

Closes the gap that made me reach for raw `docker run` to serve fleet models — which left the cluster dashboard blind to four running models. An audit (multi-agent workflow over the launch path) found the bypass was **largely avoidable**: AInode already auto-applies `--enforce-eager`, auto-detects NVFP4 and sets the GB10 MARLIN env, and loads non-catalog/local models. The **one real recurring gap was custom served-model-name aliasing**. This PR closes it.

### Changes
- **`served_model_name: Optional[List[str]]`** on `NodeConfig`. Parsed from `/api/models/load`; emitted as `--served-model-name a b c` on **both** the local-mount and the remote-download paths (previously: one name on local-only, none on remote), falling back to `config.model`. A client/router can now address a model by a short alias (e.g. `Aegis-14B` **and** `Aegis-7B`) instead of the repo-id/slug.
- **Per-load overrides** for `max_model_len` / `kv_cache_dtype` / `quantization` / `trust_remote_code`, threaded through the per-instance config snapshot (generalizing the existing gmu-only knob) and **persisted in the replay manifest** — so a 16k-context model stacks beside a 4k one without mutating global config, and it survives restart.

### Tests
- New: alias defaults to repo-id; multiple aliases emitted.
- Updated: two remote-path tests that asserted "no `--served-model-name`" now assert the repo-id is explicitly pinned (functionally identical default; aliasable). **62 passed.**

### Follow-ups (filed, not in scope)
- `--attention-backend` as a CLI flag (the env var is a documented no-op; `--enforce-eager` is the actual GB10 fix).
- Arbitrary absolute local model paths (the slug-dir convention covers the current fleet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
