### PR TITLE
ci: fix publish smoke test (entrypoint override + real version assert)

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -118,8 +118,12 @@ jobs:
 
       - name: Smoke test — image starts
         run: |
-          # Sanity: image runs, python imports ainode, version string matches.
-          docker run --rm ainode:${AINODE_VERSION} ainode --version
+          # Sanity: image runs and its baked version matches the release version.
+          # (--entrypoint: the image ENTRYPOINT execs `ainode start`, so bare args
+          # would be swallowed by the start subcommand.)
+          V_OUT=$(docker run --rm --entrypoint ainode "ainode:${AINODE_VERSION}" --version)
+          echo "image reports: ${V_OUT}"
+          echo "${V_OUT}" | grep -F "${AINODE_VERSION}"
 
       - name: Tag for registries
         if: steps.vars.outputs.push == 'true'


### PR DESCRIPTION
First tag-triggered publish (v0.5.0) failed at the smoke test: the image ENTRYPOINT execs `ainode start --in-container "$@"`, so the step's `ainode --version` args were swallowed by `start`. Override the entrypoint and actually assert the baked version equals the release version (validates the new importlib single-sourcing inside the image). Will re-point the v0.5.0 tag after merge — no consumers yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NziXzqT1L9kj2T1byA3Ak