### PR TITLE
feat(deploy): tag-triggered publish + real ainode update (env-file image swap)

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,9 +1,13 @@
 name: publish-image
 # Build + publish the AINode container image to GHCR and Docker Hub.
 #
-# Manual only (workflow_dispatch). Never runs on push — the self-hosted
-# aarch64 runner is a DGX Spark, and a ~18 GB image build is not something
-# we want firing off accidentally.
+# Two triggers:
+#   - push of a 'v*' tag (e.g. v0.5.0) → build + PUSH the release automatically.
+#     VERSION is derived from the tag (leading 'v' stripped).
+#   - workflow_dispatch → manual build; push is the operator's choice.
+#
+# The self-hosted aarch64 runner is a DGX Spark and a ~18 GB image build is
+# heavy, so non-tag pushes to branches deliberately do NOT trigger this.
 #
 # Self-hosted runner prerequisites:
 #   - labels: [self-hosted, dgx-spark, aarch64]
@@ -23,6 +27,9 @@ name: publish-image
 #   4. Emit a summary with the final image pull command.
 
 on:
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
     inputs:
       push:
@@ -50,21 +57,37 @@ jobs:
       contents: read
       packages: write
     env:
-      AINODE_VERSION: ${{ inputs.ainode_version }}
       REGISTRY_GHCR: ghcr.io/getainode
       REGISTRY_DOCKERHUB: docker.io/argentos
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Verify pyproject version matches input
+      - name: Determine version and push mode
+        id: vars
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            # Tag-triggered: derive version from the tag, always push.
+            ref="${{ github.ref_name }}"
+            version="${ref#v}"
+            push="true"
+          else
+            version="${{ inputs.ainode_version }}"
+            push="${{ inputs.push }}"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "push=$push" >> "$GITHUB_OUTPUT"
+          echo "AINODE_VERSION=$version" >> "$GITHUB_ENV"
+          echo "Resolved version=$version push=$push (event=${{ github.event_name }})"
+
+      - name: Verify pyproject version matches release version
         run: |
           pyproj_version=$(grep -m1 '^version = ' pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/')
           if [ "$pyproj_version" != "$AINODE_VERSION" ]; then
-            echo "::warning::pyproject.toml version ($pyproj_version) does not match workflow input ($AINODE_VERSION)."
-          else
-            echo "Version match: $pyproj_version"
+            echo "::error::pyproject.toml version ($pyproj_version) does not match release version ($AINODE_VERSION)."
+            exit 1
           fi
+          echo "Version match: $pyproj_version"
 
       - name: Build base (eugr) image
         run: |
@@ -99,7 +122,7 @@ jobs:
           docker run --rm ainode:${AINODE_VERSION} ainode --version
 
       - name: Tag for registries
-        if: inputs.push == 'true'
+        if: steps.vars.outputs.push == 'true'
         run: |
           docker tag ainode:${AINODE_VERSION} "${REGISTRY_GHCR}/ainode:${AINODE_VERSION}"
           docker tag ainode:${AINODE_VERSION} "${REGISTRY_GHCR}/ainode:latest"
@@ -107,7 +130,7 @@ jobs:
           docker tag ainode:${AINODE_VERSION} "${REGISTRY_DOCKERHUB}/ainode:latest"
 
       - name: Login to GHCR
-        if: inputs.push == 'true'
+        if: steps.vars.outputs.push == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -116,7 +139,7 @@ jobs:
 
       - name: Check Docker Hub secret presence
         id: dockerhub
-        if: inputs.push == 'true'
+        if: steps.vars.outputs.push == 'true'
         run: |
           if [ -n "${{ secrets.DOCKERHUB_USER }}" ]; then
             echo "present=true" >> "$GITHUB_OUTPUT"
@@ -125,20 +148,20 @@ jobs:
           fi
 
       - name: Login to Docker Hub
-        if: inputs.push == 'true' && steps.dockerhub.outputs.present == 'true'
+        if: steps.vars.outputs.push == 'true' && steps.dockerhub.outputs.present == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Push base image
-        if: inputs.push == 'true'
+        if: steps.vars.outputs.push == 'true'
         run: |
           docker push ${REGISTRY_GHCR}/ainode-base:${{ steps.eugr.outputs.short }}
           docker push ${REGISTRY_GHCR}/ainode-base:${AINODE_VERSION}-${{ steps.eugr.outputs.short }}
 
       - name: Push ainode image
-        if: inputs.push == 'true'
+        if: steps.vars.outputs.push == 'true'
         run: |
           docker push ${REGISTRY_GHCR}/ainode:${AINODE_VERSION}
           docker push ${REGISTRY_GHCR}/ainode:latest
@@ -154,9 +177,9 @@ jobs:
             echo ""
             echo "**Version:** \`${AINODE_VERSION}\`"
             echo "**Base (eugr pin):** \`${{ steps.eugr.outputs.short }}\`"
-            echo "**Pushed:** \`${{ inputs.push }}\`"
+            echo "**Pushed:** \`${{ steps.vars.outputs.push }}\`"
             echo ""
-            if [ "${{ inputs.push }}" = "true" ]; then
+            if [ "${{ steps.vars.outputs.push }}" = "true" ]; then
               echo "### Pull"
               echo ""
               echo "\`\`\`bash"

--- a/ainode/__init__.py
+++ b/ainode/__init__.py
@@ -1,5 +1,13 @@
 """AINode — Turn any NVIDIA GPU into a local AI platform."""
 
-__version__ = "0.4.44"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    # Single source of truth: the installed package version (pyproject.toml).
+    # Prevents drift between __version__, pyproject, and deployed image tags.
+    __version__ = version("ainode")
+except PackageNotFoundError:  # pragma: no cover - running from an uninstalled source tree
+    __version__ = "0.0.0+unknown"
+
 __author__ = "Argentos AI"
 __url__ = "https://ainode.dev"

--- a/ainode/api/server.py
+++ b/ainode/api/server.py
@@ -2,9 +2,11 @@
 
 import asyncio
 import logging
+import os
 import socket
 import time
 from dataclasses import asdict
+from pathlib import Path
 from typing import Optional
 
 import aiohttp
@@ -1080,6 +1082,17 @@ async def handle_cluster_update_all(request: web.Request) -> web.Response:
     config: NodeConfig = request.app["config"]
     session: aiohttp.ClientSession = request.app["client_session"]
 
+    # Optional target version, threaded to self and every peer so the whole
+    # cluster converges on the same image.
+    requested = None
+    try:
+        if request.can_read_body:
+            body = await request.json()
+            if isinstance(body, dict):
+                requested = body.get("version")
+    except Exception:
+        requested = None
+
     nodes = cluster.members()
     all_nodes = [{"node_id": config.node_id, "node_name": config.node_id, "host": "localhost", "port": config.web_port or 3000, "is_self": True}]
     for n in nodes:
@@ -1105,7 +1118,28 @@ async def handle_cluster_update_all(request: web.Request) -> web.Response:
         "started_at": asyncio.get_event_loop().time(),
     }
 
