### PR TITLE
feat(training): run LoRA jobs + adapter merge in a spawned GPU container

### DIFF
--- a/ainode/training/_run_merge.py
+++ b/ainode/training/_run_merge.py
@@ -1,0 +1,80 @@
+"""Internal adapter-merge runner — launched as a subprocess INSIDE a GPU
+container (TRAIN_IMAGE + a peft pip-shim), not the slim orchestrator.
+
+Reads a config JSON ({base_model, adapter_dir, output_dir, hf_token}), applies a
+LoRA/QLoRA adapter onto its base model, merges the weights, and writes a
+standalone servable checkpoint. Emits ``AINODE_PROGRESS:{json}`` lines the parent
+process parses — same protocol as _run_training.py / _run_quant.py.
+
+Self-contained: imports nothing from the ainode package (it isn't installed in
+the container image).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _progress(pct: float, msg: str = "") -> None:
+    print("AINODE_PROGRESS:" + json.dumps({"pct": round(pct, 1), "msg": msg}), flush=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="AINode adapter-merge runner")
+    parser.add_argument("--config", required=True, help="Path to merge config JSON")
+    args = parser.parse_args()
+
+    config_path = Path(args.config)
+    if not config_path.exists():
+        print(f"Config file not found: {config_path}", file=sys.stderr)
+        sys.exit(1)
+
+    cfg = json.loads(config_path.read_text())
+    base_model = cfg["base_model"]
+    adapter_dir = cfg["adapter_dir"]
+    output_dir = cfg["output_dir"]
+
+    token = cfg.get("hf_token") or os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    if token:
+        os.environ["HF_TOKEN"] = token
+        os.environ["HUGGING_FACE_HUB_TOKEN"] = token
+
+    try:
+        import torch
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+        from peft import PeftModel
+    except ImportError as exc:
+        print(
+            f"Missing merge dependency: {exc}. "
+            "Install with: pip install torch transformers peft",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    _progress(5, f"loading base model {base_model}")
+    base = AutoModelForCausalLM.from_pretrained(
+        base_model,
+        torch_dtype=torch.bfloat16,
+        device_map="auto",
+        trust_remote_code=True,
+    )
+
+    _progress(40, f"applying adapter {adapter_dir}")
+    model = PeftModel.from_pretrained(base, adapter_dir)
+    merged = model.merge_and_unload()
+
+    _progress(75, f"saving merged model to {output_dir}")
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+    merged.save_pretrained(output_dir)
+    tokenizer = AutoTokenizer.from_pretrained(base_model, trust_remote_code=True)
+    tokenizer.save_pretrained(output_dir)
+
+    _progress(100, "merge complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/ainode/training/_run_training.py
+++ b/ainode/training/_run_training.py
@@ -52,8 +52,14 @@ def main() -> None:
     # Resolve relative dataset paths to ~/.ainode/datasets/
     ds = config.get("dataset_path", "")
     if ds and not ds.startswith("/") and not ds.startswith("~"):
-        from ainode.core.config import AINODE_HOME
-        resolved = AINODE_HOME / "datasets" / ds
+        # The ainode package isn't installed in the spawned training container —
+        # fall back to the AINODE_HOME env var (the container run sets it to /job).
+        try:
+            from ainode.core.config import AINODE_HOME as _ainode_home
+            ainode_home = Path(_ainode_home)
+        except Exception:
+            ainode_home = Path(os.environ.get("AINODE_HOME", str(Path.home() / ".ainode")))
+        resolved = ainode_home / "datasets" / ds
         if resolved.exists():
             config["dataset_path"] = str(resolved)
 

--- a/ainode/training/api_routes.py
+++ b/ainode/training/api_routes.py
@@ -348,41 +348,87 @@ async def handle_merge_adapter(request: web.Request) -> web.Response:
 
     merge_job = manager.submit_job(merge_config)
     merge_job._adapter_dir = str(adapter_dir)  # carried through to the runner
+    # The merge container is spawned below via create_subprocess_exec (outside the
+    # normal TrainingJob.start() path), so merge_job._process is never set and
+    # stop() can't signal it. Register the container's deterministic name so a
+    # cancel (DELETE) can `docker kill` it instead of no-op'ing.
+    import os as _os
+    if _os.environ.get("AINODE_IN_CONTAINER"):
+        merge_job._container_name_override = f"ainode-merge-{merge_job.job_id}"
 
     # Run merge inline in executor (can take minutes)
     loop = asyncio.get_event_loop()
 
+    async def _merge_in_container() -> None:
+        """Slim orchestrator (no peft/torch): spawn a GPU container to merge,
+        streaming its stdout so the AINODE_PROGRESS protocol keeps working."""
+        from ainode.training.engine import build_merge_command
+        cmd = build_merge_command(merge_job, job.config.base_model, adapter_dir, merged_dir, job.config.hf_token)
+        merge_job._log("Merge command: " + " ".join(cmd))
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
+        )
+        assert proc.stdout is not None
+        async for raw in proc.stdout:
+            line = raw.decode(errors="replace").rstrip()
+            if line:
+                merge_job._log(line)
+                merge_job._parse_progress(line)
+        rc = await proc.wait()
+        if rc != 0:
+            raise RuntimeError(f"merge container exited with code {rc}")
+
     async def _do_merge():
-        merge_job.status = JobStatus.RUNNING
+        import os
         import time
+        # A cancel may already have landed while the job sat PENDING — don't
+        # resurrect it into RUNNING and run the full merge anyway.
+        if merge_job.status == JobStatus.CANCELLED:
+            return
+        merge_job.status = JobStatus.RUNNING
         merge_job.start_time = time.time()
         try:
-            def _merge_blocking():
-                from peft import PeftModel
-                import torch
-                from transformers import AutoModelForCausalLM, AutoTokenizer
+            if os.environ.get("AINODE_IN_CONTAINER"):
+                await _merge_in_container()
+            else:
+                def _merge_blocking():
+                    from peft import PeftModel
+                    import torch
+                    from transformers import AutoModelForCausalLM, AutoTokenizer
 
-                base = AutoModelForCausalLM.from_pretrained(
-                    job.config.base_model,
-                    torch_dtype=torch.bfloat16,
-                    device_map="auto",
-                    trust_remote_code=True,
-                )
-                model = PeftModel.from_pretrained(base, str(adapter_dir))
-                merged = model.merge_and_unload()
-                merged_dir.mkdir(parents=True, exist_ok=True)
-                merged.save_pretrained(str(merged_dir))
-                tokenizer = AutoTokenizer.from_pretrained(job.config.base_model, trust_remote_code=True)
-                tokenizer.save_pretrained(str(merged_dir))
+                    base = AutoModelForCausalLM.from_pretrained(
+                        job.config.base_model,
+                        torch_dtype=torch.bfloat16,
+                        device_map="auto",
+                        trust_remote_code=True,
+                    )
+                    model = PeftModel.from_pretrained(base, str(adapter_dir))
+                    merged = model.merge_and_unload()
+                    merged_dir.mkdir(parents=True, exist_ok=True)
+                    merged.save_pretrained(str(merged_dir))
+                    tokenizer = AutoTokenizer.from_pretrained(job.config.base_model, trust_remote_code=True)
+                    tokenizer.save_pretrained(str(merged_dir))
 
-            await loop.run_in_executor(None, _merge_blocking)
-            merge_job.status = JobStatus.COMPLETED
-            merge_job.end_time = time.time()
-            merge_job.progress = 100.0
+                await loop.run_in_executor(None, _merge_blocking)
         except Exception as exc:
-            merge_job.status = JobStatus.FAILED
-            merge_job.end_time = time.time()
-            merge_job._log(f"Merge failed: {exc}")
+            # A cancel (DELETE) flips status to CANCELLED and `docker kill`s the
+            # merge container, which makes _merge_in_container raise — don't
+            # clobber the user's cancellation with FAILED.
+            if merge_job.status == JobStatus.CANCELLED:
+                merge_job._log("Merge cancelled")
+            else:
+                merge_job.status = JobStatus.FAILED
+                merge_job.end_time = time.time()
+                merge_job._log(f"Merge failed: {exc}")
+            return
+        # Success path — but a cancel may have landed right as the container
+        # exited 0; honour it rather than overwriting CANCELLED with COMPLETED.
+        if merge_job.status == JobStatus.CANCELLED:
+            merge_job._log("Merge cancelled")
+            return
+        merge_job.status = JobStatus.COMPLETED
+        merge_job.end_time = time.time()
+        merge_job.progress = 100.0
 
     loop.create_task(_do_merge())
 

--- a/ainode/training/engine.py
+++ b/ainode/training/engine.py
@@ -38,6 +38,11 @@ class JobStatus(str, Enum):
 
 
 QUANT_IMAGE = os.environ.get("AINODE_QUANT_IMAGE") or "ainode-quant:0.17.0-t5"
+# LoRA / adapter-merge jobs run in a spawned GPU container too — the slim
+# orchestrator image has no torch/peft/datasets. Default to the quant image
+# (torch 2.10 / transformers 5.10 / datasets 5.0 / accelerate 1.13; peft is
+# pip-shimmed at launch, see _build_container_command). Override per-deploy.
+TRAIN_IMAGE = os.environ.get("AINODE_TRAIN_IMAGE") or QUANT_IMAGE
 
 
 def _host_path(container_path: str) -> str:
@@ -182,6 +187,10 @@ class TrainingJob:
         self.logs: collections.deque[str] = collections.deque(maxlen=5000)
         self._process: Optional[subprocess.Popen] = None
         self._monitor_task: Optional[asyncio.Task] = None
+        # Explicit override for the spawned GPU container name. Set by callers
+        # whose container is spawned outside the normal start() path (merge jobs),
+        # so stop() can still `docker kill` it. None → derive from method/job_id.
+        self._container_name_override: Optional[str] = None
 
         # Set output directory
         if self.config.output_dir is None:
@@ -249,12 +258,42 @@ class TrainingJob:
                 self._process.kill()
                 self._process.wait(timeout=5)
 
+        # For container-spawn jobs (quantize always; lora/qlora/full in-container;
+        # merge) self._process above is only the local `docker run` CLIENT — a
+        # SIGKILL to it is NOT relayed to the `--gpus all` container, which would
+        # keep running and holding the GPU with no record anywhere. Explicitly
+        # remove the named container to free the device (mirrors
+        # NvidiaBackend.stop()). Best-effort — swallow all errors.
+        name = self._container_name()
+        if name:
+            for args in (["docker", "stop", name], ["docker", "rm", "-f", name]):
+                try:
+                    subprocess.run(args, capture_output=True, text=True, timeout=30)
+                except Exception:
+                    self._log(f"{' '.join(args)} failed (best-effort)")
+
         self.status = JobStatus.CANCELLED
         self.end_time = time.time()
         self._log("Job cancelled")
 
         if self._monitor_task and not self._monitor_task.done():
             self._monitor_task.cancel()
+
+    def _container_name(self) -> Optional[str]:
+        """Deterministic name of this job's spawned GPU container, or None for the
+        in-process host-venv path (nothing to ``docker kill``).
+
+        Quantize always runs in a container; lora/qlora/full only in
+        container-spawn mode (``AINODE_IN_CONTAINER``); merge jobs register an
+        explicit override because their container is spawned outside ``start()``.
+        """
+        if self._container_name_override:
+            return self._container_name_override
+        if self.config.method == "quantize":
+            return f"ainode-quant-{self.job_id}"
+        if os.environ.get("AINODE_IN_CONTAINER"):
+            return f"ainode-train-{self.job_id}"
+        return None
 
     def get_status(self) -> dict:
         """Return a summary of the current job state."""
@@ -290,6 +329,19 @@ class TrainingJob:
 
         nproc = max(1, int(_detect_local_gpu_count()))
         needs_ddp = c.distributed or c.num_nodes > 1 or (c.method == "full" and nproc > 1)
+
+        # In the shipped (slim) orchestrator container there is no torch/peft, so
+        # the in-process `python -m ...` path is dead on arrival. Spawn a GPU
+        # container from TRAIN_IMAGE instead — same pattern as quantize.
+        if os.environ.get("AINODE_IN_CONTAINER"):
+            if needs_ddp:
+                raise RuntimeError(
+                    "Distributed training (DDP / multi-node) is not supported in "
+                    "container-spawn mode — run AINode in host-venv mode for multi-node "
+                    f"DDP. (distributed={c.distributed}, num_nodes={c.num_nodes}, "
+                    f"method={c.method}, local_gpus={nproc})"
+                )
+            return self._build_container_command()
 
         if not needs_ddp:
             return [
@@ -339,6 +391,84 @@ class TrainingJob:
         if token:
             cmd += ["-e", f"HF_TOKEN={token}", "-e", f"HUGGING_FACE_HUB_TOKEN={token}"]
         cmd += [QUANT_IMAGE, "python3", "/opt/ainode/run_quant.py", "--config", "/job/config.json"]
+        return cmd
+
+    def _build_container_command(self) -> list[str]:
+        """LoRA/QLoRA/full (single-GPU) training in a spawned GPU container — the
+        slim orchestrator has no torch/peft. Mirror _build_quant_command: --gpus all,
+        host-translated mounts, foreground so the existing Popen monitor streams
+        AINODE_PROGRESS and the container exit code signals completion.
+
+        The train image bakes no training runner, so we copy _run_training.py into
+        the job dir (mounted at /job) and rewrite a container-view config whose
+        output_dir + dataset_path point at the mounts below — otherwise checkpoints
+        land in the --rm layer and vanish on exit."""
+        import shutil
+
+        c = self.config
+        # Host-path prereq (contract tripwire) — same guard as quantize: without
+        # AINODE_HOST_HOME the RW mounts resolve to empty root-owned host dirs and
+        # the adapter is written into a throwaway --rm layer (lost on exit).
+        if not os.environ.get("AINODE_HOST_HOME"):
+            raise RuntimeError(
+                "container training requires AINODE_HOST_HOME (the host path mounted "
+                "at AINODE_HOME) so the output mount is host-backed — refusing to run, "
+                "the adapter/checkpoints would be lost with the --rm container."
+            )
+
+        # The train image knows nothing of the ainode package — copy the runner in.
+        shutil.copy2(Path(__file__).parent / "_run_training.py", self._job_dir / "_run_training.py")
+
+        # Container-view config: remap absolute output_dir + dataset_path onto the
+        # mounts. job.config.output_dir stays the orchestrator path (same host inode
+        # via the /job mount) so handle_get_output/download resolve unchanged.
+        container_cfg = dict(c.to_dict())
+        container_cfg["output_dir"] = "/job/output"
+        datasets_dir = str(AINODE_HOME / "datasets")
+        ds = c.dataset_path or ""
+        if ds.startswith(datasets_dir):
+            container_cfg["dataset_path"] = "/ainode-datasets/" + ds[len(datasets_dir):].lstrip("/")
+        elif ds and not ds.startswith("/") and not ds.startswith("~"):
+            # Relative dataset_path (e.g. "alpaca.jsonl" — exactly what the New Run
+            # wizard's placeholder suggests) resolves against ~/.ainode/datasets on
+            # the host. The runner's own resolver would look under AINODE_HOME=/job
+            # (the container's job dir), where the datasets aren't mounted, so remap
+            # it here onto the /ainode-datasets mount IF the file exists there.
+            # Leave it untouched otherwise, so a HF hub repo id ("tatsu-lab/alpaca")
+            # still passes through to load_dataset(). Mirrors _run_training.py's own
+            # exists()-gated resolution.
+            if (AINODE_HOME / "datasets" / ds).exists():
+                container_cfg["dataset_path"] = "/ainode-datasets/" + ds.lstrip("/")
+        (self._job_dir / "config.container.json").write_text(json.dumps(container_cfg, indent=2))
+
+        models_host = _host_path(str(AINODE_HOME / "models"))
+        datasets_host = _host_path(datasets_dir)
+        jobdir_host = _host_path(str(self._job_dir))
+        token = c.hf_token or os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN") or ""
+
+        cmd: list[str] = [
+            "docker", "run", "--rm",
+            "--name", f"ainode-train-{self.job_id}",
+            "--gpus", "all", "--network", "host", "--ipc=host", "--shm-size", "16g",
+            "-v", f"{models_host}:/ainode-models",             # RW: HF cache + on-disk weights
+            "-v", f"{datasets_host}:/ainode-datasets:ro",      # training data
+            "-v", f"{jobdir_host}:/job",                       # runner + config + output
+            "-e", "HF_HUB_CACHE=/ainode-models/hf-cache",      # persist HF pulls into the store
+            "-e", "AINODE_HOME=/job",                          # runner config fallback (relative datasets)
+        ]
+        if token:
+            cmd += ["-e", f"HF_TOKEN={token}", "-e", f"HUGGING_FACE_HUB_TOKEN={token}"]
+        # ponytail: peft (and bitsandbytes for qlora) aren't baked into the train
+        # image yet — pip-shim them at launch. TODO(ponytail): bake peft +
+        # bitsandbytes into the next quant/train-image build and drop this shim.
+        # bitsandbytes has no aarch64 wheel on some indexes; if the install fails the
+        # container exits non-zero and the pip error lands in the job log (readable).
+        pip_pkgs = "peft" + (" bitsandbytes" if c.method == "qlora" else "")
+        cmd += [
+            TRAIN_IMAGE, "sh", "-c",
+            f"pip install -q --no-deps {pip_pkgs} && "
+            "python3 /job/_run_training.py --config /job/config.container.json",
+        ]
         return cmd
 
     async def _monitor(self) -> None:
@@ -418,6 +548,66 @@ class TrainingJob:
         """Append a timestamped log entry."""
         ts = time.strftime("%H:%M:%S")
         self.logs.append(f"[{ts}] {msg}")
+
+
+def build_merge_command(
+    merge_job: "TrainingJob",
+    base_model: str,
+    adapter_dir: Path,
+    merged_dir: Path,
+    hf_token: Optional[str] = None,
+) -> list[str]:
+    """Spawn a GPU container to merge a LoRA/QLoRA adapter into its base model.
+
+    The slim orchestrator has no peft/torch, so — like training and quantize —
+    the merge runs in TRAIN_IMAGE. Copies the self-contained _run_merge.py into
+    the merge job dir, mounts the adapter RO, the merged-output parent RW, and the
+    models store (HF cache), and pip-shims peft at launch. Foreground: the caller
+    streams AINODE_PROGRESS and the exit code signals completion."""
+    import shutil
+
+    # Same host-backing tripwire as training/quantize.
+    if not os.environ.get("AINODE_HOST_HOME"):
+        raise RuntimeError(
+            "container merge requires AINODE_HOST_HOME (the host path mounted at "
+            "AINODE_HOME) so the merged model is host-backed — refusing to run, it "
+            "would be lost with the --rm container."
+        )
+
+    job_dir = merge_job._job_dir
+    adapter_dir = Path(adapter_dir)
+    merged_dir = Path(merged_dir)
+    merged_dir.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(Path(__file__).parent / "_run_merge.py", job_dir / "_run_merge.py")
+
+    token = hf_token or os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN") or ""
+    merge_cfg = {
+        "base_model": base_model,
+        "adapter_dir": "/adapter",
+        "output_dir": f"/out/{merged_dir.name}",
+        "hf_token": token,
+    }
+    (job_dir / "merge_config.json").write_text(json.dumps(merge_cfg, indent=2))
+
+    cmd: list[str] = [
+        "docker", "run", "--rm",
+        "--name", f"ainode-merge-{merge_job.job_id}",
+        "--gpus", "all", "--network", "host", "--ipc=host", "--shm-size", "16g",
+        "-v", f"{_host_path(str(job_dir))}:/job",                          # runner + config
+        "-v", f"{_host_path(str(adapter_dir))}:/adapter:ro",               # LoRA adapter
+        "-v", f"{_host_path(str(merged_dir.parent))}:/out",                # RW: merged model
+        "-v", f"{_host_path(str(AINODE_HOME / 'models'))}:/ainode-models",  # base weights / HF cache
+        "-e", "HF_HUB_CACHE=/ainode-models/hf-cache",
+    ]
+    if token:
+        cmd += ["-e", f"HF_TOKEN={token}", "-e", f"HUGGING_FACE_HUB_TOKEN={token}"]
+    # ponytail: peft pip-shim — bake it into the next train-image build and drop this.
+    cmd += [
+        TRAIN_IMAGE, "sh", "-c",
+        "pip install -q --no-deps peft && "
+        "python3 /job/_run_merge.py --config /job/merge_config.json",
+    ]
+    return cmd
 
 
 TRAINING_TEMPLATES: list[dict] = [

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,16 +1,20 @@
 """Tests for ainode.training — config validation, job lifecycle, manager queue, API routes."""
 
+import json
+import sys
 from pathlib import Path
 import pytest
 import pytest_asyncio
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
+import ainode.training.engine as engine
 from ainode.training.engine import (
     TrainingConfig,
     TrainingJob,
     TrainingManager,
     JobStatus,
+    build_merge_command,
 )
 from ainode.training.api_routes import setup_training_routes
 
@@ -751,6 +755,57 @@ class TestMergeEndpoint:
         resp2 = await training_client.post(f"/api/training/jobs/{job_id}/merge")
         assert resp2.status == 409
 
+    @pytest.mark.asyncio
+    async def test_merge_cancel_registers_container_and_sticks(
+        self, training_client, training_app, monkeypatch
+    ):
+        """Container-mode merge: cancel must register the ainode-merge container
+        (so stop() can docker-kill it) and the CANCELLED status must survive the
+        container later exiting — _do_merge must not overwrite it with COMPLETED."""
+        import asyncio
+
+        # Submit + complete the source LoRA job in host mode first (setting
+        # AINODE_IN_CONTAINER up front would make its auto-start build a container
+        # command and blow up on the missing AINODE_HOST_HOME guard).
+        resp = await training_client.post(
+            "/api/training/jobs",
+            json={"base_model": "m", "dataset_path": "user/d", "method": "lora"},
+        )
+        job_id = (await resp.json())["job_id"]
+        manager: TrainingManager = training_app["training_manager"]
+        job = manager.get_job(job_id)
+        job.status = JobStatus.COMPLETED
+        out = Path(job.config.output_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "adapter_model.safetensors").write_bytes(b"x" * 16)
+
+        # Now flip into container mode for the merge itself. Stub the merge
+        # container to a short-lived local process that exits 0 — exercises the
+        # success-path overwrite guard.
+        monkeypatch.setenv("AINODE_IN_CONTAINER", "1")
+        monkeypatch.setattr(
+            "ainode.training.engine.build_merge_command",
+            lambda *a, **k: ["sh", "-c", "sleep 0.3"],
+        )
+        # docker stop/rm during cancel → no-op (no daemon under test).
+        monkeypatch.setattr("ainode.training.engine.subprocess.run", lambda *a, **k: None)
+
+        resp2 = await training_client.post(f"/api/training/jobs/{job_id}/merge")
+        merge_job_id = (await resp2.json())["merge_job_id"]
+        merge_job = manager.get_job(merge_job_id)
+        assert merge_job._container_name_override == f"ainode-merge-{merge_job_id}"
+
+        # Let _do_merge flip the job to RUNNING, then cancel mid-flight.
+        await asyncio.sleep(0.05)
+        resp3 = await training_client.delete(f"/api/training/jobs/{merge_job_id}")
+        assert resp3.status == 200
+        assert merge_job.status == JobStatus.CANCELLED
+
+        # Let the stubbed container exit and _do_merge run to completion; the
+        # CANCELLED status must NOT be clobbered back to COMPLETED/FAILED.
+        await asyncio.sleep(0.5)
+        assert merge_job.status == JobStatus.CANCELLED
+
 
 class TestHFTokenPropagation:
     """Tests for HF token flow from NodeConfig → training job."""
@@ -784,3 +839,204 @@ class TestHFTokenPropagation:
         job_id = (await resp.json())["job_id"]
         resp2 = await training_client.get(f"/api/training/jobs/{job_id}")
         assert (await resp2.json())["config"]["hf_token"] == "hf_explicit"
+
+
+# =============================================================================
+# Container-spawn command building (slim-image gap: no torch/peft in-process)
+# =============================================================================
+
+
+class TestContainerTrainingCommand:
+    """_build_command must spawn a GPU container when running in-container."""
+
+    def _job(self, tmp_path, monkeypatch, **cfg):
+        monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
+        config = TrainingConfig(base_model="m", dataset_path="user/d", **cfg)
+        return TrainingJob(config)
+
+    def test_host_venv_path_unchanged(self, tmp_path, monkeypatch):
+        """No AINODE_IN_CONTAINER → the original in-process python path is used."""
+        monkeypatch.delenv("AINODE_IN_CONTAINER", raising=False)
+        job = self._job(tmp_path, monkeypatch)
+        cmd = job._build_command(job._job_dir / "config.json")
+        assert cmd[0] == sys.executable
+        assert "ainode.training._run_training" in cmd
+        assert "docker" not in cmd
+
+    def test_in_container_lora_docker_shape(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AINODE_IN_CONTAINER", "1")
+        monkeypatch.setenv("AINODE_HOST_HOME", "/host")
+        job = self._job(tmp_path, monkeypatch, method="lora")
+        cmd = job._build_command(job._job_dir / "config.json")
+
+        assert cmd[:3] == ["docker", "run", "--rm"]
+        assert engine.TRAIN_IMAGE in cmd
+        assert "--gpus" in cmd and "all" in cmd
+        assert "--ipc=host" in cmd
+
+        # Model store + job dir mounted RW (no :ro suffix); datasets RO.
+        mounts = [cmd[i + 1] for i, x in enumerate(cmd) if x == "-v"]
+        assert any(m.endswith(":/ainode-models") for m in mounts)
+        assert any(m.endswith(":/job") for m in mounts)
+        assert any(m.endswith(":/ainode-datasets:ro") for m in mounts)
+
+        # AINODE_HOME passed for the runner's config fallback.
+        assert "AINODE_HOME=/job" in cmd
+
+        # pip-shim installs peft (not bitsandbytes for plain lora); runner invoked.
+        shell = cmd[-1]
+        assert "pip install" in shell and "peft" in shell
+        assert "bitsandbytes" not in shell
+        assert "/job/_run_training.py" in shell
+        assert "/job/config.container.json" in shell
+
+        # Runner copied into the job dir; container-view config written + remapped.
+        assert (job._job_dir / "_run_training.py").exists()
+        ccfg = json.loads((job._job_dir / "config.container.json").read_text())
+        assert ccfg["output_dir"] == "/job/output"
+
+    def test_in_container_qlora_adds_bitsandbytes(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AINODE_IN_CONTAINER", "1")
+        monkeypatch.setenv("AINODE_HOST_HOME", "/host")
+        job = self._job(tmp_path, monkeypatch, method="qlora")
+        cmd = job._build_command(job._job_dir / "config.json")
+        shell = cmd[-1]
+        assert "peft" in shell and "bitsandbytes" in shell
+
+    def test_train_image_override(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AINODE_IN_CONTAINER", "1")
+        monkeypatch.setenv("AINODE_HOST_HOME", "/host")
+        monkeypatch.setattr("ainode.training.engine.TRAIN_IMAGE", "custom/train:tag")
+        job = self._job(tmp_path, monkeypatch, method="lora")
+        cmd = job._build_command(job._job_dir / "config.json")
+        assert "custom/train:tag" in cmd
+
+    def test_in_container_requires_host_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AINODE_IN_CONTAINER", "1")
+        monkeypatch.delenv("AINODE_HOST_HOME", raising=False)
+        job = self._job(tmp_path, monkeypatch, method="lora")
+        with pytest.raises(RuntimeError, match="AINODE_HOST_HOME"):
+            job._build_command(job._job_dir / "config.json")
+
+    def test_in_container_ddp_raises(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AINODE_IN_CONTAINER", "1")
+        monkeypatch.setenv("AINODE_HOST_HOME", "/host")
+        job = self._job(tmp_path, monkeypatch, method="lora", distributed=True, num_nodes=2)
+        with pytest.raises(RuntimeError, match="Distributed training"):
+            job._build_command(job._job_dir / "config.json")
+
+    def test_quantize_path_unchanged_in_container(self, tmp_path, monkeypatch):
+        """Quantize keeps its own container command (run_quant.py), not the train path."""
+        monkeypatch.setenv("AINODE_IN_CONTAINER", "1")
+        monkeypatch.setenv("AINODE_HOST_HOME", "/host")
+        monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
+        config = TrainingConfig(base_model="m", method="quantize", scheme="awq")
+        job = TrainingJob(config)
+        cmd = job._build_command(job._job_dir / "config.json")
+        assert "/opt/ainode/run_quant.py" in cmd
+        assert "/job/_run_training.py" not in " ".join(cmd)
+
+    def test_relative_dataset_remapped_when_present(self, tmp_path, monkeypatch):
+        """A bare relative dataset_path (what the wizard placeholder suggests) is
+        remapped onto the /ainode-datasets mount when the file exists — otherwise
+        the container's AINODE_HOME=/job resolver looks in the wrong place."""
+        monkeypatch.setenv("AINODE_IN_CONTAINER", "1")
+        monkeypatch.setenv("AINODE_HOST_HOME", "/host")
+        monkeypatch.setattr("ainode.training.engine.AINODE_HOME", tmp_path)
+        monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
+        (tmp_path / "datasets").mkdir()
+        (tmp_path / "datasets" / "alpaca.jsonl").write_text("{}\n")
+        job = TrainingJob(TrainingConfig(base_model="m", dataset_path="alpaca.jsonl", method="lora"))
+        job._build_container_command()
+        ccfg = json.loads((job._job_dir / "config.container.json").read_text())
+        assert ccfg["dataset_path"] == "/ainode-datasets/alpaca.jsonl"
+
+    def test_relative_dataset_hf_repo_id_passthrough(self, tmp_path, monkeypatch):
+        """A relative string with no matching local file is a HF hub repo id and
+        must pass through untouched to load_dataset()."""
+        monkeypatch.setenv("AINODE_IN_CONTAINER", "1")
+        monkeypatch.setenv("AINODE_HOST_HOME", "/host")
+        monkeypatch.setattr("ainode.training.engine.AINODE_HOME", tmp_path)
+        monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
+        (tmp_path / "datasets").mkdir()
+        job = TrainingJob(TrainingConfig(base_model="m", dataset_path="tatsu-lab/alpaca", method="lora"))
+        job._build_container_command()
+        ccfg = json.loads((job._job_dir / "config.container.json").read_text())
+        assert ccfg["dataset_path"] == "tatsu-lab/alpaca"
+
+    def test_container_name_derivation(self, tmp_path, monkeypatch):
+        """stop() must be able to name the GPU container it has to docker-kill."""
+        monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
+        # In-container lora → ainode-train-<id>
+        monkeypatch.setenv("AINODE_IN_CONTAINER", "1")
+        jt = TrainingJob(TrainingConfig(base_model="m", dataset_path="user/d", method="lora"))
+        assert jt._container_name() == f"ainode-train-{jt.job_id}"
+        # Quantize always runs in a container, regardless of AINODE_IN_CONTAINER
+        monkeypatch.delenv("AINODE_IN_CONTAINER", raising=False)
+        jq = TrainingJob(TrainingConfig(base_model="m", method="quantize", scheme="awq"))
+        assert jq._container_name() == f"ainode-quant-{jq.job_id}"
+        # Host-venv lora → no container, nothing to kill
+        jh = TrainingJob(TrainingConfig(base_model="m", dataset_path="user/d", method="lora"))
+        assert jh._container_name() is None
+        # Explicit override wins (merge jobs)
+        jh._container_name_override = "ainode-merge-abc"
+        assert jh._container_name() == "ainode-merge-abc"
+
+    @pytest.mark.asyncio
+    async def test_stop_kills_named_container(self, tmp_path, monkeypatch):
+        """Cancelling a RUNNING container-spawn job must docker-remove the GPU
+        container — a SIGKILL to the local `docker run` client is not relayed."""
+        monkeypatch.setenv("AINODE_IN_CONTAINER", "1")
+        monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
+        job = TrainingJob(TrainingConfig(base_model="m", dataset_path="user/d", method="lora"))
+        job.status = JobStatus.RUNNING
+        job.start_time = 1.0
+        calls = []
+        monkeypatch.setattr(
+            "ainode.training.engine.subprocess.run",
+            lambda args, **kw: calls.append(args),
+        )
+        await job.stop()
+        assert job.status == JobStatus.CANCELLED
+        name = f"ainode-train-{job.job_id}"
+        assert ["docker", "stop", name] in calls
+        assert ["docker", "rm", "-f", name] in calls
+
+
+class TestMergeContainerCommand:
+    """build_merge_command spawns a GPU container mirroring the training pattern."""
+
+    def test_merge_docker_shape(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AINODE_HOST_HOME", "/host")
+        monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
+        merge_job = TrainingJob(TrainingConfig(base_model="m", dataset_path="__merge__"))
+        adapter_dir = tmp_path / "src" / "output"
+        adapter_dir.mkdir(parents=True)
+        merged_dir = tmp_path / "src" / "merged"
+
+        cmd = build_merge_command(merge_job, "base/model", adapter_dir, merged_dir, "hf_tok")
+
+        assert cmd[:3] == ["docker", "run", "--rm"]
+        assert engine.TRAIN_IMAGE in cmd
+        mounts = [cmd[i + 1] for i, x in enumerate(cmd) if x == "-v"]
+        assert any(m.endswith(":/adapter:ro") for m in mounts)
+        assert any(m.endswith(":/out") for m in mounts)
+        assert any(m.endswith(":/ainode-models") for m in mounts)
+
+        shell = cmd[-1]
+        assert "pip install" in shell and "peft" in shell
+        assert "/job/_run_merge.py" in shell
+
+        # Runner copied + merge config written with remapped container paths.
+        assert (merge_job._job_dir / "_run_merge.py").exists()
+        mcfg = json.loads((merge_job._job_dir / "merge_config.json").read_text())
+        assert mcfg["adapter_dir"] == "/adapter"
+        assert mcfg["output_dir"] == "/out/merged"
+        assert mcfg["base_model"] == "base/model"
+
+    def test_merge_requires_host_home(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("AINODE_HOST_HOME", raising=False)
+        monkeypatch.setattr("ainode.training.engine.JOBS_DIR", tmp_path / "jobs")
+        merge_job = TrainingJob(TrainingConfig(base_model="m", dataset_path="__merge__"))
+        with pytest.raises(RuntimeError, match="AINODE_HOST_HOME"):
+            build_merge_command(merge_job, "base/model", tmp_path / "a", tmp_path / "b")


### PR DESCRIPTION
## Summary
The shipped orchestrator image is slim (no torch/peft) — training jobs launched as `sys.executable -m ainode.training._run_training` were dead on arrival in production containers. Quantize already solved this with a spawned GPU container; this PR gives LoRA/QLoRA/full training and adapter **merge** the same treatment.

- `_build_container_command`: docker-run mirroring the quant pattern (models store RW, job dir at `/job`, HF cache into the store, `AINODE_HOST_HOME` fail-loud guard); runner script copied into the job dir; container-view config with `output_dir` rewritten to `/job/output` (same host inode — `/output` download endpoint unchanged).
- Dataset remapping onto the RO `/ainode-datasets` mount for absolute **and** relative paths (the wizard's `alpaca.jsonl` case).
- `peft` (+ `bitsandbytes` for qlora) pip-shimmed at launch (`--no-deps`); bake into the next quant-image build (TODO in code).
- New self-contained `_run_merge.py`; `_do_merge` spawns it in a container in-container, keeps in-process peft for host-venv dev.
- `stop()` now tears down the **container** (`docker stop` + `rm -f` by deterministic name), not just the docker CLI process; merge jobs register an addressable container name so cancel sticks.
- DDP + in-container raises a clear error (distributed training stays host-mode).
- 608 passed, 1 xfailed; ruff clean. Adversarially reviewed (1 blocker + 2 majors found and fixed, each with a regression test).

Known limits (accepted): qlora depends on a bitsandbytes aarch64 wheel at job start; pip shim adds cold-start seconds until baked into the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NziXzqT1L9kj2T1byA3Ak