### PR TITLE
feat(training): wire Merge/Resume/Download in job detail; remove dead code

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install
+        run: pip install -e ".[dev]"
+      - name: Ruff
+        run: ruff check .
+      - name: Pytest
+        run: pytest tests/ -q

--- a/ainode/api/server.py
+++ b/ainode/api/server.py
@@ -771,7 +771,8 @@ def _routing_candidates(cluster, model: str, local_node_id: str, local_port: int
         seen = set()
         # The node's primary/solo model is served on its main api_port.
         if getattr(n, "model", "") == model and node_port not in seen:
-            bucket.append((host, node_port)); seen.add(node_port)
+            bucket.append((host, node_port))
+            seen.add(node_port)
         # Each stacked instance is served on its OWN port — a co-resident 2nd
         # model on this node lives at :8001, not the node's main :8000.
         for inst in (getattr(n, "instances", []) or []):
@@ -779,7 +780,8 @@ def _routing_candidates(cluster, model: str, local_node_id: str, local_port: int
                 continue
             iport = inst.get("api_port") or node_port
             if iport not in seen:
-                bucket.append((host, iport)); seen.add(iport)
+                bucket.append((host, iport))
+                seen.add(iport)
     return local + remote
 
 
@@ -1309,14 +1311,14 @@ async def handle_set_model(request: web.Request) -> web.Response:
 
 async def handle_version_check(request: web.Request) -> web.Response:
     """GET /api/version/check — compare local version against latest GHCR tag."""
-    import subprocess as _sp
     current = __version__
     try:
         # Ask the registry for the digest of :latest, then find which
         # version tag matches. We do this without auth (public image).
         loop = asyncio.get_event_loop()
         def _fetch():
-            import urllib.request, json as _json
+            import urllib.request
+            import json as _json
             token_url = "https://ghcr.io/token?service=ghcr.io&scope=repository:getainode/ainode:pull"
             with urllib.request.urlopen(token_url, timeout=5) as r:
                 token = _json.loads(r.read())["token"]
@@ -1374,7 +1376,7 @@ async def handle_engine_update(request: web.Request) -> web.Response:
         if result.returncode != 0:
             return False, result.stderr
         # Restart the systemd service via the host socket
-        restart = await loop.run_in_executor(
+        await loop.run_in_executor(
             None,
             lambda: _sp.run(
                 ["systemctl", "restart", "ainode"],

--- a/ainode/cli/main.py
+++ b/ainode/cli/main.py
@@ -8,9 +8,7 @@ import time
 import uuid
 
 from rich.console import Console
-from rich.live import Live
 from rich.panel import Panel
-from rich.spinner import Spinner
 from rich.table import Table
 from rich.text import Text
 
@@ -536,15 +534,15 @@ def cmd_role(args):
     # Workers don't need a model — clear it so the engine is skipped on start
     if job == "worker":
         config.model = None
-        console.print(f"\n  [bold cyan]Role set to: worker[/bold cyan]")
+        console.print("\n  [bold cyan]Role set to: worker[/bold cyan]")
         console.print("  This node will start immediately and wait for the")
         console.print("  master to assign work. No model required.\n")
     elif job == "master":
-        console.print(f"\n  [bold green]Role set to: master[/bold green]")
+        console.print("\n  [bold green]Role set to: master[/bold green]")
         console.print("  This node will manage the cluster and run the inference")
         console.print("  engine. Pick a model via the web UI at http://localhost:3000\n")
     else:
-        console.print(f"\n  [bold]Role set to: solo[/bold]")
+        console.print("\n  [bold]Role set to: solo[/bold]")
         console.print("  Standalone node — not part of a cluster.\n")
 
     config.save()

--- a/ainode/cluster/hca_discovery.py
+++ b/ainode/cluster/hca_discovery.py
@@ -22,7 +22,7 @@ import logging
 import re
 import subprocess
 from pathlib import Path
-from typing import Iterable, List, Optional
+from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/ainode/datasets/api_routes.py
+++ b/ainode/datasets/api_routes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from aiohttp import web
 
-from ainode.datasets.manager import Dataset, DatasetManager, DatasetSource
+from ainode.datasets.manager import DatasetManager, DatasetSource
 
 
 def setup_dataset_routes(app: web.Application, manager: DatasetManager) -> None:

--- a/ainode/datasets/manager.py
+++ b/ainode/datasets/manager.py
@@ -18,7 +18,6 @@ URL downloads) is done lazily inside each ``add_*`` method.
 from __future__ import annotations
 
 import csv
-import io
 import json
 import shutil
 import time

--- a/ainode/engine/backends/eugr.py
+++ b/ainode/engine/backends/eugr.py
@@ -27,7 +27,6 @@ import re
 import shutil
 import signal
 import subprocess
-import sys
 import threading
 import time
 import urllib.error

--- a/ainode/engine/backends/nvidia.py
+++ b/ainode/engine/backends/nvidia.py
@@ -33,7 +33,6 @@ import shlex
 import shutil
 import signal
 import subprocess
-import sys
 import threading
 import time
 import urllib.error
@@ -44,7 +43,6 @@ from typing import Callable, Dict, List, Optional
 from ainode.cluster.hca_discovery import (
     build_nccl_ib_hca_whitelist,
     detect_fabric_ip,
-    list_local_hcas,
 )
 from ainode.core.config import LOGS_DIR, NodeConfig
 from ainode.engine.backends.base import EngineBackend

--- a/ainode/engine/docker_engine.py
+++ b/ainode/engine/docker_engine.py
@@ -19,7 +19,6 @@ from ainode.engine.backends.eugr import (
     DockerEngineError,
     EugrBackend,
     EugrBackendError,
-    _local_ip_for_interface,
 )
 
 

--- a/ainode/engine/ray_autostart.py
+++ b/ainode/engine/ray_autostart.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import socket
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 
 from ainode.discovery.cluster import ClusterState

--- a/ainode/engine/sharding_routes.py
+++ b/ainode/engine/sharding_routes.py
@@ -10,7 +10,7 @@ from aiohttp import web
 
 from ainode.discovery.cluster import ClusterState
 from ainode.engine.sharding import ShardingPlanner, ShardingStrategy, ShardingConfig
-from ainode.engine.ray_setup import get_ray_status, start_ray_head, join_ray_cluster, stop_ray
+from ainode.engine.ray_setup import get_ray_status
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +113,6 @@ async def handle_sharding_launch(request: web.Request) -> web.Response:
 
     cluster: ClusterState = request.app["cluster_state"]
     config: NodeConfig = request.app["config"]
-    engine = request.app.get("engine")
 
     if min_nodes <= 1:
         # Delegate to the single-node load path so behaviour stays
@@ -122,7 +121,9 @@ async def handle_sharding_launch(request: web.Request) -> web.Response:
         from ainode.models.api_routes import handle_model_load  # lazy import
         # Re-inject body so handle_model_load can read it
         class _ReqShim:
-            def __init__(self, orig, body): self._o = orig; self._b = body
+            def __init__(self, orig, body):
+                self._o = orig
+                self._b = body
             def __getattr__(self, k): return getattr(self._o, k)
             async def json(self): return self._b
         shim = _ReqShim(request, {"model": model})
@@ -138,7 +139,8 @@ async def handle_sharding_launch(request: web.Request) -> web.Response:
         if getattr(n, "distributed_mode", "solo") == "member"
         and (n.status.value if hasattr(n.status, "value") else str(n.status)) in ("online", "member-ready", "serving")
     ]
-    fabric_of = lambda n: (getattr(n, "fabric_ip", "") or "").strip()
+    def fabric_of(n):
+        return (getattr(n, "fabric_ip", "") or "").strip()
     members_dump = [
         {"node_id": n.node_id, "node_name": n.node_name, "fabric_ip": fabric_of(n),
          "status": n.status.value if hasattr(n.status, "value") else str(n.status)}

--- a/ainode/metrics/prometheus.py
+++ b/ainode/metrics/prometheus.py
@@ -88,7 +88,7 @@ def render(collector: MetricsCollector) -> str:
     # Also emit count + sum so Prometheus recording rules can compute
     # additional aggregates (avg = sum/count) if a scraper wants them.
     lines.append(f"ainode_request_latency_milliseconds_count {total}")
-    lines.append(f"ainode_request_latency_milliseconds_sum 0")  # exact sum not tracked
+    lines.append("ainode_request_latency_milliseconds_sum 0")  # exact sum not tracked
     lines.append("")
 
     # -- GPU -----------------------------------------------------------------

--- a/ainode/models/api_routes.py
+++ b/ainode/models/api_routes.py
@@ -498,7 +498,6 @@ async def handle_model_unload(request: web.Request) -> web.Response:
 
     engine = request.app.get("engine")
     config = request.app["config"]
-    stopped = False
     errors = []
 
     # Instance-aware unload: stop the ONE instance serving `model`, leaving any

--- a/ainode/models/hf_upload.py
+++ b/ainode/models/hf_upload.py
@@ -92,13 +92,13 @@ def demo() -> None:
         def role(r):
             return {"auth": {"accessToken": {"role": r}}, "name": "me"}
     # read-only must raise
-    import types
     g = globals()
     saved = g["_whoami"]
     try:
         g["_whoami"] = lambda t: _Who.role("read")
         try:
-            assert_write_scope("x"); assert False, "read token should reject"
+            assert_write_scope("x")
+            raise AssertionError("read token should reject")
         except ValueError:
             pass
         g["_whoami"] = lambda t: _Who.role("write")

--- a/ainode/models/registry.py
+++ b/ainode/models/registry.py
@@ -47,7 +47,7 @@ def _download_max_workers() -> int:
     except (TypeError, ValueError):
         return 4
 
-from ainode.core.config import AINODE_HOME, MODELS_DIR
+from ainode.core.config import AINODE_HOME, MODELS_DIR  # noqa: E402
 
 
 @dataclass

--- a/ainode/service/systemd.py
+++ b/ainode/service/systemd.py
@@ -23,7 +23,7 @@ USER_UNIT_DIR = Path.home() / ".config" / "systemd" / "user"
 
 # Image tag follows the package version so a fresh install pulls the matching
 # image (env override for testing pre-release tags). Republished to GHCR per release.
-from ainode import __version__ as _AINODE_VERSION
+from ainode import __version__ as _AINODE_VERSION  # noqa: E402
 
 AINODE_IMAGE_TAG = os.environ.get("AINODE_IMAGE_TAG") or _AINODE_VERSION
 AINODE_IMAGE = f"ghcr.io/getainode/ainode:{AINODE_IMAGE_TAG}"

--- a/ainode/training/api_routes.py
+++ b/ainode/training/api_routes.py
@@ -336,7 +336,10 @@ async def handle_merge_adapter(request: web.Request) -> web.Response:
     merge_config = TrainingConfig(
         base_model=job.config.base_model,
         dataset_path="__merge__",  # sentinel — no dataset needed
-        method="__merge__",
+        # "lora": validate() only allows lora/full/qlora/quantize, and method is
+        # never read again — the merge itself runs via _do_merge() below, not
+        # through the manager's normal _build_command() job-start path.
+        method="lora",
         output_dir=merged_dir_name,
         run_name=f"merge-{job_id}",
         description=f"LoRA merge from job {job_id}",

--- a/ainode/web/static/js/app.js
+++ b/ainode/web/static/js/app.js
@@ -2841,7 +2841,7 @@ const AINode = {
   },
 
   // ========================================================================
-  //  TRAINING VIEW  (overview / datasets / runs / templates / benchmarks)
+  //  TRAINING VIEW  (overview / autodata / datasets / runs / templates)
   // ========================================================================
 
   trainingModels: [
@@ -2876,7 +2876,6 @@ const AINode = {
       { id: 'datasets',   label: 'Datasets',   icon: '&#8864;' },
       { id: 'runs',       label: 'Runs',       icon: '&#9873;' },
       { id: 'templates',  label: 'Templates',  icon: '&#9641;' },
-      { id: 'benchmarks', label: 'Benchmarks', icon: '&#9775;' },
     ];
     var guides = [
       { id: 'beginners',    label: "Beginner's Guide" },
@@ -3008,7 +3007,6 @@ const AINode = {
       case 'datasets':   this.renderTrainingDatasets(container); break;
       case 'runs':       this.renderTrainingRuns(container); break;
       case 'templates':  this.renderTrainingTemplates(container); break;
-      case 'benchmarks': this.renderTrainingBenchmarks(container); break;
       default:           this.renderTrainingOverview(container);
     }
   },
@@ -3476,26 +3474,6 @@ const AINode = {
           batch_size: tpl.recommended_batch_size,
           learning_rate: tpl.recommended_lr,
         });
-      });
-    });
-  },
-
-  // ---- Benchmarks --------------------------------------------------------
-  renderTrainingBenchmarks(container) {
-    var self = this;
-    // This is a placeholder view — wires to /api/benchmarks in a future pass.
-    container.innerHTML = '<div class="training-overview">' +
-      '<div class="training-section-head"><h3>Benchmarks</h3><span class="muted">NCCL / RDMA / GPU-direct</span></div>' +
-      '<div class="benchmark-grid">' +
-        '<div class="benchmark-card"><h4>NCCL all-reduce</h4><div class="benchmark-value">—</div><div class="benchmark-meta">not yet run</div><button class="btn-nvidia btn-sm" data-bench="nccl">Run</button></div>' +
-        '<div class="benchmark-card"><h4>GPU-direct RDMA</h4><div class="benchmark-value">—</div><div class="benchmark-meta">not yet run</div><button class="btn-nvidia btn-sm" data-bench="rdma">Run</button></div>' +
-        '<div class="benchmark-card"><h4>Storage Throughput</h4><div class="benchmark-value">—</div><div class="benchmark-meta">not yet run</div><button class="btn-nvidia btn-sm" data-bench="storage">Run</button></div>' +
-      '</div>' +
-    '</div>';
-
-    container.querySelectorAll('[data-bench]').forEach(function (b) {
-      b.addEventListener('click', function () {
-        self.toast('Benchmark runners coming in the next release', 'info');
       });
     });
   },