-    image = "ghcr.io/getainode/ainode:latest"
+    # Resolve the target tag once for the whole cluster.
+    target = requested
+    if not target:
+        try:
+            target = await asyncio.get_event_loop().run_in_executor(
+                None, _fetch_latest_ghcr_tag
+            )
+        except Exception:
+            target = None
+    if not target:
+        # Mark the just-created job failed instead of leaving it stuck at
+        # "running" forever in the in-memory dict (a poll would never resolve).
+        job = _cluster_update_state.get(update_id)
+        if job is not None:
+            job["status"] = "failed"
+            for n in job["nodes"].values():
+                n["status"] = "failed"
+                n["log"] = "Could not resolve a target version from GHCR"
+        return web.json_response(
+            {"error": "Could not resolve a target version from GHCR"}, status=502
+        )
+    image = f"{AINODE_GHCR_REPO}:{target}"
 
     async def _update_node(node: dict) -> None:
         nid = node["node_id"]
@@ -1113,27 +1147,56 @@ async def handle_cluster_update_all(request: web.Request) -> web.Response:
         state["status"] = "updating"
 
         if node["is_self"]:
-            # Update self: docker pull + systemctl restart
+            # Update self: docker pull → write image.env → self-stop (systemd
+            # Restart=always relaunches on the new image). systemctl does not
+            # work from inside the container.
             try:
                 loop = asyncio.get_event_loop()
