### PR TITLE
feat(training): AutoData close-loop — dashboard panel + verify-mode judge

### DIFF
--- a/ainode/training/api_routes.py
+++ b/ainode/training/api_routes.py
@@ -16,6 +16,7 @@ from ainode.training.engine import (
 def setup_training_routes(app: web.Application, manager: TrainingManager) -> None:
     """Register training API routes on the aiohttp app."""
     app["training_manager"] = manager
+    app["autodata_runs"] = {}  # run_id -> status dict (in-memory; MVP)
 
     app.router.add_post("/api/training/jobs", handle_submit_job)
     app.router.add_get("/api/training/jobs", handle_list_jobs)
@@ -30,6 +31,8 @@ def setup_training_routes(app: web.Application, manager: TrainingManager) -> Non
     app.router.add_get("/api/training/templates", handle_templates)
     app.router.add_get("/api/training/stats", handle_stats)
     app.router.add_post("/api/training/estimate", handle_estimate)
+    app.router.add_post("/api/training/autodata", handle_autodata_run)
+    app.router.add_get("/api/training/autodata/{run_id}", handle_autodata_status)
 
 
 async def handle_templates(_request: web.Request) -> web.Response:
@@ -213,7 +216,6 @@ async def handle_get_logs(request: web.Request) -> web.Response:
 
 async def handle_get_output(request: web.Request) -> web.Response:
     """GET /api/training/jobs/:job_id/output — list artifact files from the output dir."""
-    import os
     manager: TrainingManager = request.app["training_manager"]
     job_id = request.match_info["job_id"]
 
@@ -513,3 +515,102 @@ async def handle_save_template(request: web.Request) -> web.Response:
         pass  # in-memory fallback is fine
 
     return web.json_response(template, status=201)
+
+
+# ---------------------------------------------------------------------------
+# AutoData — Δ-filtered synthetic-data generation -> registered dataset
+# ---------------------------------------------------------------------------
+# Closes the loop: an AutoData run (pure-HTTP, no torch) writes ShareGPT JSONL,
+# we register it with the DatasetManager, and the returned dataset_id drops
+# straight into a training job (POST /api/training/jobs {dataset_id}).
+
+
+async def handle_autodata_run(request: web.Request) -> web.Response:
+    """POST /api/training/autodata — start a background AutoData run.
+
+    Body: {config: {AutoData config}, meta?: bool, target_yield?, max_rounds?,
+    name?, description?}. Returns 202 + run_id; poll GET /api/training/autodata/{run_id}.
+    The run executes in a thread (it's blocking HTTP I/O) so the event loop never stalls.
+    """
+    import asyncio
+    import uuid
+    from pathlib import Path as _Path
+
+    from ainode.training.autodata.core import AutoDataConfig
+
+    dsm = request.app.get("dataset_manager")
+    if dsm is None:
+        return web.json_response({"error": "Dataset manager unavailable"}, status=503)
+
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "Invalid JSON body"}, status=400)
+
+    config = body.get("config")
+    if not isinstance(config, dict):
+        return web.json_response({"error": "config (object) is required"}, status=400)
+    try:
+        cfg = AutoDataConfig.from_dict(config)
+    except Exception as exc:
+        return web.json_response({"error": f"Invalid AutoData config: {exc}"}, status=400)
+
+    is_meta = bool(body.get("meta"))
+    target_yield = float(body.get("target_yield", 30))
+    max_rounds = int(body.get("max_rounds", 4))
+
+    run_id = uuid.uuid4().hex[:12]
+    # Write under the dataset store so add_local registers it in place (and the
+    # resulting absolute path satisfies TrainingConfig's datasets-dir guard).
+    out_path = _Path(dsm.root) / f"autodata-{run_id}.jsonl"
+    cfg.out = str(out_path)
+    name = (body.get("name") or f"autodata-{run_id}").strip()
+    description = body.get("description") or "AutoData Δ-filtered synthetic dataset"
+
+    runs = request.app["autodata_runs"]
+    runs[run_id] = {
+        "run_id": run_id, "status": "running", "meta": is_meta,
+        "dataset_id": None, "report": None, "rounds": None,
+        "out": str(out_path), "error": None,
+    }
+
+    loop = asyncio.get_event_loop()
+
+    async def _do_run() -> None:
+        try:
+            def _blocking() -> dict:
+                if is_meta:
+                    from ainode.training.autodata.meta import meta_optimize
+                    res = meta_optimize(cfg, target_yield=target_yield, max_rounds=max_rounds)
+                    report = {"kept": len(res["dataset"]), "best_yield": res["best_yield"],
+                              "rounds": len(res["rounds"])}
+                    return {"report": report, "rounds": res["rounds"]}
+                from ainode.training.autodata.core import run as _run
+                res = _run(cfg)
+                return {"report": res["report"], "rounds": None}
+
+            result = await loop.run_in_executor(None, _blocking)
+            ds = dsm.add_local(str(out_path), name=name, description=description) \
+                if out_path.exists() else None
+            runs[run_id].update(
+                status="completed", dataset_id=(ds.id if ds else None),
+                report=result["report"], rounds=result["rounds"],
+            )
+        except Exception as exc:  # noqa: BLE001 — surface any run failure to the poller
+            runs[run_id].update(status="failed", error=str(exc))
+
+    loop.create_task(_do_run())
+    return web.json_response(
+        {"run_id": run_id, "status": "running",
+         "poll": f"/api/training/autodata/{run_id}"},
+        status=202,
+    )
+
+
+async def handle_autodata_status(request: web.Request) -> web.Response:
+    """GET /api/training/autodata/{run_id} — poll an AutoData run."""
+    runs = request.app.get("autodata_runs", {})
+    run = runs.get(request.match_info["run_id"])
+    if run is None:
+        return web.json_response({"error": "AutoData run not found"}, status=404)
+    return web.json_response(run)

