### PR TITLE
release: 0.5.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ainode"
-version = "0.5.5"
+version = "0.5.6"
 description = "Turn any NVIDIA GPU into a local AI platform. Inference + fine-tuning in your browser."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Version bump for the v0.5.6 tag. The four launch-path fixes (#64) have been on main since Wednesday; today the port-squatter bug they fix blocked a live model load on spark-1, which is as clear a ship signal as they come.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJ4KxqTc432yVpBBxR72zG