-                pull = await loop.run_in_executor(
-                    None, lambda: _sp.run(
-                        ["docker", "pull", image],
-                        capture_output=True, text=True, timeout=600
+                try:
+                    pull = await loop.run_in_executor(
+                        None, lambda: _sp.run(
+                            ["docker", "pull", image],
+                            capture_output=True, text=True, timeout=600
+                        )
                     )
-                )
+                except _sp.TimeoutExpired:
+                    state["status"] = "failed"
+                    state["log"] = "docker pull timed out after 600s"
+                    return
                 if pull.returncode != 0:
                     state["status"] = "failed"
                     state["log"] = pull.stderr[:500]
                     return
-                restart = await loop.run_in_executor(
-                    None, lambda: _sp.run(
-                        ["systemctl", "restart", "ainode"],
-                        capture_output=True, text=True, timeout=30
+                try:
+                    _write_image_env(image)
+                except Exception as exc:
+                    state["status"] = "failed"
+                    state["log"] = f"image.env write failed: {exc}"[:200]
+                    return
+                # Same swappable-unit gate as handle_engine_update: never self-stop
+                # a node whose unit predates the swappable image, or we'd drop it /
+                # reboot the old image and still report "done". Report honestly.
+                if not _unit_is_swappable():
+                    state["status"] = "needs-migration"
+                    state["log"] = (
+                        "Image pulled + pinned, but this node's systemd unit "
+                        "predates the swappable unit — not restarted. Re-run the "
+                        "installer on the host to migrate."
                     )
-                )
-                state["status"] = "done" if restart.returncode == 0 else "failed"
-                state["log"] = restart.stderr[:200] if restart.returncode != 0 else "Updated and restarted"
+                    return
+                state["status"] = "done"
+                state["log"] = "Updated — restarting on new image"
+
+                async def _restart_self():
+                    await asyncio.sleep(2)
+                    await loop.run_in_executor(
+                        None, lambda: _sp.run(
+                            ["docker", "stop", "ainode"],
+                            capture_output=True, text=True, timeout=60
+                        )
+                    )
+
+                asyncio.get_event_loop().create_task(_restart_self())
             except Exception as exc:
                 state["status"] = "failed"
                 state["log"] = str(exc)[:200]
@@ -1142,7 +1205,7 @@ async def handle_cluster_update_all(request: web.Request) -> web.Response:
             # Each worker runs the same AINode container with /api/engine/update.
             url = f"http://{node['host']}:{node['port']}/api/engine/update"
             try:
-                async with session.post(url, timeout=aiohttp.ClientTimeout(total=700)) as resp:
+                async with session.post(url, json={"version": target}, timeout=aiohttp.ClientTimeout(total=700)) as resp:
                     data = await resp.json()
                     if resp.status < 300:
                         state["status"] = "done"
@@ -1309,32 +1372,76 @@ async def handle_set_model(request: web.Request) -> web.Response:
     return web.json_response({"status": "restarting", "model": model})
 
 
+AINODE_GHCR_REPO = "ghcr.io/getainode/ainode"
+
+
+def _fetch_latest_ghcr_tag() -> Optional[str]:
+    """Return the highest numeric GHCR version tag, or None.
+
+    Blocking (uses urllib); call via ``run_in_executor``. Resolves anonymously
+    against the public image — no auth required.
+    """
+    import urllib.request
+    import json as _json
+
+    token_url = "https://ghcr.io/token?service=ghcr.io&scope=repository:getainode/ainode:pull"
+    with urllib.request.urlopen(token_url, timeout=5) as r:
+        token = _json.loads(r.read())["token"]
+    tags_url = "https://ghcr.io/v2/getainode/ainode/tags/list"
+    req = urllib.request.Request(tags_url, headers={"Authorization": f"Bearer {token}"})
+    with urllib.request.urlopen(req, timeout=5) as r:
+        data = _json.loads(r.read())
+    # Highest numeric version tag (ignore 'latest' and non-numeric tags).
+    versions = sorted(
+        [t for t in data.get("tags", []) if t and t != "latest" and t[0].isdigit()],
+        key=lambda v: tuple(int(x) for x in v.split(".") if x.isdigit()),
+        reverse=True,
+    )
+    return versions[0] if versions else None
+
+
+def _ainode_home_path() -> Path:
+    """Host-mounted AINode home (``~/.ainode`` bind-mounted to /root/.ainode)."""
+    return Path(os.environ.get("AINODE_HOME", str(Path.home() / ".ainode")))
+
+
+def _write_image_env(image: str) -> None:
+    """Persist the target image for the host systemd unit's EnvironmentFile.
+
+    Inside the container this writes ``$AINODE_HOME/image.env`` which is the
+    same file the host unit reads via the ``~/.ainode`` bind mount.
+
+    Written atomically (temp file + rename) so the host unit never reads a
+    half-written line if it happens to (re)load while we're mid-write.
+    """
+    home = _ainode_home_path()
+    home.mkdir(parents=True, exist_ok=True)
+    tmp = home / "image.env.tmp"
+    tmp.write_text(f"AINODE_IMAGE={image}\n")
+    tmp.replace(home / "image.env")
+
+
+def _unit_is_swappable() -> bool:
+    """True iff this container was launched by the swappable-image systemd unit.
+
+    The swappable unit (the one this deploy path relies on) stamps
+    ``AINODE_UNIT_SWAPPABLE=1`` into the container env. Its ABSENCE means the
+    host is still on a pre-swappable unit (pinned ExecStart, no EnvironmentFile),
+    where a self-``docker stop`` is destructive rather than an image swap: the
+    old unit either won't relaunch at all (Restart=on-failure + clean exit) or
+    relaunches the SAME pinned image (it never reads image.env). In that case we
+    must NOT self-stop — pull + pin image.env, and tell the operator to migrate
+    the unit on the host first.
+    """
+    return os.environ.get("AINODE_UNIT_SWAPPABLE") == "1"
+
+
 async def handle_version_check(request: web.Request) -> web.Response:
     """GET /api/version/check — compare local version against latest GHCR tag."""
     current = __version__
     try:
-        # Ask the registry for the digest of :latest, then find which
-        # version tag matches. We do this without auth (public image).
         loop = asyncio.get_event_loop()
-        def _fetch():
-            import urllib.request
-            import json as _json
-            token_url = "https://ghcr.io/token?service=ghcr.io&scope=repository:getainode/ainode:pull"
-            with urllib.request.urlopen(token_url, timeout=5) as r:
-                token = _json.loads(r.read())["token"]
-            tags_url = "https://ghcr.io/v2/getainode/ainode/tags/list"
-            req = urllib.request.Request(tags_url, headers={"Authorization": f"Bearer {token}"})
-            with urllib.request.urlopen(req, timeout=5) as r:
-                data = _json.loads(r.read())
-            # Return sorted version tags (ignore 'latest')
-            versions = sorted(
-                [t for t in data.get("tags", []) if t != "latest" and t[0].isdigit()],
-                key=lambda v: tuple(int(x) for x in v.split(".") if x.isdigit()),
-                reverse=True,
-            )
-            return versions[0] if versions else None
-
-        latest = await loop.run_in_executor(None, _fetch)
+        latest = await loop.run_in_executor(None, _fetch_latest_ghcr_tag)
     except Exception:
         latest = None
 
@@ -1355,38 +1462,106 @@ async def handle_version_check(request: web.Request) -> web.Response:
 
 
 async def handle_engine_update(request: web.Request) -> web.Response:
-    """POST /api/engine/update — trigger ainode update (docker pull + systemctl restart).
+    """POST /api/engine/update — pull a target image and swap to it.
 
-    This runs the host wrapper command from inside the container by writing
-    a trigger file that the host systemd service can detect, OR by calling
-    docker pull + systemctl directly via the mounted docker socket.
+    Body (optional): ``{"version": "X.Y.Z"}``. When omitted, targets the highest
+    numeric GHCR tag. On a successful ``docker pull`` we write ``image.env``
+    (which the host systemd unit reads via EnvironmentFile) and then, after a
+    short delay, ``docker stop ainode`` on the mounted socket — systemd's
+    ``Restart=always`` relaunches the container on the new image. ``systemctl``
+    is deliberately NOT used: it does not work from inside the container.
+
+    On pull failure we do NOT write image.env and do NOT restart — the node
+    keeps running the current image.
     """
     import subprocess as _sp
     loop = asyncio.get_event_loop()
 
-    async def _do_update():
-        # Pull the latest image using the docker CLI (mounted socket)
-        result = await loop.run_in_executor(
+    # Optional requested version from the body.
+    requested = None
+    try:
+        if request.can_read_body:
+            body = await request.json()
+            if isinstance(body, dict):
+                requested = body.get("version")
+    except Exception:
+        requested = None
+
+    target = requested
+    if not target:
+        try:
+            target = await loop.run_in_executor(None, _fetch_latest_ghcr_tag)
+        except Exception:
+            target = None
+    if not target:
+        return web.json_response(
+            {"error": "Could not resolve a target version from GHCR"}, status=502
+        )
+
+    image = f"{AINODE_GHCR_REPO}:{target}"
+
+    try:
+        pull = await loop.run_in_executor(
             None,
             lambda: _sp.run(
-                ["docker", "pull", "ghcr.io/getainode/ainode:latest"],
+                ["docker", "pull", image],
                 capture_output=True, text=True, timeout=600
             )
         )
-        if result.returncode != 0:
-            return False, result.stderr
-        # Restart the systemd service via the host socket
+    except _sp.TimeoutExpired:
+        # Same clean no-env-write failure path as a nonzero-return pull — the
+        # node keeps running the current image; nothing was pinned or restarted.
+        return web.json_response(
+            {"error": "docker pull failed", "detail": "docker pull timed out after 600s"},
+            status=502,
+        )
+    if pull.returncode != 0:
+        return web.json_response(
+            {"error": "docker pull failed", "detail": (pull.stderr or "")[-500:]},
+            status=502,
+        )
+
+    # Pull succeeded — pin the new image so the swappable unit boots it.
+    try:
+        _write_image_env(image)
+    except Exception as exc:
+        return web.json_response(
+            {"error": f"failed to write image.env: {exc}"}, status=500
+        )
+
+    # Only self-stop when THIS container was launched by the swappable unit. On a
+    # node still running a pre-swappable unit, `docker stop` is destructive (see
+    # _unit_is_swappable): the pull + pin above are harmless and ready the node,
+    # but restarting would either drop the node or reboot the SAME old image, so
+    # we refuse and point the operator at the host-side migration.
+    if not _unit_is_swappable():
+        return web.json_response({
+            "status": "pulled",
+            "restarted": False,
+            "target": target,
+            "image": image,
+            "message": (
+                "Image pulled and pinned, but this node's systemd unit predates "
+                "the swappable-image unit and will not pick it up. Migrate it on "
+                "the host (re-run the installer: curl -fsSL https://ainode.dev/"
+                "install | bash) to boot the new image."
+            ),
+        })
+
+    async def _self_restart():
+        await asyncio.sleep(2)
         await loop.run_in_executor(
             None,
             lambda: _sp.run(
-                ["systemctl", "restart", "ainode"],
-                capture_output=True, text=True, timeout=30
+                ["docker", "stop", "ainode"],
+                capture_output=True, text=True, timeout=60
             )
         )
-        return True, "Update complete — restarting"
 
-    asyncio.get_event_loop().create_task(_do_update())
-    return web.json_response({"status": "updating", "message": "Pulling latest image and restarting service"})
+    asyncio.get_event_loop().create_task(_self_restart())
+    return web.json_response(
+        {"status": "updating", "target": target, "image": image, "restarted": True}
+    )
 
 
 async def handle_patch_config(request: web.Request) -> web.Response:

--- a/ainode/cli/main.py
+++ b/ainode/cli/main.py
@@ -565,16 +565,34 @@ def cmd_service(args):
     action = getattr(args, "service_action", None)
 
     if action == "install":
-        # When running inside the container (install.sh uses `docker run
-        # --entrypoint ainode ... service install`), there is no systemd
-        # bus available so daemon-reload must be skipped here and handled
-        # by the host after the docker run returns.
+        # The systemd unit lives on the HOST, not in this container. Inside the
+        # container there is no systemd bus, no `systemctl` binary, and no
+        # bind-mount of /etc/systemd/system — so writing the unit + enabling it
+        # here would vanish into the container overlay AND then crash on the
+        # first `systemctl` call, all while printing a false "✓ installed". The
+        # host wrapper (install.sh) renders the unit directly; there is no valid
+        # in-container install path. Refuse clearly and point at the host-side
+        # migration instead of silently succeeding then crashing.
         in_container = os.environ.get("AINODE_IN_CONTAINER") == "1"
-        if is_installed(user_mode=user_mode):
+        if in_container:
+            console.print(
+                "  [yellow]`ainode service install` must run on the host, not inside the container.[/yellow]"
+            )
+            console.print(
+                "  The systemd unit is managed on the host — there is no systemd bus here."
+            )
+            console.print("  To (re)install or migrate the unit on this node, re-run the installer:")
+            console.print("    [bold]curl -fsSL https://ainode.dev/install | bash[/bold]")
+            console.print("  (idempotent — it re-renders the unit and preserves your config.json).")
+            console.print("  Powered by argentos.ai")
+            return
+        force = getattr(args, "force", False)
+        if is_installed(user_mode=user_mode) and not force:
             console.print("  [yellow]AINode service is already installed.[/yellow]")
+            console.print("  [dim](use 'ainode service install --force' to re-render the unit)[/dim]")
         else:
             console.print("  Installing AINode service...")
-            install_service(user_mode=user_mode, reload=not in_container)
+            install_service(user_mode=user_mode, reload=not in_container, force=force)
             console.print("  [green]✓[/green] Unit file written")
         console.print("  Enabling service...")
         enable_service(user_mode=user_mode)
@@ -732,7 +750,14 @@ def main():
         "--user", action="store_true", help="Use user-level systemd (no sudo required)"
     )
     service_sub = service_parser.add_subparsers(dest="service_action")
-    service_sub.add_parser("install", help="Install, enable, and start AINode service")
+    svc_install_parser = service_sub.add_parser(
+        "install", help="Install, enable, and start AINode service"
+    )
+    svc_install_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-render the unit file even if the service is already installed",
+    )
     service_sub.add_parser("uninstall", help="Stop, disable, and remove AINode service")
     service_sub.add_parser("status", help="Show AINode service status")
     svc_logs_parser = service_sub.add_parser("logs", help="Show AINode service logs")

--- a/ainode/service/systemd.py
+++ b/ainode/service/systemd.py
@@ -40,9 +40,18 @@ Requires=docker.service
 Type=simple
 # docker run in foreground so systemd tracks the container lifecycle.
 ExecStartPre=-/usr/bin/docker rm -f ainode
+# Image is swappable WITHOUT re-rendering the unit: the pinned default below is
+# overridden by {ainode_home}/image.env (written by `ainode update`) when it
+# exists. The '-' prefix makes the env file optional (back-compat: a node with
+# no image.env falls back to the pinned Environment default). The EnvironmentFile
+# line MUST come after the Environment line so the file wins on override.
+Environment=AINODE_IMAGE={image}
+EnvironmentFile=-{ainode_home}/image.env
 ExecStart={exec_start}
 ExecStop=/usr/bin/docker stop -t 30 ainode
-Restart=on-failure
+# Restart=always (not on-failure): a deliberate self-stop during `ainode update`
+# is a clean exit, and we still want systemd to relaunch on the new image.
+Restart=always
 RestartSec=10
 TimeoutStartSec=600
 TimeoutStopSec=45
@@ -61,10 +70,20 @@ WantedBy={wanted_by}
 
 DOCKER_RUN_CMD = (
     "/usr/bin/docker run --rm --name ainode"
-    " --network=host --gpus all --ipc=host --shm-size=64g"
+    " --network=host --gpus all --ipc=host --shm-size=64g --pid=host"
     " -v {ainode_home}:/root/.ainode"
     " -v /var/run/docker.sock:/var/run/docker.sock"
     " -v {home}/.ssh:/root/.ssh:ro"
+    # docker config (registry creds) + HF fast-transfer + host-home hint —
+    # baked in here so the retired 97-p5-nvidia-backend.conf drop-in is no
+    # longer needed to carry them.
+    " -v {home}/.docker:/root/.docker:ro"
+    " -e AINODE_HOST_HOME={ainode_home}"
+    # Marks the running container as launched by the swappable-image unit, so the
+    # in-container update path knows a self-`docker stop` will image-swap (systemd
+    # Restart=always + EnvironmentFile) rather than drop/rebooting the old image.
+    " -e AINODE_UNIT_SWAPPABLE=1"
+    " -e HF_HUB_ENABLE_HF_TRANSFER=1"
     # Shared cluster storage — required by DockerEngine._publish_nccl_init_script
     # to stage the per-node NCCL init shim. ``--mount type=bind`` (vs ``-v``) is
     # intentional: it fails loudly at container start if /mnt/shared-models does
@@ -120,16 +139,19 @@ def generate_unit_file(user_mode: bool = False) -> str:
     wanted_by = "default.target" if user_mode else "multi-user.target"
     ainode_home = _ainode_home()
     home = str(Path.home())
+    # ExecStart references ${AINODE_IMAGE} — systemd expands it at start time
+    # from the Environment default or the image.env override.
     exec_start = DOCKER_RUN_CMD.format(
         ainode_home=ainode_home,
         home=home,
-        image=AINODE_IMAGE,
+        image="${AINODE_IMAGE}",
     )
     return UNIT_FILE_TEMPLATE.format(
         exec_start=exec_start,
         ainode_home=ainode_home,
         home=home,
         wanted_by=wanted_by,
+        image=AINODE_IMAGE,
     )
 
 
@@ -138,19 +160,34 @@ def is_installed(user_mode: bool = False) -> bool:
     return _unit_path(user_mode).exists()
 
 
-def install_service(user_mode: bool = False, reload: bool = True) -> None:
+def install_service(
+    user_mode: bool = False, reload: bool = True, force: bool = False
+) -> None:
     """Write the unit file and optionally reload the systemd daemon.
 
     When called from inside a container (e.g. during install.sh), pass
     ``reload=False`` — the container has no systemd bus, so daemon-reload
     must be run by the host after the docker run completes.
+
+    Pass ``force=True`` to re-render an already-installed unit (e.g. after a
+    template change). Without it, an existing unit is left untouched.
+
+    Also seeds ``<AINODE_HOME>/image.env`` with the pinned image when absent so
+    the unit's ``EnvironmentFile`` has a value to read on first boot.
     """
     unit_dir = _unit_dir(user_mode)
     unit_dir.mkdir(parents=True, exist_ok=True)
 
     unit_path = _unit_path(user_mode)
-    unit_content = generate_unit_file(user_mode=user_mode)
-    unit_path.write_text(unit_content)
+    if force or not unit_path.exists():
+        unit_content = generate_unit_file(user_mode=user_mode)
+        unit_path.write_text(unit_content)
+
+    # Seed the image.env override file (pin the current image) if missing.
+    image_env = Path(_ainode_home()) / "image.env"
+    if not image_env.exists():
+        image_env.parent.mkdir(parents=True, exist_ok=True)
+        image_env.write_text(f"AINODE_IMAGE={AINODE_IMAGE}\n")
 
     if reload:
         _systemctl(["daemon-reload"], user_mode=user_mode)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,8 +16,10 @@
 set -euo pipefail
 
 # -- Defaults ---------------------------------------------------------------
-AINODE_VERSION="${AINODE_VERSION:-0.4.1}"
-AINODE_IMAGE="${AINODE_IMAGE:-ghcr.io/getainode/ainode:latest}"
+# Version + image are resolved from the highest numeric GHCR tag below (unless
+# the caller pins them explicitly). Leaving these empty is the signal to resolve.
+AINODE_VERSION="${AINODE_VERSION:-}"
+AINODE_IMAGE="${AINODE_IMAGE:-}"
 # NVIDIA official vLLM engine image — pre-pulled so first dashboard launch
 # doesn't hit a 5–10 min download. Override with AINODE_NVIDIA_IMAGE=skip to
 # suppress, or a custom tag for testing.
@@ -58,6 +60,20 @@ log() { printf "\033[1;32m==>\033[0m %s\n" "$*"; }
 warn() { printf "\033[1;33m!!\033[0m %s\n" "$*"; }
 die() { printf "\033[1;31mXX\033[0m %s\n" "$*" >&2; exit 1; }
 
+# Resolve the highest numeric GHCR tag anonymously (public image). Echoes the
+# tag on success; returns non-zero if resolution fails (caller falls back).
+resolve_latest_tag() {
+    local token tags
+    token=$(curl -fsSL "https://ghcr.io/token?service=ghcr.io&scope=repository:getainode/ainode:pull" 2>/dev/null \
+        | sed -E 's/.*"token":"([^"]+)".*/\1/') || return 1
+    [ -n "$token" ] || return 1
+    tags=$(curl -fsSL -H "Authorization: Bearer $token" \
+        "https://ghcr.io/v2/getainode/ainode/tags/list" 2>/dev/null) || return 1
+    echo "$tags" | tr ',' '\n' \
+        | grep -oE '"[0-9]+\.[0-9]+\.[0-9]+"' | tr -d '"' \
+        | sort -t. -k1,1n -k2,2n -k3,3n | tail -1
+}
+
 # -- 1. Preflight -----------------------------------------------------------
 log "Checking prerequisites"
 [ "$(uname -s)" = "Linux" ] || die "AINode requires Linux (detected $(uname -s))"
@@ -86,8 +102,29 @@ fi
 log "Preparing $AINODE_HOME"
 mkdir -p "$AINODE_HOME"/{models,logs,datasets,training}
 
+# Resolve the image to a PINNED numeric tag (never a floating :latest, which
+# has drifted to ancient builds in the past). Explicit AINODE_IMAGE wins.
+if [ -z "$AINODE_IMAGE" ]; then
+    if RESOLVED_TAG="$(resolve_latest_tag)" && [ -n "$RESOLVED_TAG" ]; then
+        AINODE_VERSION="$RESOLVED_TAG"
+        AINODE_IMAGE="ghcr.io/getainode/ainode:${RESOLVED_TAG}"
+        log "Resolved latest GHCR tag: $RESOLVED_TAG"
+    else
+        AINODE_IMAGE="ghcr.io/getainode/ainode:latest"
+        warn "Could not resolve latest GHCR tag — falling back to :latest"
+    fi
+fi
+# Derive the banner version from the pinned tag when not otherwise set.
+[ -n "$AINODE_VERSION" ] || AINODE_VERSION="${AINODE_IMAGE##*:}"
+
 log "Pulling $AINODE_IMAGE (AINode orchestrator; slim — ~500 MB)"
 docker pull "$AINODE_IMAGE"
+
+# Pin the image for the systemd unit's EnvironmentFile so `ainode update` can
+# swap it later without re-rendering the unit. Written atomically (temp+rename)
+# so the unit never reads a half-written line.
+printf 'AINODE_IMAGE=%s\n' "$AINODE_IMAGE" > "$AINODE_HOME/image.env.tmp"
+mv -f "$AINODE_HOME/image.env.tmp" "$AINODE_HOME/image.env"
 
 # -- 2a. NGC login (for nvcr.io/nvidia/vllm image pull) -------------------
 # The NVIDIA engine backend requires a pull from NGC. Non-interactive login
@@ -235,16 +272,23 @@ fi
 
 mkdir -p "$UNIT_DIR"
 
+# ExecStart references ${AINODE_IMAGE} (escaped so systemd — not this shell —
+# expands it). The pinned Environment default is overridden by image.env, so
+# `ainode update` swaps the image without re-rendering this unit.
 EXEC_START="/usr/bin/docker run --rm --name ainode \
- --network=host --gpus all --ipc=host --shm-size=64g \
+ --network=host --gpus all --ipc=host --shm-size=64g --pid=host \
  -v ${AINODE_HOME}:/root/.ainode \
  -v /var/run/docker.sock:/var/run/docker.sock \
  -v ${HOME}/.ssh:/host-ssh:ro \
+ -v ${HOME}/.docker:/root/.docker:ro \
  --mount type=bind,source=/mnt/shared-models,target=/mnt/shared-models,bind-propagation=rshared \
  -e AINODE_HOME=/root/.ainode \
+ -e AINODE_HOST_HOME=${AINODE_HOME} \
+ -e AINODE_UNIT_SWAPPABLE=1 \
+ -e HF_HUB_ENABLE_HF_TRANSFER=1 \
  -e NVIDIA_VISIBLE_DEVICES=all \
  -e CUDA_DEVICE_ORDER=PCI_BUS_ID \
- ghcr.io/getainode/ainode:latest"
+ \${AINODE_IMAGE}"
 
 cat > /tmp/ainode.service << UNIT
 [Unit]
@@ -257,9 +301,11 @@ Requires=docker.service
 [Service]
 Type=simple
 ExecStartPre=-/usr/bin/docker rm -f ainode
+Environment=AINODE_IMAGE=${AINODE_IMAGE}
+EnvironmentFile=-${AINODE_HOME}/image.env
 ExecStart=${EXEC_START}
 ExecStop=/usr/bin/docker stop -t 30 ainode
-Restart=on-failure
+Restart=always
 RestartSec=10
 TimeoutStartSec=600
 TimeoutStopSec=45
@@ -298,7 +344,21 @@ $WRAPPER_SUDO tee "$WRAPPER_PATH" >/dev/null <<WRAPPER
 # AINode host wrapper — installed by install.sh. Not user-editable.
 set -euo pipefail
 AINODE_IMAGE="\${AINODE_IMAGE:-ghcr.io/getainode/ainode:latest}"
+AINODE_HOME="\${AINODE_HOME:-\$HOME/.ainode}"
 AINODE_SERVICE="ainode.service"
+
+# Resolve the highest numeric GHCR tag anonymously (public image).
+resolve_latest_tag() {
+    local token tags
+    token=\$(curl -fsSL "https://ghcr.io/token?service=ghcr.io&scope=repository:getainode/ainode:pull" 2>/dev/null \\
+        | sed -E 's/.*"token":"([^"]+)".*/\\1/') || return 1
+    [ -n "\$token" ] || return 1
+    tags=\$(curl -fsSL -H "Authorization: Bearer \$token" \\
+        "https://ghcr.io/v2/getainode/ainode/tags/list" 2>/dev/null) || return 1
+    echo "\$tags" | tr ',' '\\n' \\
+        | grep -oE '"[0-9]+\\.[0-9]+\\.[0-9]+"' | tr -d '"' \\
+        | sort -t. -k1,1n -k2,2n -k3,3n | tail -1
+}
 
 is_user_mode() {
     systemctl --user is-enabled "\$AINODE_SERVICE" >/dev/null 2>&1
@@ -313,8 +373,25 @@ restart_service() {
 
 case "\${1:-}" in
     update)
-        echo "==> Pulling \$AINODE_IMAGE"
-        docker pull "\$AINODE_IMAGE"
+        # Optional explicit version: 'ainode update 0.5.0'. Otherwise resolve
+        # the highest numeric GHCR tag. Never pull a floating :latest here.
+        TARGET_VERSION="\${2:-}"
+        if [ -z "\$TARGET_VERSION" ]; then
+            TARGET_VERSION="\$(resolve_latest_tag || true)"
+        fi
+        if [ -n "\$TARGET_VERSION" ]; then
+            PULL_IMAGE="ghcr.io/getainode/ainode:\$TARGET_VERSION"
+        else
+            PULL_IMAGE="\$AINODE_IMAGE"
+            echo "!! Could not resolve a version — pulling \$PULL_IMAGE"
+        fi
+        echo "==> Pulling \$PULL_IMAGE"
+        docker pull "\$PULL_IMAGE"
+        # Pin it for the systemd unit's EnvironmentFile, then restart. Written
+        # atomically (temp+rename) so the unit never reads a half-written line.
+        mkdir -p "\$AINODE_HOME"
+        printf 'AINODE_IMAGE=%s\n' "\$PULL_IMAGE" > "\$AINODE_HOME/image.env.tmp"
+        mv -f "\$AINODE_HOME/image.env.tmp" "\$AINODE_HOME/image.env"
         echo "==> Restarting \$AINODE_SERVICE"
         if is_user_mode || systemctl is-active --quiet "\$AINODE_SERVICE" 2>/dev/null; then
             restart_service
@@ -323,7 +400,7 @@ case "\${1:-}" in
         fi
         echo "==> Update complete. Version:"
         docker exec ainode ainode --version 2>/dev/null || \\
-            docker run --rm --entrypoint ainode "\$AINODE_IMAGE" --version
+            docker run --rm --entrypoint ainode "\$PULL_IMAGE" --version
         ;;
     "" | -h | --help)
         cat <<HELP

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -216,3 +216,112 @@ async def test_nodes_returns_local_node_from_cluster(client):
     assert len(nodes) >= 1
     node_ids = [n["node_id"] for n in nodes]
     assert "test-node-1" in node_ids
+
+
+# ---- /api/engine/update ----------------------------------------------------
+
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_engine_update_pulls_numeric_tag_and_writes_env(client, tmp_path, monkeypatch):
+    """Update resolves the highest numeric GHCR tag, pulls it, writes image.env."""
+    monkeypatch.setenv("AINODE_HOME", str(tmp_path))
+    # Simulate a node already on the swappable-image unit so the self-stop path runs.
+    monkeypatch.setenv("AINODE_UNIT_SWAPPABLE", "1")
+    with (
+        patch("ainode.api.server._fetch_latest_ghcr_tag", return_value="0.5.0"),
+        patch("subprocess.run", return_value=MagicMock(returncode=0, stderr="")) as mrun,
+    ):
+        resp = await client.post("/api/engine/update", json={})
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["status"] == "updating"
+        assert data["target"] == "0.5.0"
+        assert data["image"] == "ghcr.io/getainode/ainode:0.5.0"
+
+    # image.env pinned to the numeric tag.
+    image_env = tmp_path / "image.env"
+    assert image_env.read_text().strip() == "AINODE_IMAGE=ghcr.io/getainode/ainode:0.5.0"
+
+    # docker pull targeted the numeric tag — never a floating :latest.
+    pull_cmds = [c.args[0] for c in mrun.call_args_list if c.args and "pull" in c.args[0]]
+    assert any("ghcr.io/getainode/ainode:0.5.0" in cmd for cmd in pull_cmds)
+    assert not any("ainode:latest" in " ".join(cmd) for cmd in pull_cmds)
+
+
+@pytest.mark.asyncio
+async def test_engine_update_uses_requested_version(client, tmp_path, monkeypatch):
+    """An explicit body version is used verbatim; GHCR resolution is skipped."""
+    monkeypatch.setenv("AINODE_HOME", str(tmp_path))
+    monkeypatch.setenv("AINODE_UNIT_SWAPPABLE", "1")
+    with (
+        patch("ainode.api.server._fetch_latest_ghcr_tag") as mfetch,
+        patch("subprocess.run", return_value=MagicMock(returncode=0, stderr="")),
+    ):
+        resp = await client.post("/api/engine/update", json={"version": "0.6.1"})
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["target"] == "0.6.1"
+        mfetch.assert_not_called()
+
+    image_env = tmp_path / "image.env"
+    assert image_env.read_text().strip() == "AINODE_IMAGE=ghcr.io/getainode/ainode:0.6.1"
+
+
+@pytest.mark.asyncio
+async def test_engine_update_pull_failure_no_env_write(client, tmp_path, monkeypatch):
+    """On docker pull failure: 502, no image.env written, no restart."""
+    monkeypatch.setenv("AINODE_HOME", str(tmp_path))
+    with (
+        patch("ainode.api.server._fetch_latest_ghcr_tag", return_value="0.5.0"),
+        patch("subprocess.run", return_value=MagicMock(returncode=1, stderr="manifest unknown")),
+    ):
+        resp = await client.post("/api/engine/update", json={})
+        assert resp.status == 502
+
+    assert not (tmp_path / "image.env").exists()
+
+
+@pytest.mark.asyncio
+async def test_engine_update_unresolvable_version(client, tmp_path, monkeypatch):
+    """No requested version and GHCR resolution returns None → 502, no pull."""
+    monkeypatch.setenv("AINODE_HOME", str(tmp_path))
+    with (
+        patch("ainode.api.server._fetch_latest_ghcr_tag", return_value=None),
+        patch("subprocess.run") as mrun,
+    ):
+        resp = await client.post("/api/engine/update", json={})
+        assert resp.status == 502
+        mrun.assert_not_called()
+
+    assert not (tmp_path / "image.env").exists()
+
+
+@pytest.mark.asyncio
+async def test_engine_update_skips_stop_when_unit_not_swappable(client, tmp_path, monkeypatch):
+    """On a node whose unit predates the swappable image: pull + pin, but NO
+    self-stop — stopping there is destructive (old unit drops the node or reboots
+    the same image). The response says restarted=False, and `docker stop` is
+    never invoked."""
+    monkeypatch.setenv("AINODE_HOME", str(tmp_path))
+    monkeypatch.delenv("AINODE_UNIT_SWAPPABLE", raising=False)
+    with (
+        patch("ainode.api.server._fetch_latest_ghcr_tag", return_value="0.5.0"),
+        patch("subprocess.run", return_value=MagicMock(returncode=0, stderr="")) as mrun,
+    ):
+        resp = await client.post("/api/engine/update", json={})
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["status"] == "pulled"
+        assert data["restarted"] is False
+
+    # Image was still pulled + pinned (readies the node for a later migration)...
+    image_env = tmp_path / "image.env"
+    assert image_env.read_text().strip() == "AINODE_IMAGE=ghcr.io/getainode/ainode:0.5.0"
+    # ...but `docker stop ainode` was NEVER called.
+    stop_cmds = [
+        c.args[0] for c in mrun.call_args_list
+        if c.args and "stop" in c.args[0]
+    ]
+    assert stop_cmds == []

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -18,7 +18,7 @@ class TestUnitFileGeneration:
         assert "ghcr.io/getainode/ainode" in content
         assert "NVIDIA_VISIBLE_DEVICES=all" in content
         assert "After=network.target docker.service" in content
-        assert "Restart=on-failure" in content
+        assert "Restart=always" in content
 
     def test_generate_user_unit(self):
         """User-level unit file uses default.target."""
@@ -41,13 +41,40 @@ class TestUnitFileGeneration:
 
     def test_unit_has_restart_policy(self):
         content = systemd.generate_unit_file()
-        assert "Restart=on-failure" in content
+        # Restart=always so a deliberate self-stop during `ainode update` still
+        # relaunches on the new image.
+        assert "Restart=always" in content
         assert "RestartSec=10" in content
 
     def test_unit_has_description(self):
         content = systemd.generate_unit_file()
         assert "Description=AINode" in content
         assert "Documentation=https://ainode.dev" in content
+
+    def test_unit_has_swappable_image_mechanism(self):
+        """Image is swappable without re-rendering: env default + optional file."""
+        content = systemd.generate_unit_file()
+        # ExecStart references the systemd variable, not a literal tag.
+        assert "${AINODE_IMAGE}" in content
+        # Pinned Environment default is a concrete image ref.
+        assert "Environment=AINODE_IMAGE=ghcr.io/getainode/ainode:" in content
+        # Optional (-prefixed) override file, rendered AFTER the Environment line.
+        assert "EnvironmentFile=-" in content
+        assert "image.env" in content
+        env_line = content.index("Environment=AINODE_IMAGE=")
+        file_line = content.index("EnvironmentFile=-")
+        assert file_line > env_line, "EnvironmentFile must come after Environment default"
+        # The container is stamped so the in-container update path knows a
+        # self-stop will image-swap (vs. drop/reboot the old image).
+        assert "AINODE_UNIT_SWAPPABLE=1" in content
+
+    def test_unit_bakes_dropin_extras(self):
+        """The retired 97-p5 drop-in's flags are now baked into the unit."""
+        content = systemd.generate_unit_file()
+        assert "--pid=host" in content
+        assert "AINODE_HOST_HOME=" in content
+        assert "HF_HUB_ENABLE_HF_TRANSFER=1" in content
+        assert "/.docker:/root/.docker:ro" in content
 
 
 class TestIsInstalled:
@@ -71,7 +98,9 @@ class TestIsInstalled:
 class TestInstallService:
     """Test install_service writes unit file and reloads daemon."""
 
-    def test_install_writes_unit_file(self, tmp_path):
+    def test_install_writes_unit_file(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        monkeypatch.setenv("AINODE_HOME", str(home))
         with (
             patch.object(systemd, "SYSTEM_UNIT_DIR", tmp_path),
             patch.object(systemd, "_systemctl") as mock_ctl,
@@ -85,7 +114,40 @@ class TestInstallService:
             assert "ghcr.io/getainode/ainode" in content
             mock_ctl.assert_called_once_with(["daemon-reload"], user_mode=False)
 
-    def test_install_user_mode(self, tmp_path):
+    def test_install_seeds_image_env(self, tmp_path, monkeypatch):
+        """install_service pins the current image in <AINODE_HOME>/image.env."""
+        home = tmp_path / "home"
+        monkeypatch.setenv("AINODE_HOME", str(home))
+        with (
+            patch.object(systemd, "SYSTEM_UNIT_DIR", tmp_path),
+            patch.object(systemd, "_systemctl"),
+        ):
+            systemd.install_service(user_mode=False)
+
+            image_env = home / "image.env"
+            assert image_env.exists()
+            assert image_env.read_text().startswith("AINODE_IMAGE=ghcr.io/getainode/ainode:")
+
+    def test_install_no_overwrite_without_force(self, tmp_path, monkeypatch):
+        """An existing unit is left untouched unless force=True."""
+        home = tmp_path / "home"
+        monkeypatch.setenv("AINODE_HOME", str(home))
+        unit_path = tmp_path / "ainode.service"
+        unit_path.write_text("STALE UNIT")
+        with (
+            patch.object(systemd, "SYSTEM_UNIT_DIR", tmp_path),
+            patch.object(systemd, "_systemctl"),
+        ):
+            systemd.install_service(user_mode=False)
+            assert unit_path.read_text() == "STALE UNIT"
+
+            systemd.install_service(user_mode=False, force=True)
+            assert unit_path.read_text() != "STALE UNIT"
+            assert "docker run" in unit_path.read_text()
+
+    def test_install_user_mode(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        monkeypatch.setenv("AINODE_HOME", str(home))
         with (
             patch.object(systemd, "USER_UNIT_DIR", tmp_path),
             patch.object(systemd, "_systemctl") as mock_ctl,


### PR DESCRIPTION
## Summary
Makes `tag → CI → GHCR → ainode update` the deploy path, and fixes the update mechanism that was a silent no-op three ways (all paths pulled `:latest` — stale at 0.4.13 — then relaunched the old pinned tag anyway).

- **Version single-source**: `__version__` from `importlib.metadata` (pyproject is the only version string; kills the banner-drift wart).
- **Swappable unit**: `Environment=AINODE_IMAGE=<pinned>` + `EnvironmentFile=-~/.ainode/image.env` (override wins), `ExecStart` uses `${AINODE_IMAGE}`, `Restart=always`; bakes in what the 97-* drop-in carried (`--pid=host`, docker-creds RO mount, `AINODE_HOST_HOME`, `HF_HUB_ENABLE_HF_TRANSFER=1`); stamps `AINODE_UNIT_SWAPPABLE=1` into the container.
- **Real updates**: `/api/engine/update` accepts `{"version"}`, resolves the highest numeric GHCR tag otherwise, pulls, pins image.env atomically **only on pull success**, then self-stops (`docker stop ainode`) so systemd relaunches on the new image — **gated on the swappable-unit stamp**: un-migrated nodes pull+pin but never self-kill, and tell the operator to migrate. `update-all` resolves one target for the whole cluster and threads it to every peer. In-container `service install` now refuses cleanly instead of writing a unit into the container overlay and crashing on missing `systemctl`.
- **install.sh**: resolves + pins the latest numeric tag (no more `:latest` roulette), writes image.env, same swappable inline unit, wrapper `update [version]` verb rewritten, stale 0.4.1 banner killed.
- **publish-image.yml**: `push: tags: ['v*']` trigger, version derived from the tag, pyproject mismatch is now a hard failure, tag builds always push. Runner `spark-1` is registered and online.

Adversarially reviewed (2 lenses): 2 blockers + 4 minors found; blockers fixed with regression tests, 3 minors fixed, 1 documented (sudo-env `$HOME` note). 603 passed, 1 xfailed; ruff clean; `bash -n` clean.

**Fleet migration note (release 0.5.0):** each deployed node needs one installer re-run (or manual unit refresh + drop-in removal) to become swappable; until then updates pin but don't restart — by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NziXzqT1L9kj2T1byA3Ak