### PR TITLE
fix(web): pause the 5s view re-render while the user is interacting (no more flicker)

### DIFF
--- a/ainode/web/static/js/app.js
+++ b/ainode/web/static/js/app.js
@@ -313,6 +313,12 @@ const AINode = {
     this.updateClusterHero();
     this.updateChatModelSelect();
 
+    // Don't rebuild the view + right panel out from under an active interaction
+    // (dragging a node pill, selecting text to copy, a mid-click) — that 5s flicker
+    // was wiping clicks/selection. State is already updated above, so the next idle
+    // tick renders fresh.
+    if (this._userBusy()) return;
+
     // Preserve scroll position of the main content area across periodic
     // re-renders — the 5s poll was rebuilding innerHTML and bouncing the
     // user back to the top of long lists.
@@ -365,8 +371,23 @@ const AINode = {
     }
   },
 
+  // True while the user is actively interacting, so the periodic poll doesn't
+  // rebuild the DOM mid-action (drag / text-selection / just-clicked).
+  _userBusy() {
+    if (this._pointerDown) return true;
+    if (this._lastInteract && (Date.now() - this._lastInteract) < 1200) return true;
+    try { if (String(window.getSelection())) return true; } catch (_) {}
+    return false;
+  },
+
   startPolling() {
     var self = this;
+    // Track active interaction so the poll won't rebuild the DOM out from under it.
+    if (!this._interactionWired) {
+      this._interactionWired = true;
+      document.addEventListener('pointerdown', function () { self._pointerDown = true; self._lastInteract = Date.now(); }, true);
+      document.addEventListener('pointerup', function () { self._pointerDown = false; self._lastInteract = Date.now(); }, true);
+    }
     // Status + nodes every 5s
     this.state.pollInterval = setInterval(function () { self.refresh(); }, 5000);
     // Metrics every 3s


### PR DESCRIPTION
**Symptom:** every page "constantly refreshes" — the 5s status poll (`refresh()`) rebuilds the active view **and** the right panel via `innerHTML` on each tick, wiping an in-progress **drag** (node pills), **text selection**, or a **click** (you can't reliably select/copy or drag).

**Fix:** add `_userBusy()` — true if a pointer is down, text is selected, or it's <1.2s since the last pointer event — and **skip the view/panel rebuild in `refresh()` while busy**. State is still fetched each tick, so the next idle tick renders fresh; lightweight chrome (topbar/cluster hero) keeps updating live. Mirrors the spirit of the Downloads view's existing render-once guard, applied to the whole poll.

Frontend-only (`app.js`), `node --check` clean. Takes effect on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)