### PR TITLE
release: 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.5.2] — 2026-07-06
+
+> The two majors from the 0.5.1 live lifecycle verification. Image published to GHCR;
+> deploy via `ainode update` at the operator's discretion.
+
+### Fixed
+- **Download Cancel is real** (#56) — cancel was a backend no-op (the flag was never
+  wired into `snapshot_download`; a cancelled 15 GB download ran to completion).
+  Downloads are now per-file, cancel-checked between files, **commit-pinned** (single
+  sha for the whole snapshot — no mixed-commit directories if the repo is pushed
+  mid-download) and parallel (`AINODE_DOWNLOAD_MAX_WORKERS`, cancellable futures).
+- **Launch form respects user node picks** (#56) — auto-recommend fired on model
+  select and silently reset the node dots to the head, landing node-targeted loads
+  on the wrong machine. Manual node toggles now set an intent flag auto-recommend
+  honors.
+
+---
+
 ## [0.5.1] — 2026-07-06
 
 > Same-day follow-up to 0.5.0: every defect found while live-proving the 0.5.0 fleet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainode"
-version = "0.5.1"
+version = "0.5.2"
 description = "Turn any NVIDIA GPU into a local AI platform. Inference + fine-tuning in your browser."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Version bump + CHANGELOG for #56. Tag after merge publishes the image to GHCR; fleet deploy is the operator's call (`ainode update`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NziXzqT1L9kj2T1byA3Ak