--- a/ainode/training/autodata/core.py
+++ b/ainode/training/autodata/core.py
@@ -37,7 +37,7 @@ class AutoDataConfig:
     judge: Endpoint
     n_tasks: int = 50
     system_prompt: str = ""        # optional system msg for solvers + emitted data
-    judge_mode: str = "rubric"     # "rubric" (LLM) or "exact" (string match vs reference)
+    judge_mode: str = "rubric"     # "rubric" (LLM), "verify" (math/numeric, rubric fallback), or "exact" (substring)
     concurrency: int = 8
     retries: int = 2               # transient HTTP/parse retries per model call
     out: str = ""                  # JSONL output path (optional)
@@ -115,7 +115,15 @@ def solve(ep: Endpoint, system: str, x: str, retries: int = 2) -> str:
 
 def judge_correct(cfg: AutoDataConfig, x: str, output: str, reference) -> int:
     """1 if `output` is correct for task `x`, else 0."""
-    if cfg.judge_mode == "exact" and reference:
+    if cfg.judge_mode == "verify":
+        # Torch-free value verifier (math/numeric): definitive on parseable answers, None on
+        # open-ended/symbolic → fall through to the LLM rubric below. Fixes the thin-ZPD where
+        # exact-match misgraded formatting variants (0.5 vs 1/2) as wrong.
+        from .verify import is_correct
+        v = is_correct(output, reference)
+        if v is not None:
+            return int(v)
+    elif cfg.judge_mode == "exact" and reference:
         return int(_norm(reference) in _norm(output))
     ref = f"\n\nReference answer:\n{reference}" if reference else ""
     prompt = (f"Task:\n{x}\n\nCandidate answer:\n{output}{ref}\n\n"
@@ -220,7 +228,27 @@ def demo() -> None:
         assert rep["too_easy"] == 1, rep        # TASK_B
         assert rep["too_hard"] == 1, rep        # TASK_C
         assert out["kept"][0]["conversations"][-1]["value"] == "A", out["kept"]
-        print("autodata demo OK:", rep)
+
+        # verify-mode: the strong solver returns the RIGHT VALUE in a different FORMAT ("1/2"
+        # for reference "0.5"). exact-match misgrades it (-> too_hard); the verifier keeps it.
+        def fake_num(ep, messages, json_mode):
+            last = messages[-1]["content"]
+            if json_mode and "Generate" in last:
+                return json.dumps({"tasks": [{"input": "HALF", "reference": "0.5"}]})
+            if json_mode and "Candidate answer" in last:   # rubric (not reached for clean numeric)
+                return json.dumps({"correct": False})
+            return "1/2" if ep.model == "strong" else "999"
+        call_model = fake_num
+        base = dict(task_spec="x", gen_prompt="x", n_tasks=1, concurrency=1,
+                    challenger=Endpoint("u", "challenger"), weak=Endpoint("u", "weak"),
+                    strong=Endpoint("u", "strong"), judge=Endpoint("u", "judge"))
+        exact = run(AutoDataConfig(judge_mode="exact", **base))["report"]
+        ver = run(AutoDataConfig(judge_mode="verify", **base))["report"]
+        assert exact["kept"] == 0 and exact["too_hard"] == 1, exact   # format variant lost
+        assert ver["kept"] == 1 and ver["too_hard"] == 0, ver         # verifier recovers it
+        print("autodata demo OK:", rep,
+              "| signal shift exact->verify: kept", exact["kept"], "->", ver["kept"],
+              "too_hard", exact["too_hard"], "->", ver["too_hard"])
     finally:
         call_model = _http_chat
 

--- a/ainode/training/autodata/verify.py
+++ b/ainode/training/autodata/verify.py
@@ -1,0 +1,101 @@
+"""Torch-free correctness verifier — numeric/math equivalence over brittle substring match.
+
+The v1 Δ-filter graded "exact" by substring (`reference in output`), which misgrades any
+formatting variant ("0.5" vs "1/2", "x = 2" vs "2", "\\frac{3}{4}" vs "0.75"). That brittle
+check is the documented root cause of the *thin ZPD*: real correct answers get marked wrong,
+inflating `too_hard` and starving the Δ=1 yield. This grades the VALUE, not the string.
+
+ponytail: stdlib only (`fractions` + `re`) — no new dependency, so the slim orchestrator's
+no-torch property holds by construction. Handles numbers, fractions, percents, simple
+"x = V" / "answer: V" equations, whitespace, and light LaTeX. Ceiling: full symbolic algebra
+(trig, multivariable, inequalities, sqrt) returns None → caller falls back to the LLM rubric;
+swap in math-verify (sympy) for that, deferred to Slice 2b. See demo() at the bottom.
+"""
+from __future__ import annotations
+
+import re
+from fractions import Fraction
+
+
+def _strip_latex(s: str) -> str:
+    s = str(s).strip()
+    s = re.sub(r"^\$+|\$+$", "", s)                                   # $...$
+    for a, b in ((r"\(", ""), (r"\)", ""), (r"\[", ""), (r"\]", "")):  # \(...\) \[...\]
+        s = s.replace(a, b)
+    s = re.sub(r"\\d?frac\s*\{([^{}]+)\}\s*\{([^{}]+)\}", r"(\1)/(\2)", s)  # \frac{a}{b}->a/b
+    s = s.replace(r"\times", "*").replace(r"\cdot", "*").replace("\\", "")
+    return s.strip()
+
+
+def _rhs(s: str) -> str:
+    """Pull the answer value out of an equation/label: 'x = 2' -> '2', 'boxed{2}' -> '2'."""
+    m = re.search(r"boxed\{([^{}]+)\}", s)
+    if m:
+        return m.group(1).strip()
+    for sep in ("=", ":"):
+        if sep in s:
+            s = s.split(sep)[-1]
+    return s.strip()
+
+
+def _frac(x: str) -> Fraction:
+    return Fraction(x.strip().strip("()").strip())
+
+
+def _to_number(s: str):
+    """Best-effort parse to a Fraction; None if not a clean single number."""
+    t = _rhs(_strip_latex(s)).strip().rstrip(".").replace(",", "").replace(" ", "")
+    if not t:
+        return None
+    pct = t.endswith("%")
+    if pct:
+        t = t[:-1]
+    try:
+        val = _frac(t.split("/", 1)[0]) / _frac(t.split("/", 1)[1]) if "/" in t else _frac(t)
+    except (ValueError, ZeroDivisionError, IndexError):
+        try:
+            val = Fraction(float(t)).limit_denominator(10 ** 9)   # 1e3, 3.0, ...
+        except (ValueError, OverflowError):
+            return None
+    return val / 100 if pct else val
+
+
+def _norm_text(s) -> str:
+    return " ".join(_strip_latex("" if s is None else s).lower().split())
+
+
+def is_correct(output: str, reference) -> "bool | None":
+    """True/False when a comparison can be made confidently; None when it can't, so the caller
+    falls back to the LLM rubric. Conservative on purpose: it only ever turns a formatting-variant
+    CORRECT answer back into a pass (killing the false-negatives that inflate too_hard); it never
+    invents a new false-negative — anything it can't cleanly judge defers to the rubric."""
+    if reference is None or str(reference).strip() == "":
+        return None
+    b = _to_number(str(reference))
+    if b is not None:
+        a = _to_number(output)
+        return (a == b) if a is not None else None   # numeric ref: judge only clean-numeric output
+    na, nb = _norm_text(output), _norm_text(reference)
+    if not na or not nb:
+        return None
+    return True if (na == nb or nb in na) else None   # text: positive call only; else rubric
+
+
+def demo() -> None:
+    """Self-check: equivalence the old substring check would have failed."""
+    assert is_correct("1/2", "0.5") is True
+    assert is_correct("x = 2", "2") is True
+    assert is_correct("50%", "0.5") is True
+    assert is_correct(r"\frac{3}{4}", "0.75") is True
+    assert is_correct("$0.5$", "1/2") is True
+    assert is_correct("1,000", "1000") is True
+    assert is_correct("7", "8") is False                  # genuinely-different numbers -> wrong
+    assert is_correct("paris", None) is None              # no reference -> rubric fallback
+    assert is_correct("The answer is 2.", "2") is None    # prose around a number -> rubric (conservative)
+    assert is_correct(r"\sqrt{4}", "2") is None           # symbolic -> rubric fallback (ceiling)
+    assert is_correct("london", "paris") is None          # wrong text -> rubric decides, not a false-neg
+    print("autodata verify demo OK")
+
+
+if __name__ == "__main__":
+    demo()

--- a/ainode/web/static/js/app.js
+++ b/ainode/web/static/js/app.js
@@ -229,6 +229,9 @@ const AINode = {
     if (view === 'downloads' && prevView !== 'downloads') {
       this._downloadsViewInitialized = false;  // force full render on entry
     }
+    if (view === 'training' && prevView !== 'training') {
+      this._autodataViewInitialized = false;   // force full render of the AutoData panel on entry
+    }
     // Update nav pill active state
     document.querySelectorAll('.nav-pill').forEach(function (el) {
       el.classList.toggle('active', el.dataset.view === view);
@@ -2869,6 +2872,7 @@ const AINode = {
     var tab = this.state.trainingTab || 'overview';
     var items = [
       { id: 'overview',   label: 'Overview',   icon: '&#9711;' },
+      { id: 'autodata',   label: 'AutoData',   icon: '&#9883;' },
       { id: 'datasets',   label: 'Datasets',   icon: '&#8864;' },
       { id: 'runs',       label: 'Runs',       icon: '&#9873;' },
       { id: 'templates',  label: 'Templates',  icon: '&#9641;' },
@@ -2932,6 +2936,7 @@ const AINode = {
         self.state.trainingTab = btn.dataset.tab;
         self.state.trainingView = 'list';
         self.state.trainingDetailId = null;
+        self._autodataViewInitialized = false;  // full-render the AutoData panel on (re)entry
         self.renderTrainingSidebar();
         self.renderTraining();
       });
@@ -2994,6 +2999,12 @@ const AINode = {
 
     switch (tab) {
       case 'overview':   this.renderTrainingOverview(container); break;
+      case 'autodata':
+        // Mirror the downloads-view guard: full render on entry, then the 5s poll
+        // leaves the panel alone (the run has its own poller) so the form never flickers.
+        if (this._autodataViewInitialized) { /* in place — _pollAutoData owns #autodata-status */ }
+        else { this._autodataViewInitialized = true; this.renderTrainingAutoData(container); }
+        break;
       case 'datasets':   this.renderTrainingDatasets(container); break;
       case 'runs':       this.renderTrainingRuns(container); break;
       case 'templates':  this.renderTrainingTemplates(container); break;
@@ -3109,6 +3120,172 @@ const AINode = {
         self.renderTraining();
       });
     });
+  },
+
+  // ---- AutoData ----------------------------------------------------------
+  // Δ-filtered synthetic-data generation over four AInode-served models. The run
+  // executes server-side and calls back into the federated /v1 proxy, so every
+  // role endpoint is this server's own loopback + the picked served-model-name.
+  renderTrainingAutoData(container) {
+    var self = this;
+    var models = this.state.fleetModels || [];
+    var opts = models.map(function (m) {
+      return '<option value="' + self.esc(m) + '">' + self.esc(m) + '</option>';
+    }).join('');
+    var role = function (key, label, hint) {
+      return '<div class="form-group"><label class="form-label">' + label + '</label>' +
+        '<select id="ad-' + key + '" class="form-input">' + opts + '</select>' +
+        (hint ? '<div class="form-hint">' + hint + '</div>' : '') + '</div>';
+    };
+
+    container.innerHTML =
+      '<div class="training-overview">' +
+        '<div class="dataset-toolbar"><div>' +
+          '<h2 style="font-size:18px;font-weight:700">AutoData</h2>' +
+          '<p style="font-size:12.5px;color:var(--text-muted);margin-top:4px">Generate synthetic training data from your loaded models. The Challenger writes tasks, a weak and a strong solver answer them, and the Judge keeps only what the strong model gets right and the weak one misses — the result lands in Datasets, ready to train on.</p>' +
+        '</div></div>' +
+        (models.length ? '' : '<div class="form-hint" style="margin-bottom:10px">No models loaded — load at least one model (Models tab) so the four roles have an endpoint to call.</div>') +
+        '<div class="quantize-panel">' +
+          '<div class="form-grid">' +
+            role('challenger', 'Challenger (writes tasks)', 'A strong, creative model') +
+            role('weak', 'Weak solver', 'Smaller/faster — should miss the hard ones') +
+            role('strong', 'Strong solver', 'The teacher — its answers become the data') +
+            role('judge', 'Judge (grades answers)', '') +
+          '</div>' +
+          '<div class="form-group" style="margin-top:8px"><label class="form-label">Task spec</label>' +
+            '<textarea id="ad-task-spec" class="form-input" rows="2" placeholder="e.g. Challenging grade-school math word problems with a single numeric answer."></textarea></div>' +
+          '<div class="form-group"><label class="form-label">Generator prompt (Challenger system prompt)</label>' +
+            '<textarea id="ad-gen-prompt" class="form-input" rows="2" placeholder="e.g. You are an expert problem author. Write diverse, unambiguous tasks."></textarea></div>' +
+          '<div class="form-grid">' +
+            '<div class="form-group"><label class="form-label"># Tasks</label><input type="number" id="ad-n-tasks" class="form-input" value="20" min="1" max="500"></div>' +
+            '<div class="form-group"><label class="form-label">Judge mode</label><select id="ad-judge-mode" class="form-input">' +
+              '<option value="rubric">Rubric (LLM grades)</option>' +
+              '<option value="verify">Verify (math/numeric, rubric fallback)</option>' +
+              '<option value="exact">Exact (substring match)</option>' +
+            '</select></div>' +
+            '<div class="form-group"><label class="form-label">Dataset name</label><input type="text" id="ad-name" class="form-input" placeholder="optional"></div>' +
+          '</div>' +
+          '<label class="form-label" style="display:block;margin-top:8px"><input type="checkbox" id="ad-meta"> Meta-optimize — rewrite the generator prompt over several rounds to lift yield</label>' +
+          '<button class="btn-nvidia" id="ad-run" style="margin-top:10px"' + (models.length ? '' : ' disabled') + '>Run AutoData &rsaquo;</button>' +
+        '</div>' +
+        '<div id="autodata-status" style="margin-top:14px"></div>' +
+      '</div>';
+
+    this._renderAutoDataStatus();  // restore an in-flight/last run if we re-entered the tab
+
+    var runBtn = container.querySelector('#ad-run');
+    if (runBtn) runBtn.addEventListener('click', function () { self._startAutoDataRun(container); });
+  },
+
+  async _startAutoDataRun(container) {
+    var self = this;
+    var val = function (sel) { var el = container.querySelector(sel); return el ? el.value.trim() : ''; };
+    var pick = function (sel) { var el = container.querySelector(sel); return el ? el.value : ''; };
+    var taskSpec = val('#ad-task-spec'), genPrompt = val('#ad-gen-prompt');
+    if (!taskSpec || !genPrompt) { self.toast('Task spec and generator prompt are required', 'error'); return; }
+    if (!pick('#ad-challenger')) { self.toast('Load at least one model first', 'error'); return; }
+    // ponytail: the federated /v1 proxy is this same server; loopback + the served-model-name
+    // routes to whichever node serves it. Assumes the default api_port when the port is blank.
+    var base = 'http://localhost:' + (window.location.port || '8000') + '/v1';
+    var ep = function (sel) { return { url: base, model: pick(sel) }; };
+    var body = {
+      config: {
+        task_spec: taskSpec, gen_prompt: genPrompt,
+        challenger: ep('#ad-challenger'), weak: ep('#ad-weak'),
+        strong: ep('#ad-strong'), judge: ep('#ad-judge'),
+        n_tasks: parseInt(val('#ad-n-tasks'), 10) || 20,
+        judge_mode: pick('#ad-judge-mode'),
+      },
+      meta: container.querySelector('#ad-meta').checked,
+    };
+    var name = val('#ad-name');
+    if (name) body.name = name;
+
+    var runBtn = container.querySelector('#ad-run');
+    runBtn.disabled = true; runBtn.textContent = 'Starting…';
+    try {
+      var resp = await fetch('/api/training/autodata', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+      });
+      var data = await resp.json();
+      if (!resp.ok) {
+        self.toast('Error: ' + (data.error || 'Failed to start AutoData'), 'error');
+        runBtn.disabled = false; runBtn.textContent = 'Run AutoData ›'; return;
+      }
+      self.state.autodataRun = { run_id: data.run_id, status: 'running', meta: body.meta };
+      self.toast('AutoData run started', 'success');
+      self._renderAutoDataStatus();
+      self._pollAutoData();
+    } catch (e) {
+      self.toast('Network error: ' + e.message, 'error');
+      runBtn.disabled = false; runBtn.textContent = 'Run AutoData ›';
+    }
+  },
+
+  _pollAutoData() {
+    var self = this;
+    if (this._autodataPollTimer) clearTimeout(this._autodataPollTimer);
+    var tick = async function () {
+      var cur = self.state.autodataRun;
+      if (!cur || !cur.run_id) return;
+      var data = await self.fetchJSON('/api/training/autodata/' + encodeURIComponent(cur.run_id));
+      if (data) {
+        self.state.autodataRun = data;
+        self._renderAutoDataStatus();
+        if (data.status === 'completed' || data.status === 'failed') {
+          var btn = document.getElementById('ad-run');
+          if (btn) { btn.disabled = false; btn.textContent = 'Run AutoData ›'; }
+          if (data.status === 'completed' && data.dataset_id) {
+            // pull the new dataset into state so it shows up the moment they open Datasets
+            var ds = await self.fetchJSON('/api/datasets');
+            if (ds && ds.datasets) self.state.datasets = ds.datasets;
+            self._renderAutoDataStatus();
+          }
+          return;  // terminal — stop polling
+        }
+      }
+      self._autodataPollTimer = setTimeout(tick, 3000);
+    };
+    tick();
+  },
+
+  _renderAutoDataStatus() {
+    var el = document.getElementById('autodata-status');
+    if (!el) return;
+    var self = this;
+    var run = this.state.autodataRun;
+    if (!run) { el.innerHTML = ''; return; }
+    var card = function (inner) {
+      return '<div style="padding:14px 16px;background:var(--bg-card);border:1px solid var(--border);border-radius:10px;font-size:13px;line-height:1.6">' + inner + '</div>';
+    };
+    if (run.status === 'running') {
+      el.innerHTML = card('<span class="job-status-badge status-running">Running</span> Generating &amp; Δ-filtering tasks…' + (run.meta ? ' (meta-optimizing the generator prompt)' : ''));
+      return;
+    }
+    if (run.status === 'failed') {
+      el.innerHTML = card('<span class="job-status-badge status-failed">Failed</span> ' + self.esc(run.error || 'Unknown error'));
+      return;
+    }
+    if (run.status === 'completed') {
+      var r = run.report || {};
+      var stats = run.meta
+        ? 'Kept <strong>' + (r.kept != null ? r.kept : '—') + '</strong> &middot; best yield <strong>' +
+            (r.best_yield != null ? r.best_yield + '%' : '—') + '</strong> &middot; <strong>' + (r.rounds != null ? r.rounds : '—') + '</strong> rounds'
+        : 'Kept <strong>' + (r.kept != null ? r.kept : '—') + '</strong> of <strong>' + (r.total != null ? r.total : '—') +
+            '</strong> &middot; yield <strong>' + (r.yield_pct != null ? r.yield_pct + '%' : '—') + '</strong> ' +
+            '<span class="muted">(too-easy ' + (r.too_easy || 0) + ' &middot; too-hard ' + (r.too_hard || 0) + ' &middot; errors ' + (r.errors || 0) + ')</span>';
+      var tail = run.dataset_id
+        ? '<div style="margin-top:10px"><button class="btn-nvidia" id="ad-goto-dataset">Open in Datasets &rsaquo;</button></div>'
+        : '<div style="margin-top:10px" class="muted">No rows kept — nothing to save. Try more tasks, or pick a wider weak/strong gap.</div>';
+      el.innerHTML = card('<span class="job-status-badge status-completed">Completed</span> ' + stats + tail);
+      var goto = document.getElementById('ad-goto-dataset');
+      if (goto) goto.addEventListener('click', function () {
+        self.state.trainingTab = 'datasets';
+        self._autodataViewInitialized = false;
+        self.renderTrainingSidebar();
+        self.renderTraining();
+      });
+    }
   },
 
   // ---- Datasets ----------------------------------------------------------

--- a/tests/test_autodata.py
+++ b/tests/test_autodata.py
@@ -1,0 +1,186 @@
+"""Tests for ainode.training.autodata — the self-check demos + the loop-closing route.
+
+The demos assert internally (they raise on failure), so collecting them here puts the
+Δ-filter and meta-optimizer logic under CI. The route test proves the whole loop:
+run -> registered dataset -> dataset_id accepted by a training job.
+"""
+
+import asyncio
+import json
+
+import pytest
+import pytest_asyncio
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from ainode.training.autodata import core, meta
+from ainode.training.autodata.core import AutoDataConfig, Endpoint, run
+from ainode.training.autodata.verify import is_correct
+from ainode.training.engine import TrainingManager
+from ainode.training.api_routes import setup_training_routes
+from ainode.datasets.manager import DatasetManager
+from ainode.datasets.api_routes import setup_dataset_routes
+
+
+def test_core_demo():
+    core.demo()  # asserts internally: only the strong-solves/weak-fails task survives
+
+
+def test_verify_demo():
+    from ainode.training.autodata import verify
+    verify.demo()  # asserts internally: equivalence the old substring check failed
+
+
+# Answers that are CORRECT but reformatted — the verifier must grade every one right.
+@pytest.mark.parametrize("output, reference", [
+    ("1/2", "0.5"),
+    ("0.5", "1/2"),
+    ("x = 2", "2"),
+    ("  2  ", "2"),
+    (r"\frac{3}{4}", "0.75"),
+    ("$0.5$", "1/2"),
+    ("50%", "0.5"),
+    ("1,000", "1000"),
+])
+def test_verify_grades_reformatted_answers(output, reference):
+    assert is_correct(output, reference) is True
+
+
+# The subset where the reference digits are NOT a literal substring of the output — exact
+# substring-match genuinely MISgrades these (the thin-ZPD root cause); the verifier fixes them.
+@pytest.mark.parametrize("output, reference", [
+    ("1/2", "0.5"),
+    (r"\frac{3}{4}", "0.75"),
+    ("$0.5$", "1/2"),
+    ("50%", "0.5"),
+    ("1,000", "1000"),
+])
+def test_verify_beats_exact_on_true_conversions(output, reference):
+    def _norm(s):
+        return " ".join(str(s).lower().split())
+    assert _norm(reference) not in _norm(output)   # exact-match would mark this WRONG
+    assert is_correct(output, reference) is True    # ...the verifier marks it RIGHT
+
+
+def test_verify_marks_genuinely_wrong_and_defers_open_ended():
+    assert is_correct("7", "8") is False           # different numbers -> wrong
+    assert is_correct("paris", None) is None       # no reference -> rubric
+    assert is_correct(r"\sqrt{4}", "2") is None    # symbolic -> rubric (ceiling, no false-neg)
+
+
+def test_signal_shift_exact_vs_verify(capsys):
+    """Re-measurement: SAME tasks, exact vs verify. Strong returns the right value in a
+    different format, weak is wrong -> exact buries them in too_hard; verify recovers Δ=1."""
+    def fake(ep, messages, json_mode):
+        last = messages[-1]["content"]
+        if json_mode and "Generate" in last:
+            return json.dumps({"tasks": [
+                {"input": "Q1", "reference": "0.5"},
+                {"input": "Q2", "reference": "0.75"},
+                {"input": "Q3", "reference": "0.25"}]})
+        if json_mode and "Candidate answer" in last:       # rubric (unused for clean numerics)
+            return json.dumps({"correct": False})
+        if ep.model != "strong":
+            return "0"                                      # weak: wrong
+        # right value, different format — reference digits are NOT a substring of these
+        return {"Q1": "1/2", "Q2": r"\frac{3}{4}", "Q3": "1/4"}.get(last, "0")
+
+    core.call_model = fake
+    try:
+        base = dict(task_spec="x", gen_prompt="x", n_tasks=3, concurrency=1,
+                    challenger=Endpoint("u", "challenger"), weak=Endpoint("u", "weak"),
+                    strong=Endpoint("u", "strong"), judge=Endpoint("u", "judge"))
+        exact = run(AutoDataConfig(judge_mode="exact", **base))["report"]
+        ver = run(AutoDataConfig(judge_mode="verify", **base))["report"]
+    finally:
+        core.call_model = core._http_chat
+
+    print(f"\nsignal shift  exact: kept={exact['kept']} too_hard={exact['too_hard']}"
+          f"  ->  verify: kept={ver['kept']} too_hard={ver['too_hard']}")
+    assert exact["kept"] == 0 and exact["too_hard"] == 3   # format variants buried as too-hard
+    assert ver["kept"] == 3 and ver["too_hard"] == 0       # verifier recovers all three
+    assert ver["kept"] > exact["kept"] and ver["too_hard"] < exact["too_hard"]
+
+
+def test_meta_demo():
+    meta.demo()  # asserts internally: yield rises round-over-round to the harder prompt
+
+
+def _fake(ep, messages, json_mode):
+    """3 tasks: A (only strong solves -> kept), B (both solve), C (neither)."""
+    last = messages[-1]["content"]
+    if json_mode and "Generate" in last:                       # challenger
+        return json.dumps({"tasks": [
+            {"input": "TASK_A", "reference": "A"},
+            {"input": "TASK_B", "reference": "B"},
+            {"input": "TASK_C", "reference": "C"}]})
+    if json_mode and "Candidate answer" in last:               # judge
+        return json.dumps({"correct": "WRONG" not in last})
+    strong = ep.model == "strong"                              # solver
+    if last == "TASK_A":
+        return "A" if strong else "WRONG"
+    if last == "TASK_B":
+        return "B"
+    return "WRONG"                                             # TASK_C: both wrong
+
+
+@pytest_asyncio.fixture
+async def client(tmp_path):
+    app = web.Application()
+    dsm = DatasetManager(root=tmp_path / "datasets")
+    app["dataset_manager"] = dsm
+    setup_training_routes(app, TrainingManager(dataset_manager=dsm))
+    setup_dataset_routes(app, dsm)
+    async with TestClient(TestServer(app)) as c:
+        yield c, dsm
+
+
+@pytest.mark.asyncio
+async def test_autodata_route_closes_the_loop(client, monkeypatch):
+    c, dsm = client
+    monkeypatch.setattr(core, "call_model", _fake)  # seen by the background run thread too
+
+    cfg = {
+        "task_spec": "x", "gen_prompt": "x", "n_tasks": 3, "concurrency": 1,
+        "challenger": {"url": "u", "model": "challenger"},
+        "weak": {"url": "u", "model": "weak"},
+        "strong": {"url": "u", "model": "strong"},
+        "judge": {"url": "u", "model": "judge"},
+    }
+    resp = await c.post("/api/training/autodata", json={"config": cfg})
+    assert resp.status == 202
+    run_id = (await resp.json())["run_id"]
+
+    # poll to completion (background run; fake model is instant)
+    data = None
+    for _ in range(200):
+        data = await (await c.get(f"/api/training/autodata/{run_id}")).json()
+        if data["status"] in ("completed", "failed"):
+            break
+        await asyncio.sleep(0.02)
+    assert data["status"] == "completed", data
+
+    ds_id = data["dataset_id"]
+    assert ds_id, data
+    assert data["report"]["kept"] == 1            # only TASK_A survives the Δ-filter
+
+    # registered, resolvable, and listed via the real dataset API
+    assert dsm.get(ds_id) is not None
+    assert dsm.get(ds_id).samples == 1            # samples == kept count
+    listing = await (await c.get("/api/datasets")).json()
+    assert any(d["id"] == ds_id for d in listing["datasets"])
+
+    # and the dataset_id is directly usable as a training job's input
+    job_resp = await c.post("/api/training/jobs", json={
+        "base_model": "meta-llama/Llama-3.2-3B-Instruct",
+        "dataset_id": ds_id, "method": "lora",
+    })
+    assert job_resp.status == 201, await job_resp.text()
+
+
+@pytest.mark.asyncio
+async def test_autodata_route_rejects_bad_body(client):
+    c, _ = client
+    resp = await c.post("/api/training/autodata", json={"meta": True})  # no config
+    assert resp.status == 400
+    assert (await c.get("/api/training/autodata/nope")).status == 404   # unknown run, not a crash


### PR DESCRIPTION
## What

Closes the AutoData loop so a human runs it **from the dashboard** — pick four models, launch, watch, get a trainable dataset — no curl/JSON.

- **API route** `POST/GET /api/training/autodata` — background Δ-filter run that registers the produced ShareGPT JSONL as a dataset; the returned `dataset_id` drops straight into a training job.
- **verify-mode judge** — torch-free numeric/math equivalence verifier (`verify.py`) that recovers formatting-variant correct answers the old substring check misgraded (`0.5` vs `1/2`, `x=2` vs `2`, `\frac{3}{4}` vs `0.75`), widening the thin-ZPD yield. Falls back to the LLM rubric on anything it can't cleanly judge.
- **Training-view AutoData panel** (`app.js`) — four role pickers (challenger/weak/strong/judge) populated from the loaded-model list, plus `task_spec`, `gen_prompt`, `n_tasks`, `judge_mode` (incl. `verify`), and a meta toggle. Run → poll → report; resulting dataset linked into the Datasets list. Follows the `_downloadsViewInitialized` guard so the 5s poll never rebuilds the panel (no flicker).
- **Tests** (`tests/test_autodata.py`) — route (loop-closing) + verifier + meta self-checks.

## Verification

- `python3 -m ainode.training.autodata.core` → self-check green (`kept:1, errors:0`; signal shift exact→verify: `kept 0→1, too_hard 1→0`).
- `python3 -m ainode.training.autodata.verify` → self-check green.
- **UI driven end-to-end in a headless browser** against the real `app.js`: panel renders (4 pickers × loaded models, judge_mode incl. `verify`, meta toggle); Run POSTs the exact `{config, meta}` contract; status polls Running→Completed with report; the produced dataset appears in Datasets ("Use in Run"); empty-field validation blocks the POST; anti-flicker guard confirmed (panel survives a 5s `refresh()` tick with `_userBusy()==false`); zero JS console errors.
- Full `pytest tests/` (aiohttp route test) runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)