@@ -4166,138 +4144,6 @@ const AINode = {
     },
   },
 
-  renderTrainingForm(container) {
-    var models = this.trainingModels;
-    var optionsHtml = models.map(function (m) {
-      return '<option value="' + AINode.esc(m.id) + '">' + AINode.esc(m.name) + ' (' + m.size + ')</option>';
-    }).join('');
-
-    container.innerHTML =
-      '<div class="training-form-wrapper">' +
-      '<div class="training-form-header">' +
-      '<button class="btn-ghost" id="training-back-btn">&larr; Back to Jobs</button>' +
-      '<h2>New Training Job</h2>' +
-      '</div>' +
-      '<form id="training-form" class="training-form">' +
-      '<div class="form-section">' +
-      '<h3 class="form-section-title">Model</h3>' +
-      '<div class="form-group"><label class="form-label">Base Model</label><select id="train-model" class="form-select" required>' + optionsHtml + '</select></div>' +
-      '<div class="form-group"><label class="form-label">Custom Model ID (optional)</label><input type="text" id="train-model-custom" class="form-input" placeholder="e.g. org/my-model"></div>' +
-      '</div>' +
-      '<div class="form-section">' +
-      '<h3 class="form-section-title">Dataset</h3>' +
-      '<div class="form-group"><label class="form-label">Dataset Path</label><input type="text" id="train-dataset" class="form-input" placeholder="my-dataset.jsonl" required>' +
-      '<div class="form-hint">Place files in <code>~/.ainode/datasets/</code>. Supported: JSON, JSONL, CSV. Fields: <code>text</code>, or <code>instruction</code>+<code>output</code>, or <code>prompt</code>+<code>completion</code>.</div></div>' +
-      '</div>' +
-      '<div class="form-section">' +
-      '<h3 class="form-section-title">Training Method</h3>' +
-      '<div class="method-toggle">' +
-      '<button type="button" class="method-btn active" data-method="lora"><strong>LoRA</strong><br><small>Recommended. Trains adapter weights only.</small></button>' +
-      '<button type="button" class="method-btn" data-method="full"><strong>Full Fine-Tune</strong><br><small>Updates all model weights.</small></button>' +
-      '</div>' +
-      '<input type="hidden" id="train-method" value="lora">' +
-      '</div>' +
-      '<div class="form-section">' +
-      '<h3 class="form-section-title collapsible" id="advanced-toggle">Advanced Settings <span class="chevron">&#9662;</span></h3>' +
-      '<div class="advanced-settings collapsed" id="advanced-settings">' +
-      '<div class="form-grid">' +
-      '<div class="form-group"><label class="form-label">Epochs</label><input type="number" id="train-epochs" class="form-input" value="3" min="1" max="100"></div>' +
-      '<div class="form-group"><label class="form-label">Batch Size</label><input type="number" id="train-batch" class="form-input" value="4" min="1" max="128"></div>' +
-      '<div class="form-group"><label class="form-label">Learning Rate</label><input type="text" id="train-lr" class="form-input" value="2e-4"></div>' +
-      '<div class="form-group"><label class="form-label">Max Seq Length</label><input type="number" id="train-seq-len" class="form-input" value="2048" min="128" max="32768" step="128"></div>' +
-      '</div>' +
-      '<div class="form-grid lora-settings" id="lora-settings">' +
-      '<div class="form-group"><label class="form-label">LoRA Rank</label><input type="number" id="train-lora-rank" class="form-input" value="16" min="1" max="256"></div>' +
-      '<div class="form-group"><label class="form-label">LoRA Alpha</label><input type="number" id="train-lora-alpha" class="form-input" value="32" min="1" max="512"></div>' +
-      '</div>' +
-      '</div>' +
-      '</div>' +
-      '<div class="form-actions">' +
-      '<button type="button" class="btn-ghost" id="training-cancel-btn">Cancel</button>' +
-      '<button type="submit" class="btn-nvidia" id="training-submit-btn">Start Training</button>' +
-      '</div>' +
-      '</form>' +
-      '</div>';
-
-    this.bindTrainingForm();
-  },
-
-  bindTrainingForm() {
-    var self = this;
-    var goBack = function () { self.state.trainingView = 'list'; self.renderTraining(); };
-
-    var bb = document.getElementById('training-back-btn');
-    if (bb) bb.addEventListener('click', goBack);
-    var cb = document.getElementById('training-cancel-btn');
-    if (cb) cb.addEventListener('click', goBack);
-
-    document.querySelectorAll('.method-btn').forEach(function (btn) {
-      btn.addEventListener('click', function () {
-        document.querySelectorAll('.method-btn').forEach(function (b) { b.classList.remove('active'); });
-        btn.classList.add('active');
-        document.getElementById('train-method').value = btn.dataset.method;
-        var ls = document.getElementById('lora-settings');
-        if (ls) ls.style.display = btn.dataset.method === 'lora' ? '' : 'none';
-      });
-    });
-
-    var at = document.getElementById('advanced-toggle');
-    if (at) {
-      at.addEventListener('click', function () {
-        var s = document.getElementById('advanced-settings');
-        if (s) s.classList.toggle('collapsed');
-        at.classList.toggle('open');
-      });
-    }
-
-    var f = document.getElementById('training-form');
-    if (f) f.addEventListener('submit', function (e) { e.preventDefault(); self.submitTrainingJob(); });
-  },
-
-  async submitTrainingJob() {
-    var submitBtn = document.getElementById('training-submit-btn');
-    if (submitBtn) { submitBtn.disabled = true; submitBtn.textContent = 'Submitting...'; }
-
-    var customModel = document.getElementById('train-model-custom')?.value?.trim();
-    var baseModel = customModel || document.getElementById('train-model')?.value;
-    var method = document.getElementById('train-method')?.value || 'lora';
-
-    var payload = {
-      base_model: baseModel,
-      dataset_path: document.getElementById('train-dataset')?.value?.trim(),
-      method: method,
-      num_epochs: parseInt(document.getElementById('train-epochs')?.value) || 3,
-      batch_size: parseInt(document.getElementById('train-batch')?.value) || 4,
-      learning_rate: parseFloat(document.getElementById('train-lr')?.value) || 2e-4,
-      max_seq_length: parseInt(document.getElementById('train-seq-len')?.value) || 2048,
-    };
-    if (method === 'lora') {
-      payload.lora_rank = parseInt(document.getElementById('train-lora-rank')?.value) || 16;
-      payload.lora_alpha = parseInt(document.getElementById('train-lora-alpha')?.value) || 32;
-    }
-
-    try {
-      var resp = await fetch('/api/training/jobs', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      });
-      var result = await resp.json();
-      if (!resp.ok) {
-        this.toast('Error: ' + (result.error || 'Failed to create job'), 'error');
-        if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = 'Start Training'; }
-        return;
-      }
-      this.state.trainingView = 'detail';
-      this.state.trainingDetailId = result.job_id;
-      this.state.trainingLossData = [];
-      this.renderTraining();
-    } catch (err) {
-      this.toast('Network error: ' + err.message, 'error');
-      if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = 'Start Training'; }
-    }
-  },
-
   async renderTrainingDetail(container) {
     var jobId = this.state.trainingDetailId;
     if (!jobId) { this.state.trainingView = 'list'; this.renderTraining(); return; }
@@ -4305,8 +4151,13 @@ const AINode = {
     var jobData = await this.fetchJSON('/api/training/jobs/' + jobId);
     if (!jobData) { container.innerHTML = '<div class="training-empty"><h3>Job not found</h3></div>'; return; }
 
-    var logsData = await this.fetchJSON('/api/training/jobs/' + jobId + '/logs?tail=200');
+    var extra = await Promise.all([
+      this.fetchJSON('/api/training/jobs/' + jobId + '/logs?tail=200'),
+      this.fetchJSON('/api/training/jobs/' + jobId + '/output'),
+    ]);
+    var logsData = extra[0];
     var logs = logsData?.logs || [];
+    var outputFiles = extra[1]?.files || [];
 
     // Collect loss data
     if (jobData.current_loss != null && jobData.progress > 0) {
@@ -4344,6 +4195,8 @@ const AINode = {
     var ended = jobData.end_time ? new Date(jobData.end_time * 1000).toLocaleString() : '--';
     var elapsed = jobData.elapsed_seconds ? this.formatUptime(Math.round(jobData.elapsed_seconds)) : '--';
     var isActive = jobData.status === 'running' || jobData.status === 'pending';
+    var canMerge = jobData.status === 'completed' && (cfg.method === 'lora' || cfg.method === 'qlora');
+    var canResume = jobData.status === 'failed' || jobData.status === 'cancelled';
 
     var html = '<div class="training-detail">' +
       '<div class="training-form-header">' +
@@ -4379,10 +4232,19 @@ const AINode = {
       '<tr><td>Duration</td><td>' + elapsed + '</td></tr>' +
       '</table>' +
       (isActive ? '<div style="margin-top:16px"><button class="btn-danger" id="training-cancel-job-btn">Cancel Job</button></div>' : '') +
+      (canMerge || canResume ? '<div style="margin-top:16px;display:flex;gap:8px;flex-wrap:wrap">' +
+        (canMerge ? '<button class="btn-nvidia" id="training-merge-btn">Merge Adapter &rarr; Full Model</button>' : '') +
+        (canResume ? '<button class="btn-ghost" id="training-resume-btn">Resume from Checkpoint</button>' : '') +
+        '</div>' : '') +
       '</div>' +
       '<div class="training-right-col">' +
       (this.state.trainingLossData.length > 1 ?
         '<div class="training-chart-card"><h3>Training Loss</h3><div class="loss-chart-container"><canvas id="loss-chart" width="460" height="200"></canvas></div></div>' : '') +
+      (outputFiles.length > 0 ? '<div class="training-config-card"><h3>Artifacts</h3><table class="config-table">' +
+        outputFiles.map(function (f) {
+          return '<tr><td><a class="chat-link" href="' + AINode.esc(f.download_url) + '" download>' + AINode.esc(f.name) + '</a></td><td class="mono">' + f.size_mb + ' MB</td></tr>';
+        }).join('') +
+        '</table></div>' : '') +
       '<div class="training-log-card"><h3>Logs <span class="log-line-count">' + (logsData?.total_lines || 0) + ' lines</span></h3>' +
       '<div class="training-log-viewer" id="training-log-viewer">' +
       (logs.length > 0 ? logs.map(function (l) { return '<div class="log-line">' + AINode.esc(l) + '</div>'; }).join('') : '<div class="log-empty">No logs yet</div>') +
@@ -4408,6 +4270,42 @@ const AINode = {
       else {
         var err = await resp.json().catch(function () { return {}; });
         self.toast(err.error || 'Failed to cancel job', 'error');
+      }
+    });
+
+    var mb = document.getElementById('training-merge-btn');
+    if (mb) mb.addEventListener('click', async function () {
+      if (!confirm('Merge this adapter into a full model? This can take several minutes.')) return;
+      mb.disabled = true;
+      var resp = await fetch('/api/training/jobs/' + jobId + '/merge', { method: 'POST' });
+      var result = await resp.json().catch(function () { return {}; });
+      if (resp.ok) {
+        self.toast('Merge started — output: ' + result.output_dir, 'success');
+        self.state.trainingDetailId = result.merge_job_id;
+        self.state.trainingLossData = [];
+        self.renderTrainingSidebar();
+        self.renderTraining();
+      } else {
+        mb.disabled = false;
+        self.toast(result.error || 'Failed to start merge', 'error');
+      }
+    });
+
+    var rb = document.getElementById('training-resume-btn');
+    if (rb) rb.addEventListener('click', async function () {
+      if (!confirm('Resume training from the latest checkpoint?')) return;
+      rb.disabled = true;
+      var resp = await fetch('/api/training/jobs/' + jobId + '/resume', { method: 'POST' });
+      var result = await resp.json().catch(function () { return {}; });
+      if (resp.ok) {
+        self.toast('Resumed from checkpoint ' + result.checkpoint, 'success');
+        self.state.trainingDetailId = result.resume_job_id;
+        self.state.trainingLossData = [];
+        self.renderTrainingSidebar();
+        self.renderTraining();
+      } else {
+        rb.disabled = false;
+        self.toast(result.error || 'Failed to resume job', 'error');
       }
     });
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,7 @@
 """Tests for ainode.api.server — AINode-specific endpoints."""
 
+import socket
+
 import pytest
 import pytest_asyncio
 from aiohttp.test_utils import TestClient, TestServer
@@ -10,7 +12,13 @@ from ainode.core.config import NodeConfig
 
 @pytest.fixture
 def config():
-    return NodeConfig(node_id="test-node-1", node_name="TestNode", model="test-model")
+    # Use a port nothing listens on: the vllm proxy falls back to
+    # localhost:<api_port>, and a real service on the default 8000 (common on
+    # dev machines) would answer instead of yielding the expected 502.
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        free_port = s.getsockname()[1]
+    return NodeConfig(node_id="test-node-1", node_name="TestNode", model="test-model", api_port=free_port)
 
 
 @pytest.fixture

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,15 +1,13 @@
 """Tests for ainode.auth — middleware, key management, enable/disable."""
 
-import json
 import pytest
 import pytest_asyncio
 from pathlib import Path
-from unittest.mock import patch
 
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
-from ainode.auth.middleware import AuthConfig, auth_middleware, AUTH_FILE
+from ainode.auth.middleware import AuthConfig, auth_middleware
 from ainode.auth.api_routes import register_auth_routes
 from ainode.core.config import NodeConfig
 
@@ -98,7 +96,7 @@ class TestAuthConfig:
         assert auth_config.validate_token(entry["key"])
 
     def test_enable_reuses_existing_key(self, auth_config):
-        first = auth_config.generate_key()
+        auth_config.generate_key()
         entry = auth_config.enable()
         assert entry["id"] == auth_config.api_keys[0]["id"]
         assert len(auth_config.api_keys) == 1

--- a/tests/test_browser_federation.py
+++ b/tests/test_browser_federation.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 
 import ainode.api.server as server
 import ainode.engine.backends as backends_mod
@@ -56,13 +55,16 @@ def test_load_body_sets_gpu_mem_util(monkeypatch):
     made = {}
     class _Eng:
         def __init__(self, cfg, instance_id=""):
-            self.config = cfg; self.instance_id = instance_id; made["cfg"] = cfg
+            self.config = cfg
+            self.instance_id = instance_id
+            made["cfg"] = cfg
         def is_running(self): return False
         def stop(self): pass
         def start(self): return True
     monkeypatch.setattr(backends_mod, "get_backend",
                         lambda cfg, instance_id="", on_ready=None: _Eng(cfg, instance_id))
-    cfg = NodeConfig(node_id="n"); cfg.save = lambda: None
+    cfg = NodeConfig(node_id="n")
+    cfg.save = lambda: None
     app = {"engine": None, "config": cfg, "cluster_state": ClusterState(),
            "ray_autostart_state": None}
     asyncio.run(mr.handle_model_load(_Req(app, {"model": "m/x", "gpu_memory_utilization": 0.25})))
@@ -116,7 +118,9 @@ def test_proxy_fails_over_past_ghost(monkeypatch):
            "client_session": _Sess(), "metrics_collector": _Collector()}
 
     class _R:
-        method = "POST"; path = "/v1/completions"; headers = {}
+        method = "POST"
+        path = "/v1/completions"
+        headers = {}
         def __init__(self): self.app = app
         async def read(self): return b'{"model":"M","prompt":"hi"}'
     resp = asyncio.run(server.proxy_to_vllm(_R()))
@@ -129,7 +133,8 @@ def test_failed_load_clears_model_claim(monkeypatch):
         def is_running(self): return False
         def stop(self): pass
         def start(self): return False          # launch fails
-    cfg = NodeConfig(node_id="n", model="m/x"); cfg.save = lambda: None
+    cfg = NodeConfig(node_id="n", model="m/x")
+    cfg.save = lambda: None
     app = {"engine": _Eng(), "config": cfg, "cluster_state": ClusterState(),
            "ray_autostart_state": None}
     resp = asyncio.run(mr.handle_model_load(_Req(app, {"model": "m/x"})))

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,7 +1,6 @@
 """Tests for cluster state, leader election, model routing, and summary."""
 
 import time
-import pytest
 
 from ainode.discovery.broadcast import (
     NodeAnnouncement,

--- a/tests/test_cluster_load.py
+++ b/tests/test_cluster_load.py
@@ -213,7 +213,7 @@ def test_load_appends_when_boot_engine_already_seeded(monkeypatch):
     from ainode.discovery.instance import InstanceRecord
     from ainode.engine.instance_manager import InstanceManager
 
-    made = _patch_backend(monkeypatch)
+    _patch_backend(monkeypatch)
     cfg = NodeConfig(node_id="spark1", api_port=8000)
     cfg.model = "boot-model"
     cfg.save = lambda: None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,6 @@
 """Tests for ainode.core.config."""
 
 import json
-from pathlib import Path
 from ainode.core.config import NodeConfig
 
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -11,7 +11,6 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from ainode.datasets.manager import (
-    Dataset,
     DatasetFormat,
     DatasetManager,
     DatasetSource,

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -2,7 +2,6 @@
 
 import time
 import json
-import pytest
 from unittest.mock import MagicMock
 
 from ainode.discovery.broadcast import (

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from ainode.discovery.broadcast import NodeAnnouncement, NodeStatus
 from ainode.discovery.cluster import ClusterNode, ClusterState

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -1,6 +1,6 @@
 """Tests for ainode.core.gpu."""
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from ainode.core.gpu import GPUInfo, detect_gpu, gpu_summary
 
 

--- a/tests/test_hca_discovery.py
+++ b/tests/test_hca_discovery.py
@@ -8,9 +8,7 @@ calls.
 
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
-from typing import Any, List
 from unittest import mock
 
 import pytest

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -349,8 +349,8 @@ class TestDelete:
 # ---------------------------------------------------------------------------
 
 pytest.importorskip("aiohttp")
-from aiohttp import web
-from ainode.models.api_routes import register_model_routes
+from aiohttp import web  # noqa: E402
+from ainode.models.api_routes import register_model_routes  # noqa: E402
 
 
 class TestModelAPI:

--- a/tests/test_nvidia_backend.py
+++ b/tests/test_nvidia_backend.py
@@ -9,7 +9,6 @@ actually invoking docker.
 from __future__ import annotations
 
 import subprocess
-from pathlib import Path
 from typing import Any, List
 from unittest import mock
 
@@ -24,9 +23,6 @@ from ainode.engine.backends import (
 from ainode.engine.backends.nvidia import (
     HEAD_CONTAINER_NAME,
     NVIDIA_VLLM_IMAGE,
-    RAY_CONTAINER_NAME_PREFIX,
-    RUN_CLUSTER_SCRIPT_FALLBACK,
-    RUN_CLUSTER_SCRIPT_SOURCE,
     WORKER_CONTAINER_NAME_PREFIX,
     NvidiaBackendError,
 )

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -19,7 +19,6 @@ def fresh_config(tmp_path):
     )
     # Override save to write to tmp instead of ~/.ainode
     config_file = tmp_path / "config.json"
-    original_save = config.save
 
     def save_to_tmp():
         import json

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -3,7 +3,6 @@
 import json
 import os
 import stat
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -11,7 +10,7 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from ainode.api.server import create_app
 from ainode.core.config import NodeConfig
-from ainode.secrets.manager import KNOWN_SECRETS, SecretsManager, _mask
+from ainode.secrets.manager import SecretsManager, _mask
 
 
 @pytest.fixture

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,11 +1,8 @@
 """Tests for ainode.service.systemd — unit file generation and service management."""
 
 import subprocess
-import sys
-from pathlib import Path
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
-import pytest
 
 from ainode.service import systemd
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,8 +1,6 @@
 """Tests for ainode.training — config validation, job lifecycle, manager queue, API routes."""
 
-import asyncio
 from pathlib import Path
-import json
 import pytest
 import pytest_asyncio
 from aiohttp import web
@@ -682,7 +680,6 @@ class TestArtifactEndpoints:
     @pytest.mark.asyncio
     async def test_output_lists_files_when_dir_exists(self, training_client, tmp_path):
         """If output_dir exists and has files, they appear in the listing."""
-        from ainode.training.engine import JOBS_DIR
         resp = await training_client.post(
             "/api/training/jobs",
             json={"base_model": "m", "dataset_path": "user/d"},
@@ -717,6 +714,42 @@ class TestArtifactEndpoints:
         )
         # Should 404 (path traversal stripped by router) or 400
         assert resp2.status in (400, 404)
+
+
+class TestMergeEndpoint:
+    """Tests for /api/training/jobs/{job_id}/merge."""
+
+    @pytest.mark.asyncio
+    async def test_merge_completed_lora_job_starts(self, training_client, training_app):
+        resp = await training_client.post(
+            "/api/training/jobs",
+            json={"base_model": "m", "dataset_path": "user/d", "method": "lora"},
+        )
+        job_id = (await resp.json())["job_id"]
+
+        manager: TrainingManager = training_app["training_manager"]
+        job = manager.get_job(job_id)
+        job.status = JobStatus.COMPLETED
+        output_dir = Path(job.config.output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "adapter_model.safetensors").write_bytes(b"x" * 16)
+
+        resp2 = await training_client.post(f"/api/training/jobs/{job_id}/merge")
+        assert resp2.status == 202
+        data = await resp2.json()
+        assert "merge_job_id" in data
+        assert data["source_job_id"] == job_id
+
+    @pytest.mark.asyncio
+    async def test_merge_rejects_non_completed_job(self, training_client):
+        resp = await training_client.post(
+            "/api/training/jobs",
+            json={"base_model": "m", "dataset_path": "user/d", "method": "lora"},
+        )
+        job_id = (await resp.json())["job_id"]
+
+        resp2 = await training_client.post(f"/api/training/jobs/{job_id}/merge")
+        assert resp2.status == 409
 
 
 class TestHFTokenPropagation:


### PR DESCRIPTION
## Summary
- Job detail view: state-gated **Merge Adapter → Full Model** and **Resume from Checkpoint** actions wired to the backend (`/merge`, `/resume`); **Artifacts** panel lists output files with download links (`/output`).
- Fixes the merge endpoint: `method="__merge__"` was rejected by `TrainingConfig.validate()` — silent failure. Uses `"lora"` (the field is never read on the `_do_merge` path).
- Removes dead code: `renderTrainingForm` / `bindTrainingForm` / `submitTrainingJob` (superseded by the Training view) and the placeholder Benchmarks tab.
- Tests: merge endpoint coverage (202 completed-LoRA, 409 non-completed); api test fixture now uses a guaranteed-free port so a dev service on `:8000` can't shadow the proxy-down 502 test.

Verified end-to-end in the 2026-07-01 session (puppeteer + seeded job states). `594 passed, 1 xfailed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NziXzqT1L9kj2T1byA3Ak