### PR TITLE
release: 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.5.3] — 2026-07-07
+
+### Fixed
+- **Truthful instances everywhere** (#59) — every instance card shows its node
+  NAME (not a hex id); the Server view lists stacked instances with node + port
+  and its count matches reality (Eject only where it can actually target);
+  per-instance status probes both directions (`starting → serving`, and back to
+  `failed` when an engine dies — no more stale STARTING bars or false READY);
+  the top-bar update banner now updates the whole fleet
+  (`/api/cluster/update-all`) with an honest confirm, not just the head node.
+
+---
+
 ## [0.5.2] — 2026-07-06
 
 > The two majors from the 0.5.1 live lifecycle verification. Image published to GHCR;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainode"
-version = "0.5.2"
+version = "0.5.3"
 description = "Turn any NVIDIA GPU into a local AI platform. Inference + fine-tuning in your browser."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Version bump + CHANGELOG for #59. After the tag builds, the dashboard's own update banner (now fleet-wide) is the intended deploy path — operator's click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NziXzqT1L9kj2T1byA3Ak